### PR TITLE
Fix: Use correct Result<T> factory functions

### DIFF
--- a/include/kcenon/common/interfaces/monitoring_interface.h
+++ b/include/kcenon/common/interfaces/monitoring_interface.h
@@ -56,12 +56,12 @@ inline Result<metric_type> metric_type_from_string(const std::string& str) {
     std::string upper = str;
     std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
 
-    if (upper == "GAUGE") return make_result(metric_type::gauge);
-    if (upper == "COUNTER") return make_result(metric_type::counter);
-    if (upper == "HISTOGRAM") return make_result(metric_type::histogram);
-    if (upper == "SUMMARY") return make_result(metric_type::summary);
+    if (upper == "GAUGE") return ok(metric_type::gauge);
+    if (upper == "COUNTER") return ok(metric_type::counter);
+    if (upper == "HISTOGRAM") return ok(metric_type::histogram);
+    if (upper == "SUMMARY") return ok(metric_type::summary);
 
-    return make_error<metric_type>("Invalid metric type: " + str);
+    return error<metric_type>(1, "Invalid metric type: " + str, "monitoring_interface");
 }
 
 /**


### PR DESCRIPTION
## Summary

Fix compilation error in `monitoring_interface.h` by using the correct Result<T> factory functions.

## Problem

The `metric_type_from_string()` function was using undefined `make_result()` and `make_error()` functions, causing build failures in systems that include this header.

## Solution

Replace with the correct factory functions defined in `result.h`:
- `make_result(value)` → `ok(value)`
- `make_error<T>(message)` → `error<T>(code, message, module)`

## Changes

```cpp
// Before (undefined functions)
if (upper == "GAUGE") return make_result(metric_type::gauge);
return make_error<metric_type>("Invalid metric type: " + str);

// After (correct functions)
if (upper == "GAUGE") return ok(metric_type::gauge);
return error<metric_type>(1, "Invalid metric type: " + str, "monitoring_interface");
```

## Testing

- [x] Code compiles successfully
- [x] Fixes logger_system CI build failure
- [x] No breaking changes to API

## Impact

This is a hotfix for Phase 2 code. All systems using `monitoring_interface.h` will benefit from this fix.

Fixes build error reported in logger_system PR #24.