### PR TITLE
fix(ci): enforce workflow timeouts and refresh badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: ${{ matrix.os }} / ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -103,6 +104,7 @@ jobs:
   sanitizer:
     name: Sanitizer / ${{ matrix.sanitizer }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![CI](https://github.com/kcenon/common_system/actions/workflows/ci.yml/badge.svg?branch=phase-0-foundation)](https://github.com/kcenon/common_system/actions/workflows/ci.yml)
-[![Code Coverage](https://github.com/kcenon/common_system/actions/workflows/coverage.yml/badge.svg?branch=phase-0-foundation)](https://github.com/kcenon/common_system/actions/workflows/coverage.yml)
-[![Static Analysis](https://github.com/kcenon/common_system/actions/workflows/static-analysis.yml/badge.svg?branch=phase-0-foundation)](https://github.com/kcenon/common_system/actions/workflows/static-analysis.yml)
+[![CI](https://github.com/kcenon/common_system/actions/workflows/ci.yml/badge.svg)](https://github.com/kcenon/common_system/actions/workflows/ci.yml)
+[![Code Coverage](https://github.com/kcenon/common_system/actions/workflows/coverage.yml/badge.svg)](https://github.com/kcenon/common_system/actions/workflows/coverage.yml)
+[![Static Analysis](https://github.com/kcenon/common_system/actions/workflows/static-analysis.yml/badge.svg)](https://github.com/kcenon/common_system/actions/workflows/static-analysis.yml)
 [![Doxygen](https://github.com/kcenon/common_system/actions/workflows/build-Doxygen.yaml/badge.svg)](https://github.com/kcenon/common_system/actions/workflows/build-Doxygen.yaml)
 [![License](https://img.shields.io/github/license/kcenon/common_system)](https://github.com/kcenon/common_system/blob/main/LICENSE)
 


### PR DESCRIPTION
## Summary\n- add 30-minute limits to the build and sanitizer jobs so workflows stop hanging\n- let the CI, coverage, and static analysis badges track the default branch automatically\n\n## Testing\n- not run (rely on updated GitHub Actions matrix after merge)