### PR TITLE
docs(common): Phase 1 Thread Safety - Result<T> and Event Bus Documentation

### DIFF
--- a/include/kcenon/common/patterns/event_bus.h
+++ b/include/kcenon/common/patterns/event_bus.h
@@ -73,32 +73,35 @@ namespace common {
 
     /**
      * @class null_event_bus
-     * @brief No-op event bus implementation for when monitoring is disabled
-     */
-    /**
-     * @class null_event_bus
      * @brief No-op event bus used when monitoring is disabled.
+     *
+     * Thread-safety: This class is thread-safe. All methods are no-ops
+     * that perform no state modifications. The singleton instance()
+     * uses C++11 magic statics for thread-safe initialization.
      */
     class null_event_bus {
     public:
         template<typename EventType>
         void publish(const EventType&, event_priority = event_priority::normal) {
-            // No-op
+            // No-op - thread-safe as it performs no operations
         }
 
         template<typename EventType>
         uint64_t subscribe(std::function<void(const EventType&)>) {
-            return 0; // Dummy subscription ID
+            return 0; // Dummy subscription ID - thread-safe as it's stateless
         }
 
         void unsubscribe(uint64_t) {
-            // No-op
+            // No-op - thread-safe as it performs no operations
         }
 
         void start() {}
         void stop() {}
         bool is_running() const { return false; }
 
+        /**
+         * @brief Get the singleton instance (thread-safe via C++11 magic statics)
+         */
         static std::shared_ptr<null_event_bus> instance() {
             static auto instance = std::make_shared<null_event_bus>();
             return instance;

--- a/include/kcenon/common/patterns/result.h
+++ b/include/kcenon/common/patterns/result.h
@@ -9,6 +9,13 @@
  * Provides a `Result<T>` type similar to Rust's Result or C++23's
  * `std::expected`, enabling explicit error propagation at module boundaries
  * without using exceptions.
+ *
+ * Thread Safety:
+ * - Result<T> objects are NOT thread-safe for concurrent modification.
+ * - Multiple threads may safely read the same Result<T> if no thread modifies it.
+ * - Helper functions are thread-safe as they don't modify global state.
+ * - If sharing Result<T> across threads, users must provide synchronization.
+ * - Best practice: Use Result<T> as return values; avoid shared mutable access.
  */
 
 #pragma once
@@ -60,9 +67,12 @@ struct error_info {
  *
  * A Result<T> can contain either a value of type T or an error_info.
  * This provides a type-safe way to handle errors without exceptions.
- */
-/**
- * @brief Discriminated union holding either a value of T or an error.
+ *
+ * Thread Safety Note:
+ * - Based on std::variant, which is NOT thread-safe for concurrent access.
+ * - Safe to pass by value or const reference across threads.
+ * - Concurrent reads of the same Result are safe if guaranteed no writes.
+ * - For shared mutable access, wrap in std::mutex or similar.
  */
 template<typename T>
 using Result = std::variant<T, error_info>;


### PR DESCRIPTION
## Summary

This PR enhances documentation to clarify thread safety guarantees for common utility patterns (Task 1.7 - Phase 1 Thread Safety). As a header-only library, proper documentation is the primary mechanism for ensuring safe concurrent usage.

### Result<T> Pattern Documentation

- **Clarified thread safety model**: Based on std::variant, NOT thread-safe for concurrent modification
- **Safe usage patterns**: Pass by value or const reference across threads
- **Concurrent read guarantee**: Safe when no writes occur
- **Best practice guidance**: Use as return values to avoid shared mutable access
- **Synchronization requirements**: Users must provide mutex/locking for shared mutable access

### Event Bus Documentation

- **null_event_bus safety**: All methods are no-ops, inherently thread-safe
- **Singleton guarantee**: Documented C++11 magic statics ensure thread-safe initialization
- **Stateless operations**: Clarified why concurrent calls are safe
- **Per-method annotations**: Each operation explicitly documented as thread-safe

### Documentation Approach

This PR takes a documentation-first approach for the following reasons:

1. **Header-only library**: No implementation to modify, only usage guidance needed
2. **Standard library patterns**: Result<T> follows std::variant semantics; event_bus uses magic statics
3. **Already safe when used correctly**: No inherent bugs, just potential for misuse
4. **Clear contracts**: Documentation establishes what users must do for safety

### Key Clarifications

- Result<T> objects should not be shared mutably between threads
- Best practice is to return Result<T> by value from functions
- If shared access is needed, users must wrap in std::mutex
- Event bus singleton is automatically thread-safe via C++11 language guarantee
- All event bus operations in no-op mode perform no state changes

### Impact

Users now have explicit guidance on:
- When synchronization is required
- Safe patterns for passing Results across threads
- Why event bus calls are safe without additional locking
- Standard library conventions these patterns follow

## Files Changed

- `include/kcenon/common/patterns/result.h`: Added comprehensive thread safety documentation
- `include/kcenon/common/patterns/event_bus.h`: Documented thread safety guarantees

## Test Plan

- Documentation-only change, no behavioral modifications
- Examples continue to build successfully
- Thread safety model aligns with std::variant and C++11 standards
- Clear guidance prevents common concurrent usage errors