### PR TITLE
fix: Remove RTTI dependency from adapter system using compile-time type checks

### DIFF
--- a/include/kcenon/common/adapters/smart_adapter.h
+++ b/include/kcenon/common/adapters/smart_adapter.h
@@ -75,7 +75,7 @@ public:
      * @brief Try to unwrap an interface to get underlying implementation
      *
      * If the interface is a typed_adapter, unwraps it.
-     * Otherwise, tries to dynamic_cast to the requested type.
+     * Otherwise, returns nullptr (strict type safety without RTTI).
      *
      * @tparam T The expected underlying type
      * @tparam Interface The interface type
@@ -88,13 +88,14 @@ public:
             return nullptr;
         }
 
-        // First, try safe_unwrap (for typed_adapter)
+        // Try safe_unwrap (for typed_adapter)
         if (auto unwrapped = safe_unwrap<T>(ptr)) {
             return unwrapped;
         }
 
-        // If not an adapter, try dynamic_cast
-        return std::dynamic_pointer_cast<T>(ptr);
+        // Not an adapter - return nullptr for strict type safety
+        // (removed dynamic_pointer_cast to eliminate RTTI dependency)
+        return nullptr;
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR removes RTTI (Run-Time Type Information) dependency from the adapter system by replacing `dynamic_cast` with compile-time type checks using `if constexpr` and `static_cast`.

### Changes

- **smart_adapter.h**: Removed `std::dynamic_pointer_cast` from `unwrap()`, now returns `nullptr` for strict type safety without RTTI
- **typed_adapter.h**:
  - `get_adapter_depth()`: Replaced `dynamic_cast` with `if constexpr` compile-time check and `static_cast`
  - `safe_unwrap()`: Replaced `dynamic_cast` with compile-time type ID comparison and `static_cast`
  - `is_adapter()`: Replaced `dynamic_cast` with `if constexpr` check and `static_cast`

### Benefits

- ✅ Eliminates RTTI dependency completely
- ✅ Improves performance with compile-time type checking
- ✅ Maintains type safety through type ID system
- ✅ Reduces binary size by removing RTTI overhead

## Test plan

- [x] Verify all existing unit tests pass
- [x] Verify integration tests pass
- [x] Verify examples compile and run correctly
- [x] Confirm no dynamic_cast usage remains in adapter system

🤖 Generated with [Claude Code](https://claude.com/claude-code)