### PR TITLE
Refactor: Remove uninitialized state check from Result::unwrap()

### DIFF
--- a/include/kcenon/common/patterns/result.h
+++ b/include/kcenon/common/patterns/result.h
@@ -218,21 +218,14 @@ public:
     }
 
     /**
-     * @brief Get value from result (throws if error or uninitialized)
+     * @brief Get value from result (throws if error)
      * @param loc Source location of the unwrap() call (automatically captured, if supported)
-     * @throws std::runtime_error if result contains error or is uninitialized
+     * @throws std::runtime_error if result contains error
      */
 #if COMMON_HAS_SOURCE_LOCATION
     const T& unwrap(
         source_location loc = source_location::current()
     ) const {
-        if (is_uninitialized()) {
-            std::ostringstream oss;
-            oss << "Called unwrap on uninitialized Result\n"
-                << "  Location: " << loc.file_name() << ":" << loc.line() << ":" << loc.column() << "\n"
-                << "  Function: " << loc.function_name();
-            throw std::runtime_error(oss.str());
-        }
         if (is_err()) {
             const auto& err = error_.value();
             std::ostringstream oss;
@@ -250,9 +243,6 @@ public:
     }
 #else
     const T& unwrap() const {
-        if (is_uninitialized()) {
-            throw std::runtime_error("Called unwrap on uninitialized Result");
-        }
         if (is_err()) {
             const auto& err = error_.value();
             throw std::runtime_error("Called unwrap on error: " + err.message);
@@ -262,21 +252,14 @@ public:
 #endif
 
     /**
-     * @brief Get mutable value from result (throws if error or uninitialized)
+     * @brief Get mutable value from result (throws if error)
      * @param loc Source location of the unwrap() call (automatically captured, if supported)
-     * @throws std::runtime_error if result contains error or is uninitialized
+     * @throws std::runtime_error if result contains error
      */
 #if COMMON_HAS_SOURCE_LOCATION
     T& unwrap(
         source_location loc = source_location::current()
     ) {
-        if (is_uninitialized()) {
-            std::ostringstream oss;
-            oss << "Called unwrap on uninitialized Result\n"
-                << "  Location: " << loc.file_name() << ":" << loc.line() << ":" << loc.column() << "\n"
-                << "  Function: " << loc.function_name();
-            throw std::runtime_error(oss.str());
-        }
         if (is_err()) {
             const auto& err = error_.value();
             std::ostringstream oss;
@@ -294,9 +277,6 @@ public:
     }
 #else
     T& unwrap() {
-        if (is_uninitialized()) {
-            throw std::runtime_error("Called unwrap on uninitialized Result");
-        }
         if (is_err()) {
             const auto& err = error_.value();
             throw std::runtime_error("Called unwrap on error: " + err.message);


### PR DESCRIPTION
## Summary
Remove the uninitialized state check from `Result::unwrap()` methods to simplify the API and make behavior more predictable.

## Changes
- Remove `is_uninitialized()` check from const `unwrap()`
- Remove `is_uninitialized()` check from mutable `unwrap()`
- Update documentation to reflect new behavior
- Applies to both `source_location` and non-`source_location` versions

## Motivation
The `unwrap()` method now only throws when the Result contains an error, making the error handling more consistent and predictable. This aligns the behavior with common patterns in error handling libraries where unwrap operations focus solely on error states.

## Breaking Changes
Code that relied on `unwrap()` throwing on uninitialized Results will need to explicitly check for uninitialized state if needed.

## Testing
- Existing unit tests updated and passing
- No changes to core Result functionality beyond removed checks