### PR TITLE
docs: update namespace references to kcenon::network::integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ process_with_executor(executor);
 
 // Use common executor with network system
 void setup_network(std::shared_ptr<common::interfaces::IExecutor> executor) {
-    auto adapted_pool = network_system::integration::make_thread_pool_adapter(executor);
+    auto adapted_pool = kcenon::network::integration::make_thread_pool_adapter(executor);
 
     network_system::server server(adapted_pool);
     // Network operations now use the common executor

--- a/README_KO.md
+++ b/README_KO.md
@@ -256,7 +256,7 @@ process_with_executor(executor);
 
 // 네트워크 시스템과 함께 공통 executor 사용
 void setup_network(std::shared_ptr<common::interfaces::IExecutor> executor) {
-    auto adapted_pool = network_system::integration::make_thread_pool_adapter(executor);
+    auto adapted_pool = kcenon::network::integration::make_thread_pool_adapter(executor);
 
     network_system::server server(adapted_pool);
     // 네트워크 작업이 이제 공통 executor를 사용

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -439,7 +439,7 @@ Network operations using common executor abstraction:
 
 void setup_network(std::shared_ptr<common::interfaces::IExecutor> executor) {
     // Adapt common executor to network system's thread pool interface
-    auto network_pool = network_system::integration::make_thread_pool_adapter(executor);
+    auto network_pool = kcenon::network::integration::make_thread_pool_adapter(executor);
 
     // Create server with adapted executor
     network_system::server server(network_pool);


### PR DESCRIPTION
## Summary
Update code examples in documentation to use the correct namespace.

## Changes
- Update `README.md`, `README_KO.md`, and `docs/FEATURES.md`
- Change `network_system::integration::make_thread_pool_adapter` to `kcenon::network::integration::make_thread_pool_adapter`

## Reason
The network_system integration headers now use `kcenon::network::integration` namespace consistently. Documentation examples should reflect this change.