### PR TITLE
feat(di): implement service container (TICKET-102)

### DIFF
--- a/include/kcenon/common/di/service_container.h
+++ b/include/kcenon/common/di/service_container.h
@@ -1,0 +1,615 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file service_container.h
+ * @brief Implementation of the service container for dependency injection.
+ *
+ * This header provides the concrete implementation of IServiceContainer,
+ * enabling type-safe dependency injection with configurable lifetimes.
+ *
+ * Thread Safety:
+ * - service_container is thread-safe for concurrent registration and resolution.
+ * - Uses std::shared_mutex for read/write locking.
+ * - Singleton instantiation uses double-checked locking pattern.
+ * - Circular dependency detection uses thread-local resolution stack.
+ *
+ * @see TICKET-102 for implementation requirements.
+ * @see service_container_interface.h for the interface definition.
+ */
+
+#pragma once
+
+#include "service_container_interface.h"
+
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace kcenon::common {
+namespace di {
+
+// Forward declaration
+class service_scope;
+
+/**
+ * @class service_container
+ * @brief Concrete implementation of IServiceContainer.
+ *
+ * Provides a thread-safe dependency injection container with support for:
+ * - Singleton, transient, and scoped service lifetimes
+ * - Factory-based lazy instantiation
+ * - Circular dependency detection
+ * - Scoped containers for request-level isolation
+ *
+ * Usage Example:
+ * @code
+ * auto& container = service_container::global();
+ *
+ * // Register a singleton logger
+ * container.register_factory<ILogger>(
+ *     [](IServiceContainer&) { return std::make_shared<ConsoleLogger>(); },
+ *     service_lifetime::singleton
+ * );
+ *
+ * // Register a transient service
+ * container.register_type<IWorker, WorkerImpl>(service_lifetime::transient);
+ *
+ * // Resolve services
+ * auto logger = container.resolve<ILogger>().value();
+ * @endcode
+ */
+class service_container : public IServiceContainer {
+public:
+    /**
+     * @brief Get the global service container instance.
+     *
+     * Returns a reference to the application-wide singleton container.
+     * Thread-safe for concurrent access.
+     *
+     * @return Reference to the global service_container
+     */
+    static service_container& global();
+
+    /**
+     * @brief Default constructor.
+     */
+    service_container() = default;
+
+    /**
+     * @brief Destructor.
+     */
+    ~service_container() override = default;
+
+    // Non-copyable, non-movable
+    service_container(const service_container&) = delete;
+    service_container& operator=(const service_container&) = delete;
+    service_container(service_container&&) = delete;
+    service_container& operator=(service_container&&) = delete;
+
+    // ===== IServiceContainer Implementation =====
+
+    /**
+     * @brief Create a new service scope.
+     * @return Unique pointer to the new scope
+     */
+    std::unique_ptr<IServiceScope> create_scope() override;
+
+    /**
+     * @brief Get list of all registered service descriptors.
+     * @return Vector of service descriptors
+     */
+    std::vector<service_descriptor> registered_services() const override;
+
+    /**
+     * @brief Clear all registrations.
+     */
+    void clear() override;
+
+protected:
+    // ===== Internal Implementation =====
+
+    VoidResult register_factory_internal(
+        std::type_index interface_type,
+        const std::string& type_name,
+        std::function<std::shared_ptr<void>(IServiceContainer&)> factory,
+        service_lifetime lifetime) override;
+
+    VoidResult register_instance_internal(
+        std::type_index interface_type,
+        const std::string& type_name,
+        std::shared_ptr<void> instance) override;
+
+    Result<std::shared_ptr<void>> resolve_internal(
+        std::type_index interface_type) override;
+
+    bool is_registered_internal(std::type_index interface_type) const override;
+
+    VoidResult unregister_internal(std::type_index interface_type) override;
+
+private:
+    friend class service_scope;
+
+    /**
+     * @brief Internal service registration entry.
+     */
+    struct service_entry {
+        std::type_index interface_type;
+        std::string type_name;
+        std::function<std::shared_ptr<void>(IServiceContainer&)> factory;
+        service_lifetime lifetime;
+        std::shared_ptr<void> singleton_instance;
+        bool is_instantiated = false;
+
+        service_entry(std::type_index type, std::string name,
+                      std::function<std::shared_ptr<void>(IServiceContainer&)> f,
+                      service_lifetime lt)
+            : interface_type(type)
+            , type_name(std::move(name))
+            , factory(std::move(f))
+            , lifetime(lt) {}
+    };
+
+    /**
+     * @brief Resolve a service with circular dependency detection.
+     *
+     * @param interface_type The type to resolve
+     * @param scoped_instances Optional map for scoped instances (from scope)
+     * @return Result containing the service or an error
+     */
+    Result<std::shared_ptr<void>> resolve_with_detection(
+        std::type_index interface_type,
+        std::unordered_map<std::type_index, std::shared_ptr<void>>* scoped_instances = nullptr);
+
+    /**
+     * @brief Check if currently resolving this type (circular dependency check).
+     */
+    bool is_resolving(std::type_index interface_type) const;
+
+    /**
+     * @brief Push type onto resolution stack.
+     */
+    void push_resolution(std::type_index interface_type);
+
+    /**
+     * @brief Pop type from resolution stack.
+     */
+    void pop_resolution(std::type_index interface_type);
+
+    /**
+     * @brief Get current resolution stack as string for error messages.
+     */
+    std::string get_resolution_stack_string() const;
+
+    // Service registry
+    mutable std::shared_mutex mutex_;
+    std::unordered_map<std::type_index, service_entry> services_;
+
+    // Thread-local resolution stack for circular dependency detection
+    static thread_local std::unordered_set<std::type_index> resolution_stack_;
+    static thread_local std::vector<std::type_index> resolution_order_;
+};
+
+/**
+ * @class service_scope
+ * @brief Scoped service container implementation.
+ *
+ * A service scope shares singleton registrations with its parent container
+ * but maintains its own instances for scoped services. When the scope is
+ * destroyed, all scoped instances are disposed.
+ */
+class service_scope : public IServiceScope {
+public:
+    /**
+     * @brief Construct a scope with a parent container.
+     * @param parent Reference to the parent container
+     */
+    explicit service_scope(service_container& parent);
+
+    /**
+     * @brief Destructor - disposes scoped instances.
+     */
+    ~service_scope() override = default;
+
+    // Non-copyable, non-movable
+    service_scope(const service_scope&) = delete;
+    service_scope& operator=(const service_scope&) = delete;
+    service_scope(service_scope&&) = delete;
+    service_scope& operator=(service_scope&&) = delete;
+
+    // ===== IServiceScope Implementation =====
+
+    /**
+     * @brief Get the parent container.
+     * @return Reference to the parent container
+     */
+    IServiceContainer& parent() override;
+
+    /**
+     * @brief Get the parent container (const).
+     * @return Const reference to the parent container
+     */
+    const IServiceContainer& parent() const override;
+
+    // ===== IServiceContainer Implementation =====
+
+    std::unique_ptr<IServiceScope> create_scope() override;
+    std::vector<service_descriptor> registered_services() const override;
+    void clear() override;
+
+protected:
+    VoidResult register_factory_internal(
+        std::type_index interface_type,
+        const std::string& type_name,
+        std::function<std::shared_ptr<void>(IServiceContainer&)> factory,
+        service_lifetime lifetime) override;
+
+    VoidResult register_instance_internal(
+        std::type_index interface_type,
+        const std::string& type_name,
+        std::shared_ptr<void> instance) override;
+
+    Result<std::shared_ptr<void>> resolve_internal(
+        std::type_index interface_type) override;
+
+    bool is_registered_internal(std::type_index interface_type) const override;
+
+    VoidResult unregister_internal(std::type_index interface_type) override;
+
+private:
+    service_container& parent_;
+    mutable std::shared_mutex mutex_;
+    std::unordered_map<std::type_index, std::shared_ptr<void>> scoped_instances_;
+};
+
+// ============================================================================
+// service_container Implementation
+// ============================================================================
+
+// Thread-local storage for circular dependency detection
+inline thread_local std::unordered_set<std::type_index> service_container::resolution_stack_;
+inline thread_local std::vector<std::type_index> service_container::resolution_order_;
+
+inline service_container& service_container::global() {
+    static service_container instance;
+    return instance;
+}
+
+inline std::unique_ptr<IServiceScope> service_container::create_scope() {
+    return std::make_unique<service_scope>(*this);
+}
+
+inline std::vector<service_descriptor> service_container::registered_services() const {
+    std::shared_lock lock(mutex_);
+
+    std::vector<service_descriptor> result;
+    result.reserve(services_.size());
+
+    for (const auto& [type_index, entry] : services_) {
+        service_descriptor desc(entry.interface_type, entry.type_name, entry.lifetime);
+        desc.is_instantiated = entry.is_instantiated;
+        result.push_back(std::move(desc));
+    }
+
+    return result;
+}
+
+inline void service_container::clear() {
+    std::unique_lock lock(mutex_);
+    services_.clear();
+}
+
+inline VoidResult service_container::register_factory_internal(
+    std::type_index interface_type,
+    const std::string& type_name,
+    std::function<std::shared_ptr<void>(IServiceContainer&)> factory,
+    service_lifetime lifetime) {
+
+    std::unique_lock lock(mutex_);
+
+    // Check if already registered
+    if (services_.find(interface_type) != services_.end()) {
+        return make_error<std::monostate>(
+            di_error_codes::already_registered,
+            "Service already registered: " + type_name,
+            "di::service_container"
+        );
+    }
+
+    services_.emplace(
+        interface_type,
+        service_entry(interface_type, type_name, std::move(factory), lifetime)
+    );
+
+    return VoidResult::ok({});
+}
+
+inline VoidResult service_container::register_instance_internal(
+    std::type_index interface_type,
+    const std::string& type_name,
+    std::shared_ptr<void> instance) {
+
+    std::unique_lock lock(mutex_);
+
+    // Check if already registered
+    if (services_.find(interface_type) != services_.end()) {
+        return make_error<std::monostate>(
+            di_error_codes::already_registered,
+            "Service already registered: " + type_name,
+            "di::service_container"
+        );
+    }
+
+    // Create entry with instance as singleton
+    service_entry entry(
+        interface_type,
+        type_name,
+        [](IServiceContainer&) -> std::shared_ptr<void> { return nullptr; },
+        service_lifetime::singleton
+    );
+    entry.singleton_instance = std::move(instance);
+    entry.is_instantiated = true;
+
+    services_.emplace(interface_type, std::move(entry));
+
+    return VoidResult::ok({});
+}
+
+inline Result<std::shared_ptr<void>> service_container::resolve_internal(
+    std::type_index interface_type) {
+    return resolve_with_detection(interface_type, nullptr);
+}
+
+inline Result<std::shared_ptr<void>> service_container::resolve_with_detection(
+    std::type_index interface_type,
+    std::unordered_map<std::type_index, std::shared_ptr<void>>* scoped_instances) {
+
+    // Check for circular dependency
+    if (is_resolving(interface_type)) {
+        std::string cycle_info = get_resolution_stack_string();
+        return make_error<std::shared_ptr<void>>(
+            di_error_codes::circular_dependency,
+            "Circular dependency detected: " + cycle_info,
+            "di::service_container"
+        );
+    }
+
+    // Check if service is registered
+    {
+        std::shared_lock lock(mutex_);
+        auto it = services_.find(interface_type);
+        if (it == services_.end()) {
+            return make_error<std::shared_ptr<void>>(
+                di_error_codes::service_not_registered,
+                "Service not registered: " + std::string(interface_type.name()),
+                "di::service_container"
+            );
+        }
+    }
+
+    // Push onto resolution stack
+    push_resolution(interface_type);
+
+    // RAII guard to pop from resolution stack
+    struct resolution_guard {
+        service_container* container;
+        std::type_index type;
+        ~resolution_guard() { container->pop_resolution(type); }
+    } guard{this, interface_type};
+
+    // Resolve based on lifetime
+    std::shared_lock read_lock(mutex_);
+    auto it = services_.find(interface_type);
+    auto& entry = it->second;
+
+    // Copy factory and lifetime before releasing lock to avoid deadlock
+    // when factory calls resolve() recursively
+    auto factory_copy = entry.factory;
+    auto lifetime = entry.lifetime;
+
+    switch (lifetime) {
+        case service_lifetime::singleton: {
+            // Double-checked locking for singleton
+            if (entry.is_instantiated) {
+                return Result<std::shared_ptr<void>>::ok(entry.singleton_instance);
+            }
+
+            read_lock.unlock();
+
+            // Create instance outside of lock to avoid deadlock
+            std::shared_ptr<void> instance;
+            try {
+                instance = factory_copy(*this);
+            } catch (const std::exception& e) {
+                return make_error<std::shared_ptr<void>>(
+                    di_error_codes::factory_error,
+                    std::string("Factory threw exception: ") + e.what(),
+                    "di::service_container"
+                );
+            }
+
+            // Now acquire write lock to store the instance
+            std::unique_lock write_lock(mutex_);
+
+            // Re-check after acquiring write lock (another thread may have created it)
+            auto it2 = services_.find(interface_type);
+            auto& entry2 = it2->second;
+            if (entry2.is_instantiated) {
+                // Another thread created it, return that instance
+                return Result<std::shared_ptr<void>>::ok(entry2.singleton_instance);
+            }
+
+            entry2.singleton_instance = std::move(instance);
+            entry2.is_instantiated = true;
+            return Result<std::shared_ptr<void>>::ok(entry2.singleton_instance);
+        }
+
+        case service_lifetime::transient: {
+            // Create new instance each time - release lock before calling factory
+            read_lock.unlock();
+            try {
+                auto instance = factory_copy(*this);
+                return Result<std::shared_ptr<void>>::ok(std::move(instance));
+            } catch (const std::exception& e) {
+                return make_error<std::shared_ptr<void>>(
+                    di_error_codes::factory_error,
+                    std::string("Factory threw exception: ") + e.what(),
+                    "di::service_container"
+                );
+            }
+        }
+
+        case service_lifetime::scoped: {
+            // Scoped services should be resolved from a scope
+            if (scoped_instances == nullptr) {
+                return make_error<std::shared_ptr<void>>(
+                    di_error_codes::scoped_from_root,
+                    "Cannot resolve scoped service from root container. Use create_scope().",
+                    "di::service_container"
+                );
+            }
+
+            // Check if already instantiated in scope
+            auto scoped_it = scoped_instances->find(interface_type);
+            if (scoped_it != scoped_instances->end()) {
+                return Result<std::shared_ptr<void>>::ok(scoped_it->second);
+            }
+
+            // Create new instance for scope - release lock before calling factory
+            read_lock.unlock();
+            try {
+                auto instance = factory_copy(*this);
+                (*scoped_instances)[interface_type] = instance;
+                return Result<std::shared_ptr<void>>::ok(std::move(instance));
+            } catch (const std::exception& e) {
+                return make_error<std::shared_ptr<void>>(
+                    di_error_codes::factory_error,
+                    std::string("Factory threw exception: ") + e.what(),
+                    "di::service_container"
+                );
+            }
+        }
+
+        default:
+            return make_error<std::shared_ptr<void>>(
+                di_error_codes::invalid_lifetime,
+                "Unknown service lifetime",
+                "di::service_container"
+            );
+    }
+}
+
+inline bool service_container::is_registered_internal(std::type_index interface_type) const {
+    std::shared_lock lock(mutex_);
+    return services_.find(interface_type) != services_.end();
+}
+
+inline VoidResult service_container::unregister_internal(std::type_index interface_type) {
+    std::unique_lock lock(mutex_);
+
+    auto it = services_.find(interface_type);
+    if (it == services_.end()) {
+        return make_error<std::monostate>(
+            di_error_codes::service_not_registered,
+            "Service not registered",
+            "di::service_container"
+        );
+    }
+
+    services_.erase(it);
+    return VoidResult::ok({});
+}
+
+inline bool service_container::is_resolving(std::type_index interface_type) const {
+    return resolution_stack_.find(interface_type) != resolution_stack_.end();
+}
+
+inline void service_container::push_resolution(std::type_index interface_type) {
+    resolution_stack_.insert(interface_type);
+    resolution_order_.push_back(interface_type);
+}
+
+inline void service_container::pop_resolution(std::type_index interface_type) {
+    resolution_stack_.erase(interface_type);
+    if (!resolution_order_.empty() && resolution_order_.back() == interface_type) {
+        resolution_order_.pop_back();
+    }
+}
+
+inline std::string service_container::get_resolution_stack_string() const {
+    std::string result;
+    for (size_t i = 0; i < resolution_order_.size(); ++i) {
+        if (i > 0) {
+            result += " -> ";
+        }
+        result += resolution_order_[i].name();
+    }
+    return result;
+}
+
+// ============================================================================
+// service_scope Implementation
+// ============================================================================
+
+inline service_scope::service_scope(service_container& parent)
+    : parent_(parent) {}
+
+inline IServiceContainer& service_scope::parent() {
+    return parent_;
+}
+
+inline const IServiceContainer& service_scope::parent() const {
+    return parent_;
+}
+
+inline std::unique_ptr<IServiceScope> service_scope::create_scope() {
+    // Nested scopes share the same root parent
+    return std::make_unique<service_scope>(parent_);
+}
+
+inline std::vector<service_descriptor> service_scope::registered_services() const {
+    // Return parent's registered services
+    return parent_.registered_services();
+}
+
+inline void service_scope::clear() {
+    std::unique_lock lock(mutex_);
+    scoped_instances_.clear();
+}
+
+inline VoidResult service_scope::register_factory_internal(
+    std::type_index interface_type,
+    const std::string& type_name,
+    std::function<std::shared_ptr<void>(IServiceContainer&)> factory,
+    service_lifetime lifetime) {
+    // Delegate to parent
+    return parent_.register_factory_internal(interface_type, type_name, std::move(factory), lifetime);
+}
+
+inline VoidResult service_scope::register_instance_internal(
+    std::type_index interface_type,
+    const std::string& type_name,
+    std::shared_ptr<void> instance) {
+    // Delegate to parent
+    return parent_.register_instance_internal(interface_type, type_name, std::move(instance));
+}
+
+inline Result<std::shared_ptr<void>> service_scope::resolve_internal(
+    std::type_index interface_type) {
+    // Resolve with scoped instances
+    return parent_.resolve_with_detection(interface_type, &scoped_instances_);
+}
+
+inline bool service_scope::is_registered_internal(std::type_index interface_type) const {
+    return parent_.is_registered_internal(interface_type);
+}
+
+inline VoidResult service_scope::unregister_internal(std::type_index interface_type) {
+    // Delegate to parent
+    return parent_.unregister_internal(interface_type);
+}
+
+} // namespace di
+} // namespace kcenon::common

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,27 @@ set_tests_properties(common_thread_safety_test PROPERTIES
     LABELS "thread_safety"
 )
 
+# Service container tests (TICKET-102)
+add_executable(common_service_container_test
+    service_container_test.cpp
+)
+
+target_link_libraries(common_service_container_test PRIVATE
+    kcenon::common
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+target_compile_features(common_service_container_test PRIVATE cxx_std_17)
+
+add_test(NAME common_service_container_test COMMAND common_service_container_test)
+
+set_tests_properties(common_service_container_test PROPERTIES
+    TIMEOUT 120
+    LABELS "unit;di"
+)
+
 # ABI version tests (Sprint 2 - Task 2.4)
 # Note: These tests require the static library build to test link-time checks
 if(NOT COMMON_HEADER_ONLY AND TARGET common_system_static)

--- a/tests/service_container_test.cpp
+++ b/tests/service_container_test.cpp
@@ -1,0 +1,600 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file service_container_test.cpp
+ * @brief Unit tests for service_container implementation (TICKET-102)
+ */
+
+#include <gtest/gtest.h>
+#include <kcenon/common/di/service_container.h>
+
+#include <thread>
+#include <vector>
+#include <atomic>
+
+using namespace kcenon::common;
+using namespace kcenon::common::di;
+
+// Test interfaces
+class ITestService {
+public:
+    virtual ~ITestService() = default;
+    virtual int get_value() const = 0;
+};
+
+class ITestDependency {
+public:
+    virtual ~ITestDependency() = default;
+    virtual std::string get_name() const = 0;
+};
+
+// Test implementations
+class TestServiceImpl : public ITestService {
+public:
+    TestServiceImpl() : value_(42) {}
+    explicit TestServiceImpl(int value) : value_(value) {}
+    int get_value() const override { return value_; }
+private:
+    int value_;
+};
+
+class TestDependencyImpl : public ITestDependency {
+public:
+    std::string get_name() const override { return "TestDependency"; }
+};
+
+class ServiceWithDependency : public ITestService {
+public:
+    explicit ServiceWithDependency(std::shared_ptr<ITestDependency> dep)
+        : dependency_(std::move(dep)) {}
+
+    int get_value() const override { return 100; }
+    const ITestDependency& dependency() const { return *dependency_; }
+private:
+    std::shared_ptr<ITestDependency> dependency_;
+};
+
+// Counter for tracking instantiations
+static std::atomic<int> g_instantiation_count{0};
+
+class CountingService : public ITestService {
+public:
+    CountingService() { g_instantiation_count++; }
+    int get_value() const override { return g_instantiation_count.load(); }
+};
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+class ServiceContainerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        container_ = std::make_unique<service_container>();
+        g_instantiation_count = 0;
+    }
+
+    void TearDown() override {
+        container_.reset();
+    }
+
+    std::unique_ptr<service_container> container_;
+};
+
+// ============================================================================
+// Registration Tests
+// ============================================================================
+
+TEST_F(ServiceContainerTest, RegisterType_Singleton) {
+    auto result = container_->register_type<ITestService, TestServiceImpl>(
+        service_lifetime::singleton);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_TRUE(container_->is_registered<ITestService>());
+}
+
+TEST_F(ServiceContainerTest, RegisterType_Transient) {
+    auto result = container_->register_type<ITestService, TestServiceImpl>(
+        service_lifetime::transient);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_TRUE(container_->is_registered<ITestService>());
+}
+
+TEST_F(ServiceContainerTest, RegisterType_Scoped) {
+    auto result = container_->register_type<ITestService, TestServiceImpl>(
+        service_lifetime::scoped);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_TRUE(container_->is_registered<ITestService>());
+}
+
+TEST_F(ServiceContainerTest, RegisterFactory) {
+    auto result = container_->register_factory<ITestService>(
+        [](IServiceContainer&) {
+            return std::make_shared<TestServiceImpl>(999);
+        },
+        service_lifetime::singleton
+    );
+
+    EXPECT_TRUE(result.is_ok());
+
+    auto resolved = container_->resolve<ITestService>();
+    EXPECT_TRUE(resolved.is_ok());
+    EXPECT_EQ(resolved.value()->get_value(), 999);
+}
+
+TEST_F(ServiceContainerTest, RegisterSimpleFactory) {
+    auto result = container_->register_simple_factory<ITestService>(
+        []() {
+            return std::make_shared<TestServiceImpl>(123);
+        },
+        service_lifetime::transient
+    );
+
+    EXPECT_TRUE(result.is_ok());
+
+    auto resolved = container_->resolve<ITestService>();
+    EXPECT_TRUE(resolved.is_ok());
+    EXPECT_EQ(resolved.value()->get_value(), 123);
+}
+
+TEST_F(ServiceContainerTest, RegisterInstance) {
+    auto instance = std::make_shared<TestServiceImpl>(777);
+    auto result = container_->register_instance<ITestService>(instance);
+
+    EXPECT_TRUE(result.is_ok());
+
+    auto resolved = container_->resolve<ITestService>();
+    EXPECT_TRUE(resolved.is_ok());
+    EXPECT_EQ(resolved.value()->get_value(), 777);
+    EXPECT_EQ(resolved.value().get(), instance.get());
+}
+
+TEST_F(ServiceContainerTest, RegisterDuplicate_Fails) {
+    container_->register_type<ITestService, TestServiceImpl>();
+
+    auto result = container_->register_type<ITestService, TestServiceImpl>();
+
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, di_error_codes::already_registered);
+}
+
+TEST_F(ServiceContainerTest, RegisterNullInstance_Fails) {
+    std::shared_ptr<ITestService> null_instance;
+    auto result = container_->register_instance<ITestService>(null_instance);
+
+    EXPECT_TRUE(result.is_err());
+}
+
+// ============================================================================
+// Resolution Tests
+// ============================================================================
+
+TEST_F(ServiceContainerTest, Resolve_Singleton_ReturnsSameInstance) {
+    container_->register_type<ITestService, CountingService>(
+        service_lifetime::singleton);
+
+    auto result1 = container_->resolve<ITestService>();
+    auto result2 = container_->resolve<ITestService>();
+
+    EXPECT_TRUE(result1.is_ok());
+    EXPECT_TRUE(result2.is_ok());
+    EXPECT_EQ(result1.value().get(), result2.value().get());
+    EXPECT_EQ(g_instantiation_count, 1);
+}
+
+TEST_F(ServiceContainerTest, Resolve_Transient_ReturnsNewInstance) {
+    container_->register_type<ITestService, CountingService>(
+        service_lifetime::transient);
+
+    auto result1 = container_->resolve<ITestService>();
+    auto result2 = container_->resolve<ITestService>();
+
+    EXPECT_TRUE(result1.is_ok());
+    EXPECT_TRUE(result2.is_ok());
+    EXPECT_NE(result1.value().get(), result2.value().get());
+    EXPECT_EQ(g_instantiation_count, 2);
+}
+
+TEST_F(ServiceContainerTest, Resolve_Scoped_FromRootContainer_Fails) {
+    container_->register_type<ITestService, TestServiceImpl>(
+        service_lifetime::scoped);
+
+    auto result = container_->resolve<ITestService>();
+
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, di_error_codes::scoped_from_root);
+}
+
+TEST_F(ServiceContainerTest, Resolve_NotRegistered_Fails) {
+    auto result = container_->resolve<ITestService>();
+
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, di_error_codes::service_not_registered);
+}
+
+TEST_F(ServiceContainerTest, ResolveOrNull_ReturnsNullWhenNotRegistered) {
+    auto result = container_->resolve_or_null<ITestService>();
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(ServiceContainerTest, ResolveOrNull_ReturnsInstanceWhenRegistered) {
+    container_->register_type<ITestService, TestServiceImpl>();
+
+    auto result = container_->resolve_or_null<ITestService>();
+
+    EXPECT_NE(result, nullptr);
+    EXPECT_EQ(result->get_value(), 42);
+}
+
+// ============================================================================
+// Dependency Resolution Tests
+// ============================================================================
+
+TEST_F(ServiceContainerTest, ResolveDependency_FromFactory) {
+    container_->register_type<ITestDependency, TestDependencyImpl>();
+
+    container_->register_factory<ITestService>(
+        [](IServiceContainer& c) {
+            auto dep = c.resolve<ITestDependency>().value();
+            return std::make_shared<ServiceWithDependency>(dep);
+        },
+        service_lifetime::singleton
+    );
+
+    auto result = container_->resolve<ITestService>();
+
+    EXPECT_TRUE(result.is_ok());
+    auto* service = dynamic_cast<ServiceWithDependency*>(result.value().get());
+    EXPECT_NE(service, nullptr);
+    EXPECT_EQ(service->dependency().get_name(), "TestDependency");
+}
+
+// ============================================================================
+// Circular Dependency Tests
+// ============================================================================
+
+class ICircularA {
+public:
+    virtual ~ICircularA() = default;
+};
+
+class ICircularB {
+public:
+    virtual ~ICircularB() = default;
+};
+
+class CircularAImpl : public ICircularA {
+public:
+    explicit CircularAImpl(std::shared_ptr<ICircularB>) {}
+};
+
+class CircularBImpl : public ICircularB {
+public:
+    explicit CircularBImpl(std::shared_ptr<ICircularA>) {}
+};
+
+TEST_F(ServiceContainerTest, CircularDependency_Detected) {
+    // A depends on B, B depends on A - create actual circular dependency
+    container_->register_factory<ICircularA>(
+        [](IServiceContainer& c) -> std::shared_ptr<ICircularA> {
+            auto b_result = c.resolve<ICircularB>();
+            if (b_result.is_err()) {
+                // Propagate the error by throwing
+                throw std::runtime_error(b_result.error().message);
+            }
+            return std::make_shared<CircularAImpl>(b_result.value());
+        },
+        service_lifetime::singleton
+    );
+
+    container_->register_factory<ICircularB>(
+        [](IServiceContainer& c) -> std::shared_ptr<ICircularB> {
+            auto a_result = c.resolve<ICircularA>();
+            if (a_result.is_err()) {
+                // Propagate the error by throwing
+                throw std::runtime_error(a_result.error().message);
+            }
+            return std::make_shared<CircularBImpl>(a_result.value());
+        },
+        service_lifetime::singleton
+    );
+
+    auto result = container_->resolve<ICircularA>();
+
+    EXPECT_TRUE(result.is_err());
+    // The error could be either circular_dependency or factory_error
+    // (factory_error wraps the circular_dependency when it throws)
+    EXPECT_TRUE(result.error().code == di_error_codes::circular_dependency ||
+                result.error().code == di_error_codes::factory_error);
+}
+
+// ============================================================================
+// Scope Tests
+// ============================================================================
+
+TEST_F(ServiceContainerTest, Scope_ScopedService_ReturnsSameInstanceInScope) {
+    container_->register_type<ITestService, CountingService>(
+        service_lifetime::scoped);
+
+    auto scope = container_->create_scope();
+
+    auto result1 = scope->resolve<ITestService>();
+    auto result2 = scope->resolve<ITestService>();
+
+    EXPECT_TRUE(result1.is_ok());
+    EXPECT_TRUE(result2.is_ok());
+    EXPECT_EQ(result1.value().get(), result2.value().get());
+    EXPECT_EQ(g_instantiation_count, 1);
+}
+
+TEST_F(ServiceContainerTest, Scope_DifferentScopes_ReturnDifferentInstances) {
+    container_->register_type<ITestService, CountingService>(
+        service_lifetime::scoped);
+
+    auto scope1 = container_->create_scope();
+    auto scope2 = container_->create_scope();
+
+    auto result1 = scope1->resolve<ITestService>();
+    auto result2 = scope2->resolve<ITestService>();
+
+    EXPECT_TRUE(result1.is_ok());
+    EXPECT_TRUE(result2.is_ok());
+    EXPECT_NE(result1.value().get(), result2.value().get());
+    EXPECT_EQ(g_instantiation_count, 2);
+}
+
+TEST_F(ServiceContainerTest, Scope_SingletonService_SharedAcrossScopes) {
+    container_->register_type<ITestService, CountingService>(
+        service_lifetime::singleton);
+
+    auto scope1 = container_->create_scope();
+    auto scope2 = container_->create_scope();
+
+    auto result1 = scope1->resolve<ITestService>();
+    auto result2 = scope2->resolve<ITestService>();
+
+    EXPECT_TRUE(result1.is_ok());
+    EXPECT_TRUE(result2.is_ok());
+    EXPECT_EQ(result1.value().get(), result2.value().get());
+    EXPECT_EQ(g_instantiation_count, 1);
+}
+
+TEST_F(ServiceContainerTest, Scope_TransientService_NewInstanceEachTime) {
+    container_->register_type<ITestService, CountingService>(
+        service_lifetime::transient);
+
+    auto scope = container_->create_scope();
+
+    auto result1 = scope->resolve<ITestService>();
+    auto result2 = scope->resolve<ITestService>();
+
+    EXPECT_TRUE(result1.is_ok());
+    EXPECT_TRUE(result2.is_ok());
+    EXPECT_NE(result1.value().get(), result2.value().get());
+    EXPECT_EQ(g_instantiation_count, 2);
+}
+
+TEST_F(ServiceContainerTest, Scope_ParentAccess) {
+    auto scope = container_->create_scope();
+
+    EXPECT_EQ(&scope->parent(), container_.get());
+}
+
+TEST_F(ServiceContainerTest, Scope_NestedScope) {
+    container_->register_type<ITestService, CountingService>(
+        service_lifetime::scoped);
+
+    auto scope1 = container_->create_scope();
+    auto scope2 = scope1->create_scope();
+
+    auto result1 = scope1->resolve<ITestService>();
+    auto result2 = scope2->resolve<ITestService>();
+
+    EXPECT_TRUE(result1.is_ok());
+    EXPECT_TRUE(result2.is_ok());
+    // Nested scopes share the same root parent, so different scoped instances
+    EXPECT_NE(result1.value().get(), result2.value().get());
+}
+
+// ============================================================================
+// Introspection Tests
+// ============================================================================
+
+TEST_F(ServiceContainerTest, RegisteredServices_ListsAllServices) {
+    container_->register_type<ITestService, TestServiceImpl>(
+        service_lifetime::singleton);
+    container_->register_type<ITestDependency, TestDependencyImpl>(
+        service_lifetime::transient);
+
+    auto services = container_->registered_services();
+
+    EXPECT_EQ(services.size(), 2u);
+}
+
+TEST_F(ServiceContainerTest, Unregister_RemovesService) {
+    container_->register_type<ITestService, TestServiceImpl>();
+
+    EXPECT_TRUE(container_->is_registered<ITestService>());
+
+    auto result = container_->unregister<ITestService>();
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_FALSE(container_->is_registered<ITestService>());
+}
+
+TEST_F(ServiceContainerTest, Unregister_NotRegistered_Fails) {
+    auto result = container_->unregister<ITestService>();
+
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, di_error_codes::service_not_registered);
+}
+
+TEST_F(ServiceContainerTest, Clear_RemovesAllServices) {
+    container_->register_type<ITestService, TestServiceImpl>();
+    container_->register_type<ITestDependency, TestDependencyImpl>();
+
+    container_->clear();
+
+    EXPECT_FALSE(container_->is_registered<ITestService>());
+    EXPECT_FALSE(container_->is_registered<ITestDependency>());
+    EXPECT_EQ(container_->registered_services().size(), 0u);
+}
+
+// ============================================================================
+// Thread Safety Tests
+// ============================================================================
+
+TEST_F(ServiceContainerTest, ThreadSafety_ConcurrentRegistration) {
+    constexpr int NUM_THREADS = 10;
+    std::vector<std::thread> threads;
+    std::atomic<int> success_count{0};
+
+    for (int i = 0; i < NUM_THREADS; ++i) {
+        threads.emplace_back([this, i, &success_count]() {
+            auto result = container_->register_factory<ITestService>(
+                [](IServiceContainer&) {
+                    return std::make_shared<TestServiceImpl>();
+                },
+                service_lifetime::singleton
+            );
+            if (result.is_ok()) {
+                success_count++;
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // Only one registration should succeed
+    EXPECT_EQ(success_count, 1);
+}
+
+TEST_F(ServiceContainerTest, ThreadSafety_ConcurrentResolution) {
+    container_->register_type<ITestService, TestServiceImpl>(
+        service_lifetime::singleton);
+
+    constexpr int NUM_THREADS = 10;
+    constexpr int ITERATIONS = 100;
+    std::vector<std::thread> threads;
+    std::atomic<int> resolve_count{0};
+    std::shared_ptr<ITestService> first_instance;
+    std::mutex first_mutex;
+
+    for (int i = 0; i < NUM_THREADS; ++i) {
+        threads.emplace_back([this, &resolve_count, &first_instance, &first_mutex]() {
+            for (int j = 0; j < ITERATIONS; ++j) {
+                auto result = container_->resolve<ITestService>();
+                if (result.is_ok()) {
+                    resolve_count++;
+                    std::lock_guard<std::mutex> lock(first_mutex);
+                    if (!first_instance) {
+                        first_instance = result.value();
+                    } else {
+                        // All instances should be the same (singleton)
+                        EXPECT_EQ(result.value().get(), first_instance.get());
+                    }
+                }
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(resolve_count, NUM_THREADS * ITERATIONS);
+}
+
+TEST_F(ServiceContainerTest, ThreadSafety_ConcurrentScopeResolution) {
+    container_->register_type<ITestService, CountingService>(
+        service_lifetime::scoped);
+
+    constexpr int NUM_THREADS = 10;
+    std::vector<std::thread> threads;
+    std::atomic<int> total_instantiations{0};
+
+    for (int i = 0; i < NUM_THREADS; ++i) {
+        threads.emplace_back([this, &total_instantiations]() {
+            auto scope = container_->create_scope();
+
+            // Multiple resolutions in same scope should return same instance
+            auto result1 = scope->resolve<ITestService>();
+            auto result2 = scope->resolve<ITestService>();
+
+            EXPECT_TRUE(result1.is_ok());
+            EXPECT_TRUE(result2.is_ok());
+            EXPECT_EQ(result1.value().get(), result2.value().get());
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // Each thread should have created exactly one instance
+    EXPECT_EQ(g_instantiation_count, NUM_THREADS);
+}
+
+// ============================================================================
+// Global Container Tests
+// ============================================================================
+
+TEST(GlobalContainerTest, Global_ReturnsSameInstance) {
+    auto& container1 = service_container::global();
+    auto& container2 = service_container::global();
+
+    EXPECT_EQ(&container1, &container2);
+}
+
+TEST(GlobalContainerTest, Global_CanRegisterAndResolve) {
+    auto& container = service_container::global();
+
+    // Clean up from other tests
+    container.clear();
+
+    container.register_type<ITestService, TestServiceImpl>();
+
+    auto result = container.resolve<ITestService>();
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value()->get_value(), 42);
+
+    // Clean up
+    container.clear();
+}
+
+// ============================================================================
+// Factory Exception Handling Tests
+// ============================================================================
+
+TEST_F(ServiceContainerTest, Factory_ThrowsException_ReturnsError) {
+    container_->register_factory<ITestService>(
+        [](IServiceContainer&) -> std::shared_ptr<ITestService> {
+            throw std::runtime_error("Factory failed!");
+        },
+        service_lifetime::singleton
+    );
+
+    auto result = container_->resolve<ITestService>();
+
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, di_error_codes::factory_error);
+    EXPECT_TRUE(result.error().message.find("Factory failed!") != std::string::npos);
+}
+
+// ============================================================================
+// Lifetime String Conversion Tests
+// ============================================================================
+
+TEST(ServiceLifetimeTest, ToString) {
+    EXPECT_STREQ(to_string(service_lifetime::singleton), "singleton");
+    EXPECT_STREQ(to_string(service_lifetime::transient), "transient");
+    EXPECT_STREQ(to_string(service_lifetime::scoped), "scoped");
+}


### PR DESCRIPTION
## Summary

- Implement concrete `service_container` class based on `IServiceContainer` interface from TICKET-101
- Support for singleton, transient, and scoped service lifetimes
- Thread-safe implementation using `std::shared_mutex`
- Circular dependency detection using thread-local resolution stack
- Comprehensive test coverage with 33 unit tests

## Implementation Details

### Key Features
- **Service Registration**: Factory-based, type-based, and instance registration
- **Lifetime Management**: Singleton (global), transient (per-request), scoped (per-scope)
- **Thread Safety**: All operations are thread-safe using shared_mutex for read/write locking
- **Circular Dependency Detection**: Prevents infinite loops during service resolution
- **Scoped Containers**: Create isolated scopes for request-level service instances

### Files Changed
- `include/kcenon/common/di/service_container.h` - Implementation
- `tests/service_container_test.cpp` - Unit tests (33 tests)
- `tests/CMakeLists.txt` - Build configuration for tests

## Test Plan
- [x] All 33 unit tests passing
- [x] Registration tests (type, factory, instance)
- [x] Resolution tests (singleton, transient, scoped)
- [x] Circular dependency detection test
- [x] Thread safety tests (concurrent registration/resolution)
- [x] Scope isolation tests
- [x] Factory exception handling tests

## Related Issues
- Implements TICKET-102 from ROADMAP_01_INTEGRATION_LAYER.md
- Depends on TICKET-101 (interface design) - PR #82