### PR TITLE
feat(config): implement CLI configuration override (TICKET-204)

### DIFF
--- a/include/kcenon/common/config/cli_config_parser.h
+++ b/include/kcenon/common/config/cli_config_parser.h
@@ -1,0 +1,486 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file cli_config_parser.h
+ * @brief Command-line interface configuration parser.
+ *
+ * This header provides the cli_config_parser class for parsing command-line
+ * arguments and applying configuration overrides.
+ *
+ * Supported arguments:
+ * - --config=<path>    Load configuration from YAML file
+ * - --set key=value    Override a specific configuration value
+ * - --help, -h         Show help message
+ * - --version, -v      Show version information
+ *
+ * Configuration Priority (highest to lowest):
+ * 1. CLI arguments (--set key=value)
+ * 2. Environment variables (UNIFIED_*)
+ * 3. Configuration file (YAML)
+ * 4. Default values
+ *
+ * @see TICKET-204 for implementation requirements.
+ * @see config_loader.h for loading implementation.
+ */
+
+#pragma once
+
+#include "config_loader.h"
+#include "unified_config.h"
+
+#include <kcenon/common/patterns/result.h>
+
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace kcenon::common::config {
+
+/**
+ * @brief CLI parsing error codes.
+ */
+namespace cli_error_codes {
+    constexpr int invalid_argument = 2001;
+    constexpr int missing_value = 2002;
+    constexpr int invalid_key = 2003;
+    constexpr int invalid_format = 2004;
+}
+
+/**
+ * @struct parsed_args
+ * @brief Parsed command-line arguments.
+ */
+struct parsed_args {
+    /// Configuration file path (from --config)
+    std::string config_path;
+
+    /// Configuration overrides (from --set key=value)
+    std::vector<std::pair<std::string, std::string>> overrides;
+
+    /// Show help flag
+    bool show_help = false;
+
+    /// Show version flag
+    bool show_version = false;
+
+    /// Unparsed positional arguments
+    std::vector<std::string> positional_args;
+};
+
+/**
+ * @class cli_config_parser
+ * @brief Parses command-line arguments for configuration.
+ *
+ * Usage Example:
+ * @code
+ * int main(int argc, char** argv) {
+ *     auto result = cli_config_parser::load_with_cli_overrides(argc, argv);
+ *     if (result.is_err()) {
+ *         if (result.error().code == cli_error_codes::invalid_argument) {
+ *             cli_config_parser::print_help(argv[0]);
+ *         }
+ *         return 1;
+ *     }
+ *
+ *     auto config = result.value();
+ *     // Use config...
+ * }
+ * @endcode
+ */
+class cli_config_parser {
+public:
+    /**
+     * @brief Parse command-line arguments.
+     *
+     * Parses the given arguments and returns a parsed_args structure.
+     *
+     * @param argc Number of arguments
+     * @param argv Argument array
+     * @return Result containing parsed_args or error
+     */
+    static Result<parsed_args> parse(int argc, char** argv) {
+        parsed_args result;
+
+        for (int i = 1; i < argc; ++i) {
+            std::string arg = argv[i];
+
+            if (arg == "--help" || arg == "-h") {
+                result.show_help = true;
+            } else if (arg == "--version" || arg == "-v") {
+                result.show_version = true;
+            } else if (starts_with(arg, "--config=")) {
+                result.config_path = arg.substr(9);
+            } else if (arg == "--config") {
+                if (i + 1 >= argc) {
+                    return make_error<parsed_args>(
+                        cli_error_codes::missing_value,
+                        "Missing value for --config",
+                        "cli_config_parser"
+                    );
+                }
+                result.config_path = argv[++i];
+            } else if (starts_with(arg, "--set=")) {
+                auto kv_result = parse_key_value(arg.substr(6));
+                if (kv_result.is_err()) {
+                    return make_error<parsed_args>(kv_result.error());
+                }
+                result.overrides.push_back(kv_result.value());
+            } else if (arg == "--set") {
+                if (i + 1 >= argc) {
+                    return make_error<parsed_args>(
+                        cli_error_codes::missing_value,
+                        "Missing value for --set",
+                        "cli_config_parser"
+                    );
+                }
+                auto kv_result = parse_key_value(argv[++i]);
+                if (kv_result.is_err()) {
+                    return make_error<parsed_args>(kv_result.error());
+                }
+                result.overrides.push_back(kv_result.value());
+            } else if (starts_with(arg, "--")) {
+                return make_error<parsed_args>(
+                    cli_error_codes::invalid_argument,
+                    "Unknown argument: " + arg,
+                    "cli_config_parser"
+                );
+            } else if (starts_with(arg, "-")) {
+                return make_error<parsed_args>(
+                    cli_error_codes::invalid_argument,
+                    "Unknown short argument: " + arg,
+                    "cli_config_parser"
+                );
+            } else {
+                // Positional argument
+                result.positional_args.push_back(arg);
+            }
+        }
+
+        return Result<parsed_args>::ok(std::move(result));
+    }
+
+    /**
+     * @brief Load configuration with CLI overrides.
+     *
+     * Parses CLI arguments, loads configuration from file (if specified),
+     * applies environment variable overrides, and then applies CLI overrides.
+     *
+     * Priority (highest to lowest):
+     * 1. --set key=value overrides
+     * 2. Environment variables (UNIFIED_*)
+     * 3. Configuration file
+     * 4. Defaults
+     *
+     * @param argc Number of arguments
+     * @param argv Argument array
+     * @return Result containing unified_config or error
+     */
+    static Result<unified_config> load_with_cli_overrides(int argc, char** argv) {
+        // Parse CLI arguments
+        auto parse_result = parse(argc, argv);
+        if (parse_result.is_err()) {
+            return make_error<unified_config>(parse_result.error());
+        }
+
+        auto args = parse_result.value();
+
+        // Handle --help and --version early
+        if (args.show_help || args.show_version) {
+            // Return an "error" to indicate the caller should handle this
+            return make_error<unified_config>(
+                args.show_help ? cli_error_codes::invalid_argument : cli_error_codes::invalid_argument,
+                args.show_help ? "help_requested" : "version_requested",
+                "cli_config_parser"
+            );
+        }
+
+        // Load configuration
+        unified_config config;
+
+        if (!args.config_path.empty()) {
+            // Load from file
+            auto load_result = config_loader::load(args.config_path);
+            if (load_result.is_err()) {
+                return make_error<unified_config>(load_result.error());
+            }
+            config = load_result.value();
+        } else {
+            // Load from environment only
+            auto load_result = config_loader::load_from_env();
+            if (load_result.is_err()) {
+                return make_error<unified_config>(load_result.error());
+            }
+            config = load_result.value();
+        }
+
+        // Apply CLI overrides
+        for (const auto& [key, value] : args.overrides) {
+            auto result = apply_override(config, key, value);
+            if (result.is_err()) {
+                return make_error<unified_config>(result.error());
+            }
+        }
+
+        // Validate final configuration
+        auto validation_result = config_loader::validate(config);
+        if (validation_result.is_err()) {
+            return make_error<unified_config>(validation_result.error());
+        }
+
+        return Result<unified_config>::ok(std::move(config));
+    }
+
+    /**
+     * @brief Print help message to stdout.
+     *
+     * @param program_name Name of the program (usually argv[0])
+     */
+    static void print_help(const std::string& program_name = "program") {
+        std::cout << "Usage: " << program_name << " [OPTIONS]\n\n"
+                  << "Options:\n"
+                  << "  --config=<path>     Load configuration from YAML file\n"
+                  << "  --set <key>=<value> Override a configuration value\n"
+                  << "  --help, -h          Show this help message\n"
+                  << "  --version, -v       Show version information\n\n"
+                  << "Configuration keys:\n";
+
+        // Print available configuration keys
+        auto metadata = get_config_metadata();
+        for (const auto& field : metadata) {
+            std::cout << "  " << field.path;
+            if (!field.allowed_values.empty()) {
+                std::cout << " (";
+                for (size_t i = 0; i < field.allowed_values.size(); ++i) {
+                    if (i > 0) std::cout << "|";
+                    std::cout << field.allowed_values[i];
+                }
+                std::cout << ")";
+            }
+            std::cout << "\n    " << field.description;
+            if (!field.env_var.empty()) {
+                std::cout << " [env: " << field.env_var << "]";
+            }
+            std::cout << "\n";
+        }
+
+        std::cout << "\nExamples:\n"
+                  << "  " << program_name << " --config=config.yaml\n"
+                  << "  " << program_name << " --set logger.level=debug\n"
+                  << "  " << program_name << " --config=config.yaml --set thread.pool_size=16\n";
+    }
+
+    /**
+     * @brief Print version information to stdout.
+     *
+     * @param version Version string
+     */
+    static void print_version(const std::string& version = "1.0.0") {
+        std::cout << "unified_system version " << version << "\n";
+    }
+
+private:
+    /**
+     * @brief Check if a string starts with a prefix.
+     */
+    static bool starts_with(const std::string& str, const std::string& prefix) {
+        return str.size() >= prefix.size() &&
+               str.compare(0, prefix.size(), prefix) == 0;
+    }
+
+    /**
+     * @brief Parse a key=value string.
+     */
+    static Result<std::pair<std::string, std::string>> parse_key_value(const std::string& str) {
+        auto pos = str.find('=');
+        if (pos == std::string::npos) {
+            return make_error<std::pair<std::string, std::string>>(
+                cli_error_codes::invalid_format,
+                "Invalid key=value format: " + str,
+                "cli_config_parser"
+            );
+        }
+
+        std::string key = str.substr(0, pos);
+        std::string value = str.substr(pos + 1);
+
+        // Trim whitespace from key
+        key.erase(0, key.find_first_not_of(" \t"));
+        key.erase(key.find_last_not_of(" \t") + 1);
+
+        if (key.empty()) {
+            return make_error<std::pair<std::string, std::string>>(
+                cli_error_codes::invalid_key,
+                "Empty key in key=value pair",
+                "cli_config_parser"
+            );
+        }
+
+        return Result<std::pair<std::string, std::string>>::ok(
+            std::make_pair(std::move(key), std::move(value)));
+    }
+
+    /**
+     * @brief Apply a configuration override.
+     *
+     * @param config Configuration to modify
+     * @param key Configuration key (dot-separated path)
+     * @param value Value to set
+     * @return VoidResult indicating success or error
+     */
+    static VoidResult apply_override(unified_config& config,
+                                     const std::string& key,
+                                     const std::string& value) {
+        // Thread configuration
+        if (key == "thread.pool_size") {
+            config.thread.pool_size = parse_size_t(value);
+        } else if (key == "thread.queue_type") {
+            config.thread.queue_type = value;
+        } else if (key == "thread.max_queue_size") {
+            config.thread.max_queue_size = parse_size_t(value);
+        } else if (key == "thread.thread_name_prefix") {
+            config.thread.thread_name_prefix = value;
+        }
+        // Logger configuration
+        else if (key == "logger.level") {
+            config.logger.level = value;
+        } else if (key == "logger.async") {
+            config.logger.async = parse_bool(value);
+        } else if (key == "logger.buffer_size") {
+            config.logger.buffer_size = parse_size_t(value);
+        } else if (key == "logger.file_path") {
+            config.logger.file_path = value;
+        } else if (key == "logger.max_file_size") {
+            config.logger.max_file_size = parse_size_t(value);
+        } else if (key == "logger.max_backup_files") {
+            config.logger.max_backup_files = parse_size_t(value);
+        } else if (key == "logger.format_pattern") {
+            config.logger.format_pattern = value;
+        }
+        // Monitoring configuration
+        else if (key == "monitoring.enabled") {
+            config.monitoring.enabled = parse_bool(value);
+        } else if (key == "monitoring.metrics_interval" ||
+                   key == "monitoring.metrics_interval_ms") {
+            config.monitoring.metrics_interval = std::chrono::milliseconds{parse_int64(value)};
+        } else if (key == "monitoring.health_check_interval" ||
+                   key == "monitoring.health_check_interval_ms") {
+            config.monitoring.health_check_interval = std::chrono::milliseconds{parse_int64(value)};
+        } else if (key == "monitoring.prometheus_port") {
+            config.monitoring.prometheus_port = static_cast<uint16_t>(parse_size_t(value));
+        } else if (key == "monitoring.prometheus_path") {
+            config.monitoring.prometheus_path = value;
+        }
+        // Tracing configuration
+        else if (key == "monitoring.tracing.enabled") {
+            config.monitoring.tracing.enabled = parse_bool(value);
+        } else if (key == "monitoring.tracing.sampling_rate") {
+            config.monitoring.tracing.sampling_rate = parse_double(value);
+        } else if (key == "monitoring.tracing.exporter") {
+            config.monitoring.tracing.exporter = value;
+        } else if (key == "monitoring.tracing.endpoint") {
+            config.monitoring.tracing.endpoint = value;
+        }
+        // Database configuration
+        else if (key == "database.backend") {
+            config.database.backend = value;
+        } else if (key == "database.connection_string") {
+            config.database.connection_string = value;
+        } else if (key == "database.log_queries") {
+            config.database.log_queries = parse_bool(value);
+        } else if (key == "database.slow_query_threshold" ||
+                   key == "database.slow_query_threshold_ms") {
+            config.database.slow_query_threshold = std::chrono::milliseconds{parse_int64(value)};
+        } else if (key == "database.pool.min_size") {
+            config.database.pool.min_size = parse_size_t(value);
+        } else if (key == "database.pool.max_size") {
+            config.database.pool.max_size = parse_size_t(value);
+        } else if (key == "database.pool.idle_timeout" ||
+                   key == "database.pool.idle_timeout_ms") {
+            config.database.pool.idle_timeout = std::chrono::milliseconds{parse_int64(value)};
+        } else if (key == "database.pool.acquire_timeout" ||
+                   key == "database.pool.acquire_timeout_ms") {
+            config.database.pool.acquire_timeout = std::chrono::milliseconds{parse_int64(value)};
+        }
+        // Network configuration
+        else if (key == "network.compression") {
+            config.network.compression = value;
+        } else if (key == "network.buffer_size") {
+            config.network.buffer_size = parse_size_t(value);
+        } else if (key == "network.connect_timeout" ||
+                   key == "network.connect_timeout_ms") {
+            config.network.connect_timeout = std::chrono::milliseconds{parse_int64(value)};
+        } else if (key == "network.io_timeout" ||
+                   key == "network.io_timeout_ms") {
+            config.network.io_timeout = std::chrono::milliseconds{parse_int64(value)};
+        } else if (key == "network.keepalive_interval" ||
+                   key == "network.keepalive_interval_ms") {
+            config.network.keepalive_interval = std::chrono::milliseconds{parse_int64(value)};
+        } else if (key == "network.max_connections") {
+            config.network.max_connections = parse_size_t(value);
+        }
+        // TLS configuration
+        else if (key == "network.tls.enabled") {
+            config.network.tls.enabled = parse_bool(value);
+        } else if (key == "network.tls.version") {
+            config.network.tls.version = value;
+        } else if (key == "network.tls.cert_path") {
+            config.network.tls.cert_path = value;
+        } else if (key == "network.tls.key_path") {
+            config.network.tls.key_path = value;
+        } else if (key == "network.tls.ca_path") {
+            config.network.tls.ca_path = value;
+        } else if (key == "network.tls.verify_peer") {
+            config.network.tls.verify_peer = parse_bool(value);
+        }
+        // Unknown key
+        else {
+            return make_error<std::monostate>(
+                cli_error_codes::invalid_key,
+                "Unknown configuration key: " + key,
+                "cli_config_parser"
+            );
+        }
+
+        return VoidResult::ok({});
+    }
+
+    // Value parsing helpers
+
+    static size_t parse_size_t(const std::string& value) {
+        try {
+            return std::stoull(value);
+        } catch (...) {
+            return 0;
+        }
+    }
+
+    static int64_t parse_int64(const std::string& value) {
+        try {
+            return std::stoll(value);
+        } catch (...) {
+            return 0;
+        }
+    }
+
+    static double parse_double(const std::string& value) {
+        try {
+            return std::stod(value);
+        } catch (...) {
+            return 0.0;
+        }
+    }
+
+    static bool parse_bool(const std::string& value) {
+        std::string lower = value;
+        std::transform(lower.begin(), lower.end(), lower.begin(),
+                      [](unsigned char c) { return std::tolower(c); });
+        return lower == "true" || lower == "1" || lower == "yes" || lower == "on";
+    }
+};
+
+}  // namespace kcenon::common::config

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -166,6 +166,27 @@ set_tests_properties(common_config_loader_test PROPERTIES
     LABELS "unit;config"
 )
 
+# CLI config parser tests (TICKET-204)
+add_executable(common_cli_config_parser_test
+    cli_config_parser_test.cpp
+)
+
+target_link_libraries(common_cli_config_parser_test PRIVATE
+    kcenon::common
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+target_compile_features(common_cli_config_parser_test PRIVATE cxx_std_17)
+
+add_test(NAME common_cli_config_parser_test COMMAND common_cli_config_parser_test)
+
+set_tests_properties(common_cli_config_parser_test PROPERTIES
+    TIMEOUT 60
+    LABELS "unit;config;cli"
+)
+
 # ABI version tests (Sprint 2 - Task 2.4)
 # Note: These tests require the static library build to test link-time checks
 if(NOT COMMON_HEADER_ONLY AND TARGET common_system_static)

--- a/tests/cli_config_parser_test.cpp
+++ b/tests/cli_config_parser_test.cpp
@@ -1,0 +1,484 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+#include <gtest/gtest.h>
+
+#include <kcenon/common/config/cli_config_parser.h>
+
+#include <cstdlib>
+#include <vector>
+#include <string>
+
+using namespace kcenon::common::config;
+
+// ============================================================================
+// Helper class for managing argv arrays
+// ============================================================================
+
+class ArgvBuilder {
+public:
+    ArgvBuilder() = default;
+
+    ArgvBuilder& add(const std::string& arg) {
+        args_.push_back(arg);
+        return *this;
+    }
+
+    int argc() const { return static_cast<int>(args_.size()); }
+
+    char** argv() {
+        ptrs_.clear();
+        for (auto& arg : args_) {
+            ptrs_.push_back(const_cast<char*>(arg.c_str()));
+        }
+        ptrs_.push_back(nullptr);
+        return ptrs_.data();
+    }
+
+private:
+    std::vector<std::string> args_;
+    std::vector<char*> ptrs_;
+};
+
+// Helper class for environment variable management
+class EnvVarGuard {
+public:
+    EnvVarGuard(const std::string& name, const std::string& value)
+        : name_(name) {
+        const char* old = std::getenv(name.c_str());
+        if (old) {
+            had_value_ = true;
+            old_value_ = old;
+        }
+        setenv(name.c_str(), value.c_str(), 1);
+    }
+
+    ~EnvVarGuard() {
+        if (had_value_) {
+            setenv(name_.c_str(), old_value_.c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+private:
+    std::string name_;
+    std::string old_value_;
+    bool had_value_ = false;
+};
+
+// ============================================================================
+// Parse Tests
+// ============================================================================
+
+TEST(CliConfigParserTest, Parse_NoArgs_ReturnsEmpty) {
+    ArgvBuilder args;
+    args.add("program");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+
+    auto parsed = result.value();
+    EXPECT_TRUE(parsed.config_path.empty());
+    EXPECT_TRUE(parsed.overrides.empty());
+    EXPECT_FALSE(parsed.show_help);
+    EXPECT_FALSE(parsed.show_version);
+}
+
+TEST(CliConfigParserTest, Parse_HelpFlag_Long) {
+    ArgvBuilder args;
+    args.add("program").add("--help");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(result.value().show_help);
+}
+
+TEST(CliConfigParserTest, Parse_HelpFlag_Short) {
+    ArgvBuilder args;
+    args.add("program").add("-h");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(result.value().show_help);
+}
+
+TEST(CliConfigParserTest, Parse_VersionFlag_Long) {
+    ArgvBuilder args;
+    args.add("program").add("--version");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(result.value().show_version);
+}
+
+TEST(CliConfigParserTest, Parse_VersionFlag_Short) {
+    ArgvBuilder args;
+    args.add("program").add("-v");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(result.value().show_version);
+}
+
+TEST(CliConfigParserTest, Parse_ConfigFlag_Equals) {
+    ArgvBuilder args;
+    args.add("program").add("--config=path/to/config.yaml");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().config_path, "path/to/config.yaml");
+}
+
+TEST(CliConfigParserTest, Parse_ConfigFlag_Separate) {
+    ArgvBuilder args;
+    args.add("program").add("--config").add("path/to/config.yaml");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().config_path, "path/to/config.yaml");
+}
+
+TEST(CliConfigParserTest, Parse_ConfigFlag_MissingValue) {
+    ArgvBuilder args;
+    args.add("program").add("--config");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, cli_error_codes::missing_value);
+}
+
+TEST(CliConfigParserTest, Parse_SetFlag_Equals) {
+    ArgvBuilder args;
+    args.add("program").add("--set=logger.level=debug");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+
+    auto& overrides = result.value().overrides;
+    ASSERT_EQ(overrides.size(), 1);
+    EXPECT_EQ(overrides[0].first, "logger.level");
+    EXPECT_EQ(overrides[0].second, "debug");
+}
+
+TEST(CliConfigParserTest, Parse_SetFlag_Separate) {
+    ArgvBuilder args;
+    args.add("program").add("--set").add("logger.level=debug");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+
+    auto& overrides = result.value().overrides;
+    ASSERT_EQ(overrides.size(), 1);
+    EXPECT_EQ(overrides[0].first, "logger.level");
+    EXPECT_EQ(overrides[0].second, "debug");
+}
+
+TEST(CliConfigParserTest, Parse_SetFlag_MissingValue) {
+    ArgvBuilder args;
+    args.add("program").add("--set");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, cli_error_codes::missing_value);
+}
+
+TEST(CliConfigParserTest, Parse_SetFlag_InvalidFormat) {
+    ArgvBuilder args;
+    args.add("program").add("--set=no_equals_sign");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, cli_error_codes::invalid_format);
+}
+
+TEST(CliConfigParserTest, Parse_MultipleOverrides) {
+    ArgvBuilder args;
+    args.add("program")
+        .add("--set=logger.level=debug")
+        .add("--set").add("thread.pool_size=16")
+        .add("--set=monitoring.enabled=false");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+
+    auto& overrides = result.value().overrides;
+    ASSERT_EQ(overrides.size(), 3);
+
+    EXPECT_EQ(overrides[0].first, "logger.level");
+    EXPECT_EQ(overrides[0].second, "debug");
+
+    EXPECT_EQ(overrides[1].first, "thread.pool_size");
+    EXPECT_EQ(overrides[1].second, "16");
+
+    EXPECT_EQ(overrides[2].first, "monitoring.enabled");
+    EXPECT_EQ(overrides[2].second, "false");
+}
+
+TEST(CliConfigParserTest, Parse_UnknownLongArg) {
+    ArgvBuilder args;
+    args.add("program").add("--unknown-arg");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, cli_error_codes::invalid_argument);
+}
+
+TEST(CliConfigParserTest, Parse_UnknownShortArg) {
+    ArgvBuilder args;
+    args.add("program").add("-x");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, cli_error_codes::invalid_argument);
+}
+
+TEST(CliConfigParserTest, Parse_PositionalArgs) {
+    ArgvBuilder args;
+    args.add("program").add("file1.txt").add("file2.txt");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+
+    auto& positional = result.value().positional_args;
+    ASSERT_EQ(positional.size(), 2);
+    EXPECT_EQ(positional[0], "file1.txt");
+    EXPECT_EQ(positional[1], "file2.txt");
+}
+
+TEST(CliConfigParserTest, Parse_MixedArgs) {
+    ArgvBuilder args;
+    args.add("program")
+        .add("--config=config.yaml")
+        .add("--set=logger.level=debug")
+        .add("input.txt")
+        .add("--set=thread.pool_size=8");
+
+    auto result = cli_config_parser::parse(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+
+    auto parsed = result.value();
+    EXPECT_EQ(parsed.config_path, "config.yaml");
+    EXPECT_EQ(parsed.overrides.size(), 2);
+    EXPECT_EQ(parsed.positional_args.size(), 1);
+    EXPECT_EQ(parsed.positional_args[0], "input.txt");
+}
+
+// ============================================================================
+// Load With CLI Overrides Tests
+// ============================================================================
+
+TEST(CliConfigParserTest, LoadWithCliOverrides_NoArgs) {
+    ArgvBuilder args;
+    args.add("program");
+
+    auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+
+    // Should have default values
+    auto config = result.value();
+    EXPECT_EQ(config.thread.pool_size, 0);
+    EXPECT_EQ(config.logger.level, "info");
+}
+
+TEST(CliConfigParserTest, LoadWithCliOverrides_AppliesOverrides) {
+    ArgvBuilder args;
+    args.add("program")
+        .add("--set=logger.level=debug")
+        .add("--set=thread.pool_size=16")
+        .add("--set=monitoring.enabled=false");
+
+    auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+
+    auto config = result.value();
+    EXPECT_EQ(config.logger.level, "debug");
+    EXPECT_EQ(config.thread.pool_size, 16);
+    EXPECT_FALSE(config.monitoring.enabled);
+}
+
+TEST(CliConfigParserTest, LoadWithCliOverrides_OverridesEnv) {
+    // Set environment variable
+    EnvVarGuard guard("UNIFIED_LOGGER_LEVEL", "warn");
+
+    ArgvBuilder args;
+    args.add("program").add("--set=logger.level=error");
+
+    auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+
+    // CLI override should take precedence over environment
+    EXPECT_EQ(result.value().logger.level, "error");
+}
+
+TEST(CliConfigParserTest, LoadWithCliOverrides_InvalidKey) {
+    ArgvBuilder args;
+    args.add("program").add("--set=invalid.key.path=value");
+
+    auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, cli_error_codes::invalid_key);
+}
+
+TEST(CliConfigParserTest, LoadWithCliOverrides_ValidationFails) {
+    ArgvBuilder args;
+    args.add("program").add("--set=logger.level=invalid_level");
+
+    auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST(CliConfigParserTest, LoadWithCliOverrides_BooleanValues) {
+    // Test various boolean formats
+    {
+        ArgvBuilder args;
+        args.add("program").add("--set=logger.async=true");
+        auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+        ASSERT_TRUE(result.is_ok());
+        EXPECT_TRUE(result.value().logger.async);
+    }
+    {
+        ArgvBuilder args;
+        args.add("program").add("--set=logger.async=false");
+        auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+        ASSERT_TRUE(result.is_ok());
+        EXPECT_FALSE(result.value().logger.async);
+    }
+    {
+        ArgvBuilder args;
+        args.add("program").add("--set=logger.async=1");
+        auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+        ASSERT_TRUE(result.is_ok());
+        EXPECT_TRUE(result.value().logger.async);
+    }
+    {
+        ArgvBuilder args;
+        args.add("program").add("--set=logger.async=0");
+        auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+        ASSERT_TRUE(result.is_ok());
+        EXPECT_FALSE(result.value().logger.async);
+    }
+}
+
+TEST(CliConfigParserTest, LoadWithCliOverrides_NumericValues) {
+    ArgvBuilder args;
+    args.add("program")
+        .add("--set=thread.pool_size=32")
+        .add("--set=network.buffer_size=131072")
+        .add("--set=monitoring.tracing.sampling_rate=0.5");
+
+    auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+
+    auto config = result.value();
+    EXPECT_EQ(config.thread.pool_size, 32);
+    EXPECT_EQ(config.network.buffer_size, 131072);
+    EXPECT_DOUBLE_EQ(config.monitoring.tracing.sampling_rate, 0.5);
+}
+
+TEST(CliConfigParserTest, LoadWithCliOverrides_DurationValues) {
+    ArgvBuilder args;
+    args.add("program")
+        .add("--set=monitoring.metrics_interval_ms=10000")
+        .add("--set=network.connect_timeout_ms=3000");
+
+    auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+
+    auto config = result.value();
+    EXPECT_EQ(config.monitoring.metrics_interval.count(), 10000);
+    EXPECT_EQ(config.network.connect_timeout.count(), 3000);
+}
+
+TEST(CliConfigParserTest, LoadWithCliOverrides_NestedKeys) {
+    ArgvBuilder args;
+    args.add("program")
+        .add("--set=monitoring.tracing.enabled=true")
+        .add("--set=monitoring.tracing.exporter=jaeger")
+        .add("--set=database.pool.min_size=10")
+        .add("--set=network.tls.version=1.2");
+
+    auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+
+    auto config = result.value();
+    EXPECT_TRUE(config.monitoring.tracing.enabled);
+    EXPECT_EQ(config.monitoring.tracing.exporter, "jaeger");
+    EXPECT_EQ(config.database.pool.min_size, 10);
+    EXPECT_EQ(config.network.tls.version, "1.2");
+}
+
+// ============================================================================
+// Help and Version Tests
+// ============================================================================
+
+TEST(CliConfigParserTest, LoadWithCliOverrides_HelpReturnsError) {
+    ArgvBuilder args;
+    args.add("program").add("--help");
+
+    auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().message, "help_requested");
+}
+
+TEST(CliConfigParserTest, LoadWithCliOverrides_VersionReturnsError) {
+    ArgvBuilder args;
+    args.add("program").add("--version");
+
+    auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().message, "version_requested");
+}
+
+// ============================================================================
+// Print Help Test (just verify it doesn't crash)
+// ============================================================================
+
+TEST(CliConfigParserTest, PrintHelp_DoesNotCrash) {
+    // Redirect stdout to suppress output
+    testing::internal::CaptureStdout();
+
+    cli_config_parser::print_help("test_program");
+
+    std::string output = testing::internal::GetCapturedStdout();
+    EXPECT_FALSE(output.empty());
+    EXPECT_NE(output.find("test_program"), std::string::npos);
+    EXPECT_NE(output.find("--config"), std::string::npos);
+    EXPECT_NE(output.find("--set"), std::string::npos);
+    EXPECT_NE(output.find("--help"), std::string::npos);
+}
+
+TEST(CliConfigParserTest, PrintVersion_DoesNotCrash) {
+    testing::internal::CaptureStdout();
+
+    cli_config_parser::print_version("2.0.0");
+
+    std::string output = testing::internal::GetCapturedStdout();
+    EXPECT_FALSE(output.empty());
+    EXPECT_NE(output.find("2.0.0"), std::string::npos);
+}
+
+// ============================================================================
+// Integration Tests
+// ============================================================================
+
+TEST(CliConfigParserTest, FullWorkflow) {
+    ArgvBuilder args;
+    args.add("myapp")
+        .add("--set=thread.pool_size=8")
+        .add("--set=logger.level=warn")
+        .add("--set=database.backend=postgresql")
+        .add("--set=database.connection_string=postgresql://localhost/mydb")
+        .add("--set=network.compression=zstd");
+
+    auto result = cli_config_parser::load_with_cli_overrides(args.argc(), args.argv());
+    ASSERT_TRUE(result.is_ok());
+
+    auto config = result.value();
+    EXPECT_EQ(config.thread.pool_size, 8);
+    EXPECT_EQ(config.logger.level, "warn");
+    EXPECT_EQ(config.database.backend, "postgresql");
+    EXPECT_EQ(config.database.connection_string, "postgresql://localhost/mydb");
+    EXPECT_EQ(config.network.compression, "zstd");
+}


### PR DESCRIPTION
## Summary
- Implement `cli_config_parser` class for parsing command-line arguments
- Add `--config=<path>` flag support for loading YAML configuration files
- Add `--set key=value` support for individual setting overrides
- Add `--help` and `--version` flags with auto-generated help message

## Changes
- `include/kcenon/common/config/cli_config_parser.h`: New CLI parser implementation
- `tests/cli_config_parser_test.cpp`: 31 unit tests covering all scenarios
- `tests/CMakeLists.txt`: Added test target

## Configuration Priority
Priority order (highest to lowest):
1. CLI arguments (`--set key=value`)
2. Environment variables (`UNIFIED_*`)
3. Configuration file (YAML)
4. Default values

## Test plan
- [x] Parse tests: help, version, config, set flags
- [x] Load with CLI overrides tests
- [x] Boolean, numeric, duration value parsing
- [x] Nested configuration key support
- [x] Priority override tests (CLI > ENV)
- [x] Invalid key and validation error handling

All 31 tests passing.