### PR TITLE
docs: add downstream system deprecation notifications

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Downstream System Deprecation Notifications** (#220)
+  - Created migration tracking issues in all dependent systems
+  - thread_system, logger_system, monitoring_system, pacs_system, database_system notified
+  - Each issue includes migration guide links and v3.0.0 removal timeline
+  - Updated `docs/DEPRECATION.md` with notification status table
+
 - **Deprecated API Documentation** (#213)
   - New `docs/DEPRECATION.md` documenting all deprecated APIs
   - Migration guides with before/after examples

--- a/docs/CHANGELOG_KO.md
+++ b/docs/CHANGELOG_KO.md
@@ -12,6 +12,12 @@ Common System 프로젝트의 모든 주요 변경 사항이 이 파일에 문�
 ## [Unreleased]
 
 ### Added
+- **다운스트림 시스템 Deprecation 알림** (#220)
+  - 모든 의존 시스템에 마이그레이션 추적 이슈 생성
+  - thread_system, logger_system, monitoring_system, pacs_system, database_system에 알림 완료
+  - 각 이슈에 마이그레이션 가이드 링크 및 v3.0.0 제거 타임라인 포함
+  - `docs/DEPRECATION.md`에 알림 상태 테이블 업데이트
+
 - **Deprecated API 문서화** (#213)
   - 모든 deprecated API를 문서화한 새로운 `docs/DEPRECATION.md`
   - Before/After 예제가 포함된 마이그레이션 가이드

--- a/docs/DEPRECATION.md
+++ b/docs/DEPRECATION.md
@@ -230,6 +230,22 @@ make 2>&1 | grep -i deprecated
 
 ---
 
+## Downstream System Notifications
+
+All dependent systems have been notified about the deprecated APIs and upcoming v3.0.0 removal:
+
+| System | Repository | Notification Issue |
+|--------|------------|-------------------|
+| thread_system | [kcenon/thread_system](https://github.com/kcenon/thread_system) | [#331](https://github.com/kcenon/thread_system/issues/331) |
+| logger_system | [kcenon/logger_system](https://github.com/kcenon/logger_system) | [#248](https://github.com/kcenon/logger_system/issues/248) |
+| monitoring_system | [kcenon/monitoring_system](https://github.com/kcenon/monitoring_system) | [#269](https://github.com/kcenon/monitoring_system/issues/269) |
+| pacs_system | [kcenon/pacs_system](https://github.com/kcenon/pacs_system) | [#399](https://github.com/kcenon/pacs_system/issues/399) |
+| database_system | [kcenon/database_system](https://github.com/kcenon/database_system) | [#276](https://github.com/kcenon/database_system/issues/276) |
+
+For tracking the overall deprecation plan, see [#213](https://github.com/kcenon/common_system/issues/213).
+
+---
+
 ## Related Documentation
 
 - [CHANGELOG](CHANGELOG.md) - Version history with deprecation notices

--- a/docs/DEPRECATION_KO.md
+++ b/docs/DEPRECATION_KO.md
@@ -229,6 +229,22 @@ make 2>&1 | grep -i deprecated
 
 ---
 
+## 다운스트림 시스템 알림
+
+모든 의존 시스템에 deprecated API 및 v3.0.0 제거 예정에 대해 알림을 완료했습니다:
+
+| 시스템 | 리포지토리 | 알림 이슈 |
+|--------|------------|-----------|
+| thread_system | [kcenon/thread_system](https://github.com/kcenon/thread_system) | [#331](https://github.com/kcenon/thread_system/issues/331) |
+| logger_system | [kcenon/logger_system](https://github.com/kcenon/logger_system) | [#248](https://github.com/kcenon/logger_system/issues/248) |
+| monitoring_system | [kcenon/monitoring_system](https://github.com/kcenon/monitoring_system) | [#269](https://github.com/kcenon/monitoring_system/issues/269) |
+| pacs_system | [kcenon/pacs_system](https://github.com/kcenon/pacs_system) | [#399](https://github.com/kcenon/pacs_system/issues/399) |
+| database_system | [kcenon/database_system](https://github.com/kcenon/database_system) | [#276](https://github.com/kcenon/database_system/issues/276) |
+
+전체 deprecation 계획 추적은 [#213](https://github.com/kcenon/common_system/issues/213)을 참조하세요.
+
+---
+
 ## 관련 문서
 
 - [CHANGELOG](CHANGELOG_KO.md) - deprecation 공지가 포함된 버전 히스토리


### PR DESCRIPTION
## Summary

- Created migration tracking issues in all 5 downstream systems
- Updated DEPRECATION.md with notification status table
- Updated CHANGELOG.md with notification work

## Downstream Systems Notified

| System | Issue |
|--------|-------|
| thread_system | [#331](https://github.com/kcenon/thread_system/issues/331) |
| logger_system | [#248](https://github.com/kcenon/logger_system/issues/248) |
| monitoring_system | [#269](https://github.com/kcenon/monitoring_system/issues/269) |
| pacs_system | [#399](https://github.com/kcenon/pacs_system/issues/399) |
| database_system | [#276](https://github.com/kcenon/database_system/issues/276) |

## Related Issues

- Closes #220
- Part of #213 (Phase 3 completed)

## Test Plan

- [x] All downstream issues created and linked
- [x] Documentation updated (DEPRECATION.md, CHANGELOG.md)
- [x] Korean versions updated (DEPRECATION_KO.md, CHANGELOG_KO.md)