### PR TITLE
docs(deprecation): update downstream system migration status

### DIFF
--- a/docs/DEPRECATION.md
+++ b/docs/DEPRECATION.md
@@ -216,17 +216,17 @@ make 2>&1 | grep -i deprecated
 
 ---
 
-## Downstream System Notifications
+## Downstream System Migration Status
 
-All dependent systems have been notified about the deprecated APIs and upcoming v3.0.0 removal:
+All dependent systems have been notified and have completed migration to the new APIs:
 
-| System | Repository | Notification Issue |
-|--------|------------|-------------------|
-| thread_system | [kcenon/thread_system](https://github.com/kcenon/thread_system) | [#331](https://github.com/kcenon/thread_system/issues/331) |
-| logger_system | [kcenon/logger_system](https://github.com/kcenon/logger_system) | [#248](https://github.com/kcenon/logger_system/issues/248) |
-| monitoring_system | [kcenon/monitoring_system](https://github.com/kcenon/monitoring_system) | [#269](https://github.com/kcenon/monitoring_system/issues/269) |
-| pacs_system | [kcenon/pacs_system](https://github.com/kcenon/pacs_system) | [#399](https://github.com/kcenon/pacs_system/issues/399) |
-| database_system | [kcenon/database_system](https://github.com/kcenon/database_system) | [#276](https://github.com/kcenon/database_system/issues/276) |
+| System | Repository | Notification Issue | Migration Status |
+|--------|------------|-------------------|------------------|
+| thread_system | [kcenon/thread_system](https://github.com/kcenon/thread_system) | [#331](https://github.com/kcenon/thread_system/issues/331) | ✅ Completed |
+| logger_system | [kcenon/logger_system](https://github.com/kcenon/logger_system) | [#248](https://github.com/kcenon/logger_system/issues/248) | ✅ Completed |
+| monitoring_system | [kcenon/monitoring_system](https://github.com/kcenon/monitoring_system) | [#269](https://github.com/kcenon/monitoring_system/issues/269) | ✅ Completed |
+| pacs_system | [kcenon/pacs_system](https://github.com/kcenon/pacs_system) | [#399](https://github.com/kcenon/pacs_system/issues/399) | ✅ Completed |
+| database_system | [kcenon/database_system](https://github.com/kcenon/database_system) | [#276](https://github.com/kcenon/database_system/issues/276) | ✅ Completed |
 
 For tracking the overall deprecation plan, see [#213](https://github.com/kcenon/common_system/issues/213).
 

--- a/docs/DEPRECATION_KO.md
+++ b/docs/DEPRECATION_KO.md
@@ -216,17 +216,17 @@ make 2>&1 | grep -i deprecated
 
 ---
 
-## 다운스트림 시스템 알림
+## 다운스트림 시스템 마이그레이션 상태
 
-모든 의존 시스템에 deprecated API 및 v3.0.0 제거 예정에 대해 알림을 완료했습니다:
+모든 의존 시스템에 알림이 완료되었고 새로운 API로 마이그레이션이 완료되었습니다:
 
-| 시스템 | 리포지토리 | 알림 이슈 |
-|--------|------------|-----------|
-| thread_system | [kcenon/thread_system](https://github.com/kcenon/thread_system) | [#331](https://github.com/kcenon/thread_system/issues/331) |
-| logger_system | [kcenon/logger_system](https://github.com/kcenon/logger_system) | [#248](https://github.com/kcenon/logger_system/issues/248) |
-| monitoring_system | [kcenon/monitoring_system](https://github.com/kcenon/monitoring_system) | [#269](https://github.com/kcenon/monitoring_system/issues/269) |
-| pacs_system | [kcenon/pacs_system](https://github.com/kcenon/pacs_system) | [#399](https://github.com/kcenon/pacs_system/issues/399) |
-| database_system | [kcenon/database_system](https://github.com/kcenon/database_system) | [#276](https://github.com/kcenon/database_system/issues/276) |
+| 시스템 | 리포지토리 | 알림 이슈 | 마이그레이션 상태 |
+|--------|------------|-----------|------------------|
+| thread_system | [kcenon/thread_system](https://github.com/kcenon/thread_system) | [#331](https://github.com/kcenon/thread_system/issues/331) | ✅ 완료 |
+| logger_system | [kcenon/logger_system](https://github.com/kcenon/logger_system) | [#248](https://github.com/kcenon/logger_system/issues/248) | ✅ 완료 |
+| monitoring_system | [kcenon/monitoring_system](https://github.com/kcenon/monitoring_system) | [#269](https://github.com/kcenon/monitoring_system/issues/269) | ✅ 완료 |
+| pacs_system | [kcenon/pacs_system](https://github.com/kcenon/pacs_system) | [#399](https://github.com/kcenon/pacs_system/issues/399) | ✅ 완료 |
+| database_system | [kcenon/database_system](https://github.com/kcenon/database_system) | [#276](https://github.com/kcenon/database_system/issues/276) | ✅ 완료 |
 
 전체 deprecation 계획 추적은 [#213](https://github.com/kcenon/common_system/issues/213)을 참조하세요.
 


### PR DESCRIPTION
## Summary

- Add migration status column to downstream system notification table
- Track and document that all dependent systems have completed migration to new APIs
- Update both English and Korean deprecation documentation

## Changes

### DEPRECATION.md / DEPRECATION_KO.md
- Rename section from "Downstream System Notifications" to "Downstream System Migration Status"
- Add "Migration Status" column showing all systems have completed migration
- All 5 downstream systems (thread_system, logger_system, monitoring_system, pacs_system, database_system) confirmed migrated

## Verification

Verified migration status by checking all notification issues:
- kcenon/thread_system#331: CLOSED
- kcenon/logger_system#248: CLOSED
- kcenon/monitoring_system#269: CLOSED
- kcenon/pacs_system#399: CLOSED
- kcenon/database_system#276: CLOSED

## Related Issues

- Completes Phase 3 of #213 (Track migration status in dependent projects)