### PR TITLE
refactor(patterns): migrate result.h to KCENON_* macros

### DIFF
--- a/include/kcenon/common/patterns/result.h
+++ b/include/kcenon/common/patterns/result.h
@@ -245,7 +245,7 @@ public:
      * @throws std::runtime_error if result contains error
      * @note When source_location is available, error messages include file/line info
      */
-#if COMMON_HAS_SOURCE_LOCATION
+#if KCENON_HAS_SOURCE_LOCATION
     const T& unwrap(
         source_location loc = source_location::current()
     ) const {
@@ -279,7 +279,7 @@ public:
      * @throws std::runtime_error if result contains error
      * @note When source_location is available, error messages include file/line info
      */
-#if COMMON_HAS_SOURCE_LOCATION
+#if KCENON_HAS_SOURCE_LOCATION
     T& unwrap(
         source_location loc = source_location::current()
     ) {
@@ -434,7 +434,7 @@ public:
      * @throws std::runtime_error if optional is None with detailed location info
      * @note When source_location is available, error messages include file/line info
      */
-#if COMMON_HAS_SOURCE_LOCATION
+#if KCENON_HAS_SOURCE_LOCATION
     const T& unwrap(
         source_location loc = source_location::current()
     ) const {


### PR DESCRIPTION
## Summary
- Migrate `result.h` from legacy `COMMON_HAS_SOURCE_LOCATION` macro to unified `KCENON_HAS_SOURCE_LOCATION` macro
- Part of Epic #223 unified feature-flag consolidation effort

## Changes
- Replace 3 occurrences of `COMMON_HAS_SOURCE_LOCATION` with `KCENON_HAS_SOURCE_LOCATION` in `result.h`
- The legacy alias remains available through `feature_flags.h` for backward compatibility

## Test Plan
- [x] All 105 tests pass
- [x] Build succeeds with C++20
- [x] Verified macro is correctly defined via `feature_flags.h`

Relates to: #223