### PR TITLE
docs(modules): add C++20 module documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The Common System Project is a foundational C++20 header-only library providing 
 - **Header-only design**: No library linking, no dependencies, instant integration
 - **Well-tested**: 80%+ test coverage, zero sanitizer warnings, full CI/CD
 - **Universal compatibility**: C++20 standard with modern language features
+- **C++20 Module support**: Optional module-based build for faster compilation (experimental)
 - **Ecosystem foundation**: Powers thread_system, network_system, database_system, and more
 
 > **Latest Updates**: Complete separation from individual modules, comprehensive Result<T> pattern implementation, IExecutor interface standardization with ABI version checking, unified `kcenon::common` namespace, event bus integration tests, and enhanced documentation structure.
@@ -131,6 +132,29 @@ cd common_system
 ./scripts/build.sh --release --install-prefix=/usr/local
 sudo cmake --build build --target install
 ```
+
+#### Option 5: C++20 Modules (Experimental)
+
+```bash
+# Build with C++20 module support (requires CMake 3.28+, Ninja, Clang 16+/GCC 14+)
+cmake -G Ninja -B build -DCOMMON_BUILD_MODULES=ON
+cmake --build build
+```
+
+```cpp
+// Using modules instead of headers
+import kcenon.common;
+
+int main() {
+    auto result = kcenon::common::ok(42);
+    if (result.is_ok()) {
+        std::cout << result.value() << std::endl;
+    }
+    return 0;
+}
+```
+
+> **Note**: Module support requires Ninja generator and a C++20-capable compiler with module support (Clang 16+, GCC 14+, MSVC 2022 17.4+). AppleClang does not fully support modules yet.
 
 ### Building from Source
 
@@ -433,6 +457,7 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guid
 - [x] C++20 source_location integration
 - [x] C++20 Concepts for type validation
 - [x] Package manager support (Conan)
+- [x] C++20 Module files for faster compilation (experimental)
 
 **Planned:**
 - [ ] Coroutine support for async patterns

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -113,8 +113,25 @@ common_system/
 │               └── ...
 │
 ├── src/                        # Source files (minimal - header-only)
-│   └── config/                # Configuration implementation
-│       └── build_config.cpp   # Build configuration (if needed)
+│   ├── config/                # Configuration implementation
+│   │   └── build_config.cpp   # Build configuration (if needed)
+│   │
+│   └── modules/               # C++20 Module files (experimental)
+│       ├── common.cppm        # Primary module interface
+│       ├── utils.cppm         # Utility partition
+│       ├── error.cppm         # Error codes partition
+│       ├── result.cppm        # Result<T> aggregator
+│       │   └── result/
+│       │       ├── core.cppm
+│       │       └── utilities.cppm
+│       ├── concepts.cppm      # C++20 concepts partition
+│       ├── interfaces.cppm    # Interfaces aggregator
+│       │   └── interfaces/
+│       │       └── core.cppm
+│       ├── config.cppm        # Configuration partition
+│       ├── di.cppm            # Dependency injection partition
+│       ├── patterns.cppm      # Design patterns partition
+│       └── logging.cppm       # Logging utilities partition
 │
 ├── tests/                      # Test suite
 │   ├── unit/                  # Unit tests
@@ -340,6 +357,43 @@ option(BUILD_WITH_MONITORING_SYSTEM "Enable monitoring_system integration" OFF)
 # Feature flags
 option(COMMON_ENABLE_CPP20 "Enable C++20 features" OFF)
 option(COMMON_ENABLE_COROUTINES "Enable coroutine support" OFF)
+
+# C++20 Module support (experimental)
+option(COMMON_BUILD_MODULES "Build C++20 module version" OFF)
+```
+
+### C++20 Module Support
+
+**Experimental Feature**: C++20 modules provide an alternative to header-only usage with potentially faster compilation.
+
+**Requirements:**
+- CMake 3.28+
+- Ninja generator
+- Clang 16+, GCC 14+, or MSVC 2022 17.4+
+
+**Module Structure:**
+
+```
+kcenon.common                    # Primary module
+├── :utils                       # Tier 1: CircularBuffer, ObjectPool
+├── :error                       # Tier 1: Error codes
+├── :result                      # Tier 2: Result<T>, error_info
+│   ├── :result.core
+│   └── :result.utilities
+├── :concepts                    # Tier 2: C++20 concepts
+├── :interfaces                  # Tier 3: IExecutor, ILogger, etc.
+│   └── :interfaces.core
+├── :config                      # Tier 3: Configuration
+├── :di                          # Tier 3: Dependency injection
+├── :patterns                    # Tier 4: EventBus
+└── :logging                     # Tier 4: Logging utilities
+```
+
+**Building with Modules:**
+
+```bash
+cmake -G Ninja -B build -DCOMMON_BUILD_MODULES=ON
+cmake --build build
 ```
 
 ### CMake Modules
@@ -361,6 +415,9 @@ option(COMMON_ENABLE_COROUTINES "Enable coroutine support" OFF)
 ```bash
 # Main library target (interface library)
 kcenon::common
+
+# C++20 Module target (when COMMON_BUILD_MODULES=ON)
+kcenon::common_modules
 
 # Test targets
 common_tests           # Unit tests
@@ -682,5 +739,5 @@ After `cmake --install`, the following files are installed:
 
 ---
 
-**Last Updated**: 2024-11-15
-**Version**: 1.0
+**Last Updated**: 2025-01-03
+**Version**: 1.1


### PR DESCRIPTION
## Summary
- Add C++20 module support documentation to README.md and PROJECT_STRUCTURE.md
- Document module build configuration, structure, and usage examples

## Changes
- **README.md**:
  - Add C++20 module support mention in highlights
  - Add installation option 5 for C++20 modules with usage example
  - Update roadmap to mark module files as completed

- **docs/PROJECT_STRUCTURE.md**:
  - Add `src/modules/` directory structure documentation
  - Document module build configuration options
  - Add module structure and tier hierarchy documentation
  - Add `kcenon::common_modules` target to available targets list

## Test plan
- [x] All 108 existing tests pass
- [x] Documentation builds correctly
- [ ] Module build tested on CI (requires Ninja + Clang 16+/GCC 14+)

Closes #269