### PR TITLE
build(cmake): add compiler and generator validation for C++20 modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,16 @@ if(COMMON_BUILD_MODULES)
     if(CMAKE_VERSION VERSION_LESS "3.28")
         message(WARNING "C++20 modules require CMake 3.28+. Disabling module build.")
         set(COMMON_BUILD_MODULES OFF)
+    # Check for AppleClang (does not support module dependency scanning)
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+        message(WARNING "AppleClang does not support C++20 module dependency scanning. "
+                        "Use Clang 16+, GCC 14+, or MSVC 2022. Disabling module build.")
+        set(COMMON_BUILD_MODULES OFF)
+    # Check generator (modules require Ninja or Visual Studio 17.4+)
+    elseif(NOT CMAKE_GENERATOR MATCHES "Ninja" AND NOT CMAKE_GENERATOR MATCHES "Visual Studio")
+        message(WARNING "C++20 modules require Ninja or Visual Studio generator. "
+                        "Current generator: ${CMAKE_GENERATOR}. Disabling module build.")
+        set(COMMON_BUILD_MODULES OFF)
     else()
         message(STATUS "C++20 module build enabled")
 


### PR DESCRIPTION
## Summary
- Add AppleClang detection to disable module build (lacks dependency scanning support)
- Add CMake generator validation (requires Ninja or Visual Studio)
- Provide clear warning messages for unsupported configurations

## Test Results
✅ All 109 tests passed with header-only build
⚠️ AppleClang module limitation documented and handled gracefully

## Test Plan
- [x] Verify header-only build works (backward compatibility)
- [x] Verify module build with AppleClang shows appropriate warning
- [x] Verify all unit and integration tests pass
- [x] Document compiler compatibility in issue

## Related Issues
Closes #277

Part of Phase 3 (C++20 Module Stabilization) from #275