### PR TITLE
docs(modules): complete C++20 module documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ cd common_system
 sudo cmake --build build --target install
 ```
 
-#### Option 5: C++20 Modules (Experimental)
+#### Option 5: C++20 Modules
 
 ```bash
 # Build with C++20 module support (requires CMake 3.28+, Ninja, Clang 16+/GCC 14+)
@@ -155,7 +155,7 @@ int main() {
 }
 ```
 
-> **Note**: Module support requires Ninja generator and a C++20-capable compiler with module support (Clang 16+, GCC 14+, MSVC 2022 17.4+). AppleClang does not fully support modules yet.
+> **Note**: Module support requires Ninja generator and a C++20-capable compiler with module support (Clang 16+, GCC 14+, MSVC 2022 17.4+). AppleClang does not fully support modules yet. See [Module Migration Guide](docs/guides/MODULE_MIGRATION.md) for detailed instructions.
 
 ### Building from Source
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -18,6 +18,7 @@ Common System Project는 모듈식, 느슨하게 결합된 시스템 아키텍�
 - **Header-only 설계**: 라이브러리 링킹 불필요, 의존성 없음, 즉시 통합
 - **충분한 테스트**: 80%+ 테스트 커버리지, 제로 sanitizer 경고, 완전한 CI/CD
 - **범용 호환성**: C++20 표준, 현대적 언어 기능 지원
+- **C++20 모듈 지원**: 더 빠른 컴파일을 위한 선택적 모듈 기반 빌드
 - **생태계 기반**: thread_system, network_system, database_system 등을 지원
 
 > **최신 업데이트**: 개별 모듈과의 완전한 분리, 포괄적인 Result<T> 패턴 구현, ABI 버전 검사를 포함한 IExecutor 인터페이스 표준화, 통합된 `kcenon::common` 네임스페이스, 이벤트 버스 통합 테스트, 향상된 문서 구조
@@ -117,6 +118,29 @@ cd common_system
 ./scripts/build.sh --release --install-prefix=/usr/local
 sudo cmake --build build --target install
 ```
+
+#### 옵션 4: C++20 모듈
+
+```bash
+# C++20 모듈 지원으로 빌드 (CMake 3.28+, Ninja, Clang 16+/GCC 14+ 필요)
+cmake -G Ninja -B build -DCOMMON_BUILD_MODULES=ON
+cmake --build build
+```
+
+```cpp
+// 헤더 대신 모듈 사용
+import kcenon.common;
+
+int main() {
+    auto result = kcenon::common::ok(42);
+    if (result.is_ok()) {
+        std::cout << result.value() << std::endl;
+    }
+    return 0;
+}
+```
+
+> **참고**: 모듈 지원은 Ninja 생성기와 모듈을 지원하는 C++20 호환 컴파일러가 필요합니다 (Clang 16+, GCC 14+, MSVC 2022 17.4+). AppleClang은 아직 모듈을 완전히 지원하지 않습니다. 자세한 내용은 [모듈 마이그레이션 가이드](docs/guides/MODULE_MIGRATION_KO.md)를 참조하세요.
 
 ### 소스에서 빌드
 
@@ -412,6 +436,8 @@ void setup_network(std::shared_ptr<common::interfaces::IExecutor> executor) {
 - [x] C++20 source_location 통합
 - [x] C++20 Concepts 타입 검증
 - [x] 패키지 관리자 지원 (Conan)
+- [x] C++20 모듈 파일을 통한 빠른 컴파일
+- [x] 의존성 그래프 및 복구 핸들러를 포함한 상태 모니터링 시스템
 
 **계획:**
 - [ ] 비동기 패턴을 위한 Coroutine 지원

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -416,8 +416,101 @@ All systems follow Semantic Versioning (SemVer):
 
 Current versions aligned to **v1.0.0** baseline (2025-10-03).
 
+## C++20 Module Architecture
+
+### Module Overview
+
+C++20 modules provide an alternative to the header-only build with significant compilation speed improvements.
+
+```
+kcenon.common (Main Module)
+├── :utils       ─── Tier 1: CircularBuffer, ObjectPool, source_location
+├── :error       ─── Tier 1: Error codes and categories
+├── :result      ─── Tier 2: Result<T> pattern implementation
+├── :concepts    ─── Tier 2: C++20 concepts for type validation
+├── :interfaces  ─── Tier 3: IExecutor, ILogger, IThreadPool interfaces
+├── :config      ─── Tier 3: Configuration utilities
+├── :di          ─── Tier 3: Dependency injection
+├── :patterns    ─── Tier 4: EventBus implementation
+└── :logging     ─── Tier 4: Logging utilities
+```
+
+### Module Build Dependencies
+
+```mermaid
+graph TD
+    subgraph "Tier 0 - Foundation"
+        common[kcenon.common]
+    end
+
+    subgraph "Tier 1 - Core"
+        thread[kcenon.thread]
+        container[kcenon.container]
+    end
+
+    subgraph "Tier 2 - Logging"
+        logger[kcenon.logger]
+    end
+
+    subgraph "Tier 3 - Services"
+        database[kcenon.database]
+        monitoring[kcenon.monitoring]
+    end
+
+    subgraph "Tier 4 - Network"
+        network[kcenon.network]
+    end
+
+    subgraph "Tier 5 - Application"
+        messaging[kcenon.messaging]
+    end
+
+    common --> thread
+    common --> container
+    thread --> logger
+    container --> logger
+    logger --> database
+    logger --> monitoring
+    monitoring --> network
+    database --> network
+    network --> messaging
+
+    style common fill:#e1f5ff
+    style thread fill:#fff4e1
+    style container fill:#fff4e1
+    style logger fill:#e8f5e9
+    style database fill:#e8f5e9
+    style monitoring fill:#e8f5e9
+    style network fill:#f3e5f5
+    style messaging fill:#fce4ec
+```
+
+### Build Configuration
+
+```cmake
+# Enable module build
+cmake -G Ninja -B build \
+    -DCOMMON_BUILD_MODULES=ON \
+    -DCMAKE_CXX_COMPILER=clang++
+
+# Use module target in your project
+target_link_libraries(your_app PRIVATE kcenon::common_modules)
+```
+
+### Compiler Support
+
+| Compiler | Minimum Version | Status |
+|----------|-----------------|--------|
+| Clang | 16.0 | ✅ Supported |
+| GCC | 14.0 | ✅ Supported |
+| MSVC | 17.4 (2022) | ✅ Supported |
+| AppleClang | - | ❌ Not supported |
+
+For detailed migration instructions, see the [Module Migration Guide](guides/MODULE_MIGRATION.md).
+
 ## References
 
 - [INTEGRATION_POLICY.md](./INTEGRATION_POLICY.md) - Integration policy
 - [INTEGRATION.md](./INTEGRATION.md) - Integration examples
 - [NEED_TO_FIX.md](./NEED_TO_FIX.md) - Improvement tracking
+- [Module Migration Guide](guides/MODULE_MIGRATION.md) - C++20 module migration


### PR DESCRIPTION
## Summary
- Remove experimental tag from README.md C++20 module section
- Add Module Migration Guide reference to README.md
- Add complete C++20 module section to README_KO.md (was missing)
- Add module highlights and roadmap completion items to README_KO.md
- Add C++20 Module Architecture section with module structure and dependency graph to ARCHITECTURE.md
- Add C++20 Module Architecture section to ARCHITECTURE_KO.md

## Related Issue
Completes #278

## Test plan
- [x] Verify documentation renders correctly on GitHub
- [x] Check all links to MODULE_MIGRATION.md work
- [x] Confirm no experimental tags remain for C++20 modules