### PR TITLE
test(modules): add module verification test infrastructure

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -410,6 +410,63 @@ set_tests_properties(common_health_monitoring_test PROPERTIES
     LABELS "unit;interfaces;monitoring;health"
 )
 
+# =============================================================================
+# Module Verification Tests (Issue #277)
+# =============================================================================
+# These tests verify C++20 module functionality when modules are enabled.
+# The same test file runs in both header-only and module modes to ensure
+# API compatibility.
+# =============================================================================
+
+# Header-only mode verification test (always built)
+add_executable(common_module_verification_test
+    module_verification_test.cpp
+)
+
+target_link_libraries(common_module_verification_test PRIVATE
+    kcenon::common
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+target_compile_features(common_module_verification_test PRIVATE cxx_std_20)
+
+add_test(NAME common_module_verification_test COMMAND common_module_verification_test)
+
+set_tests_properties(common_module_verification_test PROPERTIES
+    TIMEOUT 60
+    LABELS "unit;module"
+)
+
+# Module mode verification test (only when COMMON_BUILD_MODULES is ON)
+if(COMMON_BUILD_MODULES AND TARGET common_system_modules)
+    add_executable(common_module_mode_test
+        module_verification_test.cpp
+    )
+
+    target_link_libraries(common_module_mode_test PRIVATE
+        kcenon::common_modules
+        GTest::gtest
+        GTest::gtest_main
+        Threads::Threads
+    )
+
+    target_compile_features(common_module_mode_test PRIVATE cxx_std_20)
+
+    # Define KCENON_USE_MODULES to switch to module imports
+    target_compile_definitions(common_module_mode_test PRIVATE KCENON_USE_MODULES=1)
+
+    add_test(NAME common_module_mode_test COMMAND common_module_mode_test)
+
+    set_tests_properties(common_module_mode_test PROPERTIES
+        TIMEOUT 60
+        LABELS "unit;module;cpp20"
+    )
+
+    message(STATUS "Module verification test (module mode): enabled")
+endif()
+
 # ABI version tests (Sprint 2 - Task 2.4)
 # Note: These tests require the static library build to test link-time checks
 if(NOT COMMON_HEADER_ONLY AND TARGET common_system_static)
@@ -475,6 +532,7 @@ set(COMMON_TEST_TARGETS
     common_metric_collector_interface_test
     common_concepts_test
     common_health_monitoring_test
+    common_module_verification_test
 )
 
 # Apply warning flags to all test targets
@@ -487,4 +545,9 @@ endforeach()
 # Apply to ABI version test if it exists
 if(TARGET common_abi_version_test)
     target_compile_options(common_abi_version_test PRIVATE ${COMMON_WARNING_FLAGS})
+endif()
+
+# Apply to module mode test if it exists
+if(TARGET common_module_mode_test)
+    target_compile_options(common_module_mode_test PRIVATE ${COMMON_WARNING_FLAGS})
 endif()

--- a/tests/module_verification_test.cpp
+++ b/tests/module_verification_test.cpp
@@ -1,0 +1,206 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file module_verification_test.cpp
+ * @brief Tests for C++20 module functionality verification.
+ *
+ * This file tests that C++20 modules work correctly when enabled.
+ * Tests are conditional on KCENON_USE_MODULES being defined.
+ *
+ * Part of Phase 3 (C++20 Module Stabilization) from Issue #275.
+ * Sub-issue: #277 - Test verification with module builds.
+ */
+
+#ifdef KCENON_USE_MODULES
+import kcenon.common;
+#else
+// Header-only fallback for comparison testing
+#include <kcenon/common/patterns/result.h>
+#include <kcenon/common/patterns/event_bus.h>
+#include <kcenon/common/di/service_container.h>
+#include <kcenon/common/config/unified_config.h>
+#endif
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+using namespace kcenon::common;
+
+namespace {
+
+// =============================================================================
+// Result Module Tests (Using member method API - RECOMMENDED)
+// =============================================================================
+
+class module_result_test : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(module_result_test, OkResultWorks) {
+    auto result = Result<int>::ok(42);
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_FALSE(result.is_err());
+    EXPECT_EQ(result.unwrap(), 42);
+}
+
+TEST_F(module_result_test, ErrorResultWorks) {
+    auto result = Result<int>::err(-1, "test error", "test_module");
+    EXPECT_FALSE(result.is_ok());
+    EXPECT_TRUE(result.is_err());
+
+    const auto& err = result.error();
+    EXPECT_EQ(err.code, -1);
+    EXPECT_EQ(err.message, "test error");
+    EXPECT_EQ(err.module, "test_module");
+}
+
+TEST_F(module_result_test, MapTransformation) {
+    auto result = Result<int>::ok(10);
+    auto mapped = result.map([](int x) { return x * 2; });
+    EXPECT_TRUE(mapped.is_ok());
+    EXPECT_EQ(mapped.unwrap(), 20);
+}
+
+TEST_F(module_result_test, AndThenChaining) {
+    auto result = Result<int>::ok(5);
+    auto chained = result.and_then([](int x) {
+        return Result<std::string>::ok(std::to_string(x));
+    });
+    EXPECT_TRUE(chained.is_ok());
+    EXPECT_EQ(chained.unwrap(), "5");
+}
+
+TEST_F(module_result_test, ValueOrDefault) {
+    auto success = Result<int>::ok(10);
+    auto failure = Result<int>::err(-1, "Error");
+
+    EXPECT_EQ(success.value_or(0), 10);
+    EXPECT_EQ(failure.value_or(0), 0);
+}
+
+// =============================================================================
+// Event Bus Module Tests
+// =============================================================================
+
+class module_event_bus_test : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+struct test_module_event {
+    int id;
+    std::string message;
+};
+
+TEST_F(module_event_bus_test, PublishAndSubscribe) {
+    simple_event_bus bus;
+    std::atomic<int> received_value{0};
+
+    auto token = bus.subscribe<test_module_event>(
+        [&received_value](const test_module_event& evt) {
+            received_value = evt.id;
+        });
+
+    bus.start();
+    bus.publish(test_module_event{42, "test"});
+
+    // Wait for event to be processed
+    auto start = std::chrono::steady_clock::now();
+    while (received_value == 0 &&
+           std::chrono::steady_clock::now() - start < std::chrono::seconds(1)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    EXPECT_EQ(received_value, 42);
+
+    bus.unsubscribe(token);
+    bus.stop();
+}
+
+// =============================================================================
+// Service Container Module Tests
+// =============================================================================
+
+class module_service_container_test : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+class i_module_test_service {
+public:
+    i_module_test_service() = default;
+    virtual ~i_module_test_service() = default;
+    i_module_test_service(const i_module_test_service&) = default;
+    i_module_test_service& operator=(const i_module_test_service&) = default;
+    i_module_test_service(i_module_test_service&&) = default;
+    i_module_test_service& operator=(i_module_test_service&&) = default;
+
+    virtual int get_value() const = 0;
+};
+
+class module_test_service_impl : public i_module_test_service {
+public:
+    int get_value() const override { return 42; }
+};
+
+TEST_F(module_service_container_test, RegisterAndResolve) {
+    di::service_container container;
+
+    auto result = container.register_type<i_module_test_service, module_test_service_impl>(
+        di::service_lifetime::singleton);
+    EXPECT_TRUE(result.is_ok());
+
+    auto resolve_result = container.resolve<i_module_test_service>();
+    ASSERT_TRUE(resolve_result.is_ok());
+
+    const auto& service = resolve_result.value();
+    ASSERT_NE(service, nullptr);
+    EXPECT_EQ(service->get_value(), 42);
+}
+
+// =============================================================================
+// Module Version Test (Only available with module build)
+// =============================================================================
+
+#ifdef KCENON_USE_MODULES
+TEST(module_version_test, VersionInfoAvailable) {
+    EXPECT_EQ(module_version::major, 0);
+    EXPECT_EQ(module_version::minor, 2);
+    EXPECT_EQ(module_version::patch, 0);
+    EXPECT_STREQ(module_version::string, "0.2.0.0");
+    EXPECT_STREQ(module_version::module_name, "kcenon.common");
+}
+#endif
+
+// =============================================================================
+// Module Build Verification
+// =============================================================================
+
+TEST(module_build_verification_test, ModuleModeDetection) {
+#ifdef KCENON_USE_MODULES
+    // Module build is active - this test verifies module imports work
+    SUCCEED() << "Module build is active";
+#else
+    // Header-only build is active - this test verifies header includes work
+    SUCCEED() << "Header-only build is active";
+#endif
+}
+
+TEST(module_build_verification_test, CoreTypesAccessible) {
+    // Verify core types are accessible regardless of build mode
+    auto result = Result<int>::ok(100);
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(result.unwrap(), 100);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Add test infrastructure for C++20 module build verification as part of Phase 3 Module Stabilization (Issue #275).

**Changes:**
- Add `module_verification_test.cpp` with comprehensive tests for:
  - Result<T> pattern (ok, err, map, and_then, value_or)
  - EventBus (publish/subscribe operations)
  - ServiceContainer (registration and resolution)
  - Module version info (when modules enabled)
- Update `tests/CMakeLists.txt` with conditional module test support
- Same test file runs in both header-only and module modes

## Test Results

**Header-only mode:** 18/18 tests passed

The module verification test (`common_module_verification_test`) validates API compatibility between header-only and module builds.

## Related Issues

- Closes #277
- Part of #275 (Phase 3: C++20 Module Stabilization)
- Parent EPIC: #256

## Test Plan

- [x] Verify all unit tests pass with header-only build
- [x] Verify module verification test compiles and runs
- [x] Test infrastructure ready for module mode (requires Clang 16+, GCC 14+, or MSVC 2022)
- [ ] CI verification (AppleClang will skip module tests)

## Notes

- AppleClang does not support C++20 module dependency scanning, so module mode tests require different compilers
- The test file uses conditional compilation (`#ifdef KCENON_USE_MODULES`) to switch between header includes and module imports