### PR TITLE
refactor(logging): remove deprecated THREAD_LOG_* macros

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -626,18 +626,6 @@ LOG_IS_ENABLED(level)                // Check if level is enabled
 LOG_IS_ENABLED_FOR(level, logger_name)
 ```
 
-#### Legacy Compatibility
-
-```cpp
-// These macros redirect to LOG_* equivalents (deprecated)
-THREAD_LOG_TRACE(msg)
-THREAD_LOG_DEBUG(msg)
-THREAD_LOG_INFO(msg)
-THREAD_LOG_WARNING(msg)
-THREAD_LOG_ERROR(msg)
-THREAD_LOG_CRITICAL(msg)
-```
-
 #### Compile-Time Level Filtering
 
 Define `KCENON_MIN_LOG_LEVEL` before including the header to disable lower log levels at compile time:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Removed
+- **Deprecated THREAD_LOG_* macros** (#289)
+  - Removed deprecated logging macros that were scheduled for removal in v3.0.0:
+    - `THREAD_LOG_TRACE(msg)` → Use `LOG_TRACE(msg)` instead
+    - `THREAD_LOG_DEBUG(msg)` → Use `LOG_DEBUG(msg)` instead
+    - `THREAD_LOG_INFO(msg)` → Use `LOG_INFO(msg)` instead
+    - `THREAD_LOG_WARNING(msg)` → Use `LOG_WARNING(msg)` instead
+    - `THREAD_LOG_ERROR(msg)` → Use `LOG_ERROR(msg)` instead
+    - `THREAD_LOG_CRITICAL(msg)` → Use `LOG_CRITICAL(msg)` instead
+  - **BREAKING CHANGE**: Migrate to `LOG_*` macros before upgrading
+  - See `docs/DEPRECATION.md` for migration instructions
+
 - **Deprecated Result<T> free functions** (#288)
   - Removed deprecated free functions that were replaced by member methods:
     - `is_ok(result)` → Use `result.is_ok()` instead

--- a/docs/CHANGELOG_KO.md
+++ b/docs/CHANGELOG_KO.md
@@ -11,6 +11,18 @@ Common System 프로젝트의 모든 주요 변경 사항이 이 파일에 문�
 
 ## [Unreleased]
 
+### Removed
+- **Deprecated THREAD_LOG_* 매크로 제거** (#289)
+  - v3.0.0에서 제거 예정이었던 deprecated 로깅 매크로 제거:
+    - `THREAD_LOG_TRACE(msg)` → `LOG_TRACE(msg)` 사용
+    - `THREAD_LOG_DEBUG(msg)` → `LOG_DEBUG(msg)` 사용
+    - `THREAD_LOG_INFO(msg)` → `LOG_INFO(msg)` 사용
+    - `THREAD_LOG_WARNING(msg)` → `LOG_WARNING(msg)` 사용
+    - `THREAD_LOG_ERROR(msg)` → `LOG_ERROR(msg)` 사용
+    - `THREAD_LOG_CRITICAL(msg)` → `LOG_CRITICAL(msg)` 사용
+  - **BREAKING CHANGE**: 업그레이드 전 `LOG_*` 매크로로 마이그레이션 필요
+  - 마이그레이션 방법은 `docs/DEPRECATION_KO.md` 참조
+
 ### Breaking Changes
 - **ILogger 인터페이스에서 deprecated file/line/function log() 메서드 제거** (#217)
   - 제거됨: `virtual VoidResult log(log_level, const std::string&, const std::string& file, int line, const std::string& function)`

--- a/docs/DEPRECATION.md
+++ b/docs/DEPRECATION.md
@@ -363,19 +363,18 @@ if (result.is_uninitialized()) { ... }
 if (!result.is_ok()) { ... }
 ```
 
-### 2. THREAD_LOG_* Macros (Re-added as Deprecated)
+### 2. THREAD_LOG_* Macros (Removed)
 
-**Status:** Re-added in v2.x for backward compatibility, deprecated, removal planned for v3.0.0
+**Status:** ~~Removed in v3.0.0~~
 
-**Note:** These macros were removed in v2.0.0 but have been re-added to ease migration.
-They now redirect to the standard LOG_* macros but are marked as deprecated.
+**Note:** These macros have been permanently removed. All code must use the standard LOG_* macros.
 
 **Migration:**
 ```cpp
-// Before (deprecated)
-THREAD_LOG_INFO("Message");
+// Before (no longer available)
+// THREAD_LOG_INFO("Message");
 
-// After (recommended)
+// After (required)
 LOG_INFO("Message");
 ```
 

--- a/docs/DEPRECATION_KO.md
+++ b/docs/DEPRECATION_KO.md
@@ -152,19 +152,18 @@ if (result.is_uninitialized()) { ... }
 if (!result.is_ok()) { ... }
 ```
 
-### 2. THREAD_LOG_* 매크로 (Deprecated로 재추가됨)
+### 2. THREAD_LOG_* 매크로 (제거됨)
 
-**상태:** v2.x에서 하위 호환성을 위해 재추가됨, deprecated, v3.0.0에서 제거 예정
+**상태:** ~~v3.0.0에서 제거됨~~
 
-**참고:** 이 매크로들은 v2.0.0에서 제거되었지만 마이그레이션을 돕기 위해 재추가되었습니다.
-현재 표준 LOG_* 매크로로 리디렉션되지만 deprecated로 표시되어 있습니다.
+**참고:** 이 매크로들은 영구적으로 제거되었습니다. 모든 코드는 표준 LOG_* 매크로를 사용해야 합니다.
 
 **마이그레이션:**
 ```cpp
-// Before (deprecated)
-THREAD_LOG_INFO("메시지");
+// Before (더 이상 사용 불가)
+// THREAD_LOG_INFO("메시지");
 
-// After (권장)
+// After (필수)
 LOG_INFO("메시지");
 ```
 

--- a/docs/guides/TROUBLESHOOTING_LOGGING.md
+++ b/docs/guides/TROUBLESHOOTING_LOGGING.md
@@ -165,7 +165,6 @@ message(STATUS "Linked libraries: ${LINKED_LIBS}")
 **Symptoms:**
 ```
 warning: 'log_level' is deprecated: Use kcenon::common::interfaces::log_level
-warning: 'THREAD_LOG_INFO' is deprecated: Use LOG_INFO
 ```
 
 **Cause:** Using legacy compatibility aliases.
@@ -177,8 +176,9 @@ Update code to use new types and macros:
 | Old | New |
 |-----|-----|
 | `kcenon::logger::log_level` | `kcenon::common::interfaces::log_level` |
-| `THREAD_LOG_INFO(msg)` | `LOG_INFO(msg)` |
 | `logger_interface` | `ILogger` |
+
+> **Note:** `THREAD_LOG_*` macros have been removed in v3.0.0. Use `LOG_*` macros instead.
 
 See [Migration Guide](MIGRATION_RUNTIME_BINDING.md) for complete mapping.
 

--- a/include/kcenon/common/logging/log_macros.h
+++ b/include/kcenon/common/logging/log_macros.h
@@ -13,7 +13,6 @@
  * The macros support:
  * - Standard LOG_* macros for each log level
  * - Conditional logging based on log level
- * - Legacy THREAD_LOG_* compatibility (redirects to LOG_*)
  *
  * Thread Safety:
  * - All macros are thread-safe as they delegate to thread-safe functions.
@@ -26,14 +25,9 @@
  *
  * // Conditional logging (avoids message construction when disabled)
  * LOG_IF(log_level::debug, expensive_to_string(data));
- *
- * // Legacy macros (deprecated, prefer LOG_* versions)
- * THREAD_LOG_INFO("Still works for compatibility");
  * @endcode
  *
  * @note Prefer using LOG_* macros over direct function calls for consistency.
- * @note Legacy THREAD_LOG_* macros are provided for backward compatibility
- *       but are marked as deprecated.
  *
  * @see Issue #175 for implementation requirements.
  * @see log_functions.h for the underlying function implementations.
@@ -234,52 +228,6 @@
     ::kcenon::common::logging::is_enabled(level, logger_name)
 
 // =============================================================================
-// Legacy THREAD_LOG_* Macros (Deprecated)
-// =============================================================================
-//
-// These macros are provided for backward compatibility with thread_system code.
-// New code should use the LOG_* macros instead.
-//
-// @deprecated Use LOG_* macros instead. Will be removed in v3.0.0.
-// @see docs/DEPRECATION.md for migration guide.
-
-/**
- * @def THREAD_LOG_TRACE(msg)
- * @deprecated Use LOG_TRACE(msg) instead. Will be removed in v3.0.0.
- */
-#define THREAD_LOG_TRACE(msg) LOG_TRACE(msg)
-
-/**
- * @def THREAD_LOG_DEBUG(msg)
- * @deprecated Use LOG_DEBUG(msg) instead. Will be removed in v3.0.0.
- */
-#define THREAD_LOG_DEBUG(msg) LOG_DEBUG(msg)
-
-/**
- * @def THREAD_LOG_INFO(msg)
- * @deprecated Use LOG_INFO(msg) instead. Will be removed in v3.0.0.
- */
-#define THREAD_LOG_INFO(msg) LOG_INFO(msg)
-
-/**
- * @def THREAD_LOG_WARNING(msg)
- * @deprecated Use LOG_WARNING(msg) instead. Will be removed in v3.0.0.
- */
-#define THREAD_LOG_WARNING(msg) LOG_WARNING(msg)
-
-/**
- * @def THREAD_LOG_ERROR(msg)
- * @deprecated Use LOG_ERROR(msg) instead. Will be removed in v3.0.0.
- */
-#define THREAD_LOG_ERROR(msg) LOG_ERROR(msg)
-
-/**
- * @def THREAD_LOG_CRITICAL(msg)
- * @deprecated Use LOG_CRITICAL(msg) instead. Will be removed in v3.0.0.
- */
-#define THREAD_LOG_CRITICAL(msg) LOG_CRITICAL(msg)
-
-// =============================================================================
 // Compile-time Log Level Control (Optional)
 // =============================================================================
 
@@ -316,8 +264,6 @@
     #define LOG_TRACE(msg) ((void)0)
     #undef LOG_TRACE_TO
     #define LOG_TRACE_TO(logger_name, msg) ((void)0)
-    #undef THREAD_LOG_TRACE
-    #define THREAD_LOG_TRACE(msg) ((void)0)
 #endif
 
 #if KCENON_MIN_LOG_LEVEL > 1
@@ -325,8 +271,6 @@
     #define LOG_DEBUG(msg) ((void)0)
     #undef LOG_DEBUG_TO
     #define LOG_DEBUG_TO(logger_name, msg) ((void)0)
-    #undef THREAD_LOG_DEBUG
-    #define THREAD_LOG_DEBUG(msg) ((void)0)
 #endif
 
 #if KCENON_MIN_LOG_LEVEL > 2
@@ -334,8 +278,6 @@
     #define LOG_INFO(msg) ((void)0)
     #undef LOG_INFO_TO
     #define LOG_INFO_TO(logger_name, msg) ((void)0)
-    #undef THREAD_LOG_INFO
-    #define THREAD_LOG_INFO(msg) ((void)0)
 #endif
 
 #if KCENON_MIN_LOG_LEVEL > 3
@@ -343,8 +285,6 @@
     #define LOG_WARNING(msg) ((void)0)
     #undef LOG_WARNING_TO
     #define LOG_WARNING_TO(logger_name, msg) ((void)0)
-    #undef THREAD_LOG_WARNING
-    #define THREAD_LOG_WARNING(msg) ((void)0)
 #endif
 
 #if KCENON_MIN_LOG_LEVEL > 4
@@ -352,8 +292,6 @@
     #define LOG_ERROR(msg) ((void)0)
     #undef LOG_ERROR_TO
     #define LOG_ERROR_TO(logger_name, msg) ((void)0)
-    #undef THREAD_LOG_ERROR
-    #define THREAD_LOG_ERROR(msg) ((void)0)
 #endif
 
 #if KCENON_MIN_LOG_LEVEL > 5
@@ -361,6 +299,4 @@
     #define LOG_CRITICAL(msg) ((void)0)
     #undef LOG_CRITICAL_TO
     #define LOG_CRITICAL_TO(logger_name, msg) ((void)0)
-    #undef THREAD_LOG_CRITICAL
-    #define THREAD_LOG_CRITICAL(msg) ((void)0)
 #endif


### PR DESCRIPTION
## Summary
- Remove all deprecated `THREAD_LOG_*` logging macros that were scheduled for removal in v3.0.0
- Update documentation to reflect the removal

## Changes
### Removed
- `THREAD_LOG_TRACE`, `THREAD_LOG_DEBUG`, `THREAD_LOG_INFO`
- `THREAD_LOG_WARNING`, `THREAD_LOG_ERROR`, `THREAD_LOG_CRITICAL`
- Corresponding compile-time level filtering definitions in `KCENON_MIN_LOG_LEVEL` section

### Updated Documentation
- `DEPRECATION.md`, `DEPRECATION_KO.md`: Marked as removed
- `API_REFERENCE.md`: Removed legacy compatibility section
- `CHANGELOG.md`, `CHANGELOG_KO.md`: Added removal notice
- `TROUBLESHOOTING_LOGGING.md`: Updated deprecation warning examples

## Test Plan
- [x] Build succeeds (cmake --build)
- [x] All 110 tests pass (ctest)
- [x] No production code uses `THREAD_LOG_*` macros (grep verified)

## Migration
Users must migrate from `THREAD_LOG_*` to `LOG_*` macros:
```cpp
// Before (no longer available)
THREAD_LOG_INFO("message");

// After (required)
LOG_INFO("message");
```

**BREAKING CHANGE**: `THREAD_LOG_*` macros are no longer available.

Closes #289