### PR TITLE
feat(interfaces): add warn and fatal aliases to log_level enum

### DIFF
--- a/include/kcenon/common/interfaces/logger_interface.h
+++ b/include/kcenon/common/interfaces/logger_interface.h
@@ -31,14 +31,19 @@ namespace interfaces {
 /**
  * @enum log_level
  * @brief Standard log levels
+ *
+ * @note v3.0.0: Added 'warn' and 'fatal' as aliases for 'warning' and 'critical'
+ *       respectively, for backward compatibility with logger_system::log_level.
  */
 enum class log_level {
     trace = 0,
     debug = 1,
     info = 2,
     warning = 3,
+    warn = 3,       ///< Alias for warning (backward compatibility)
     error = 4,
     critical = 5,
+    fatal = 5,      ///< Alias for critical (backward compatibility)
     off = 6
 };
 


### PR DESCRIPTION
## Summary

- Add `warn` alias for `warning` (value 3)
- Add `fatal` alias for `critical` (value 5)

## Background

This change enables backward compatibility for logger_system migration from `logger_system::log_level` to `common::interfaces::log_level`. The legacy enum uses `warn`/`warning` and `fatal`/`critical` as interchangeable aliases.

## Test Plan

- [x] Build succeeded
- [x] All tests pass

## Related Issues

- kcenon/logger_system#340 - Part 1 of logger_system v3.0.0 migration