### PR TITLE
refactor(utils): extract generic enum serialization template

### DIFF
--- a/include/kcenon/common/interfaces/monitoring_interface.h
+++ b/include/kcenon/common/interfaces/monitoring_interface.h
@@ -13,14 +13,18 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 #include "../patterns/result.h"
+#include "../utils/enum_serialization.h"
 
 namespace kcenon::common {
 namespace interfaces {
@@ -36,33 +40,36 @@ enum class metric_type {
     summary     // Statistical summary (min, max, mean, percentiles)
 };
 
+}  // namespace interfaces
+
+/**
+ * @brief Specialization of enum_traits for metric_type
+ */
+template<>
+struct enum_traits<interfaces::metric_type> {
+    static constexpr auto values = std::array{
+        std::pair{interfaces::metric_type::gauge, std::string_view{"GAUGE"}},
+        std::pair{interfaces::metric_type::counter, std::string_view{"COUNTER"}},
+        std::pair{interfaces::metric_type::histogram, std::string_view{"HISTOGRAM"}},
+        std::pair{interfaces::metric_type::summary, std::string_view{"SUMMARY"}},
+    };
+    static constexpr std::string_view module_name = "monitoring_interface";
+};
+
+namespace interfaces {
+
 /**
  * @brief Convert metric type to string
  */
 inline std::string to_string(metric_type type) {
-    switch(type) {
-        case metric_type::gauge: return "GAUGE";
-        case metric_type::counter: return "COUNTER";
-        case metric_type::histogram: return "HISTOGRAM";
-        case metric_type::summary: return "SUMMARY";
-        default: return "UNKNOWN";
-    }
+    return enum_to_string(type);
 }
 
 /**
  * @brief Convert string to metric type
  */
 inline Result<metric_type> metric_type_from_string(const std::string& str) {
-    std::string upper = str;
-    std::transform(upper.begin(), upper.end(), upper.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
-
-    if (upper == "GAUGE") return ok(metric_type::gauge);
-    if (upper == "COUNTER") return ok(metric_type::counter);
-    if (upper == "HISTOGRAM") return ok(metric_type::histogram);
-    if (upper == "SUMMARY") return ok(metric_type::summary);
-
-    return Result<metric_type>(error_info{1, "Invalid metric type: " + str, "monitoring_interface"});
+    return enum_from_string<metric_type>(str);
 }
 
 /**
@@ -204,6 +211,24 @@ enum class health_status {
     unknown = 3
 };
 
+}  // namespace interfaces
+
+/**
+ * @brief Specialization of enum_traits for health_status
+ */
+template<>
+struct enum_traits<interfaces::health_status> {
+    static constexpr auto values = std::array{
+        std::pair{interfaces::health_status::healthy, std::string_view{"HEALTHY"}},
+        std::pair{interfaces::health_status::degraded, std::string_view{"DEGRADED"}},
+        std::pair{interfaces::health_status::unhealthy, std::string_view{"UNHEALTHY"}},
+        std::pair{interfaces::health_status::unknown, std::string_view{"UNKNOWN"}},
+    };
+    static constexpr std::string_view module_name = "monitoring_interface";
+};
+
+namespace interfaces {
+
 /**
  * @struct health_check_result
  * @brief Result of a health check operation
@@ -339,14 +364,8 @@ public:
  * @brief Convert health status to string
  */
 inline std::string to_string(health_status status) {
-    switch(status) {
-        case health_status::healthy: return "HEALTHY";
-        case health_status::degraded: return "DEGRADED";
-        case health_status::unhealthy: return "UNHEALTHY";
-        case health_status::unknown: return "UNKNOWN";
-        default: return "UNKNOWN";
-    }
+    return enum_to_string(status);
 }
 
-} // namespace interfaces
-} // namespace kcenon::common
+}  // namespace interfaces
+}  // namespace kcenon::common

--- a/include/kcenon/common/utils/enum_serialization.h
+++ b/include/kcenon/common/utils/enum_serialization.h
@@ -1,0 +1,110 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file enum_serialization.h
+ * @brief Generic enum serialization utilities using C++20 concepts.
+ *
+ * This header provides a type-safe, compile-time approach to enum
+ * serialization and deserialization. It eliminates duplicated switch/case
+ * patterns across multiple enum types.
+ *
+ * Usage:
+ * @code
+ * // 1. Define enum_traits specialization for your enum
+ * template<>
+ * struct enum_traits<my_enum> {
+ *     static constexpr auto values = std::array{
+ *         std::pair{my_enum::value1, std::string_view{"VALUE1"}},
+ *         std::pair{my_enum::value2, std::string_view{"VALUE2"}},
+ *     };
+ *     static constexpr std::string_view module_name = "my_module";
+ * };
+ *
+ * // 2. Use generic functions
+ * auto str = enum_to_string(my_enum::value1);  // "VALUE1"
+ * auto result = enum_from_string<my_enum>("VALUE1");  // Result<my_enum>
+ * @endcode
+ *
+ * @note Issue #293: Created to eliminate duplicated enum serialization patterns.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <span>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+#include "../patterns/result.h"
+
+namespace kcenon::common {
+
+/**
+ * @brief Primary template for enum traits (must be specialized for each enum)
+ *
+ * Specializations must provide:
+ * - static constexpr auto values: array of {enum_value, string_view} pairs
+ * - static constexpr std::string_view module_name: module name for error reporting
+ */
+template<typename Enum>
+struct enum_traits;
+
+/**
+ * @brief Concept to check if an enum has valid traits defined
+ */
+template<typename Enum>
+concept EnumSerializable = std::is_enum_v<Enum> && requires {
+    { enum_traits<Enum>::values } -> std::convertible_to<
+        std::span<const std::pair<Enum, std::string_view>>>;
+    { enum_traits<Enum>::module_name } -> std::convertible_to<std::string_view>;
+};
+
+/**
+ * @brief Convert an enum value to its string representation
+ *
+ * @tparam Enum The enum type (must satisfy EnumSerializable concept)
+ * @param value The enum value to convert
+ * @return String representation, or "UNKNOWN" if not found
+ */
+template<EnumSerializable Enum>
+[[nodiscard]] inline std::string enum_to_string(Enum value) {
+    for (const auto& [e, s] : enum_traits<Enum>::values) {
+        if (e == value) {
+            return std::string(s);
+        }
+    }
+    return "UNKNOWN";
+}
+
+/**
+ * @brief Convert a string to its enum value (case-insensitive)
+ *
+ * @tparam Enum The enum type (must satisfy EnumSerializable concept)
+ * @param str The string to convert
+ * @return Result containing the enum value or error
+ */
+template<EnumSerializable Enum>
+[[nodiscard]] inline Result<Enum> enum_from_string(std::string_view str) {
+    // Convert input to uppercase for case-insensitive comparison
+    std::string upper(str.size(), '\0');
+    std::transform(str.begin(), str.end(), upper.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+
+    for (const auto& [e, s] : enum_traits<Enum>::values) {
+        if (s == upper) {
+            return Result<Enum>::ok(e);
+        }
+    }
+
+    return Result<Enum>::err(
+        error_info{1, "Invalid enum value: " + std::string(str),
+                   std::string(enum_traits<Enum>::module_name)});
+}
+
+}  // namespace kcenon::common

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -466,6 +466,27 @@ if(COMMON_BUILD_MODULES AND TARGET common_system_modules)
     message(STATUS "Module verification test (module mode): enabled")
 endif()
 
+# Enum serialization tests (Issue #293)
+add_executable(common_enum_serialization_test
+    enum_serialization_test.cpp
+)
+
+target_link_libraries(common_enum_serialization_test PRIVATE
+    kcenon::common
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+target_compile_features(common_enum_serialization_test PRIVATE cxx_std_20)
+
+add_test(NAME common_enum_serialization_test COMMAND common_enum_serialization_test)
+
+set_tests_properties(common_enum_serialization_test PROPERTIES
+    TIMEOUT 60
+    LABELS "unit;utils;serialization"
+)
+
 # ABI version tests (Sprint 2 - Task 2.4)
 # Note: These tests require the static library build to test link-time checks
 if(NOT COMMON_HEADER_ONLY AND TARGET common_system_static)
@@ -532,6 +553,7 @@ set(COMMON_TEST_TARGETS
     common_concepts_test
     common_health_monitoring_test
     common_module_verification_test
+    common_enum_serialization_test
 )
 
 # Apply warning flags to all test targets

--- a/tests/enum_serialization_test.cpp
+++ b/tests/enum_serialization_test.cpp
@@ -1,0 +1,320 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file enum_serialization_test.cpp
+ * @brief Unit tests for generic enum serialization utilities
+ *
+ * Tests the enum_traits template and enum_to_string/enum_from_string functions
+ * for all supported enum types.
+ *
+ * @note Issue #293: Added tests for generic enum serialization template.
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/common/utils/enum_serialization.h>
+#include <kcenon/common/interfaces/logger_interface.h>
+#include <kcenon/common/interfaces/monitoring_interface.h>
+#include <kcenon/common/interfaces/monitoring/health_check.h>
+
+using namespace kcenon::common;
+using namespace kcenon::common::interfaces;
+
+// =============================================================================
+// EnumSerializable Concept Tests
+// =============================================================================
+
+static_assert(EnumSerializable<log_level>,
+              "log_level should satisfy EnumSerializable concept");
+static_assert(EnumSerializable<metric_type>,
+              "metric_type should satisfy EnumSerializable concept");
+static_assert(EnumSerializable<health_status>,
+              "health_status should satisfy EnumSerializable concept");
+static_assert(EnumSerializable<health_check_type>,
+              "health_check_type should satisfy EnumSerializable concept");
+
+// Negative test: regular enums without traits should not satisfy the concept
+enum class unregistered_enum { value1, value2 };
+static_assert(!EnumSerializable<unregistered_enum>,
+              "unregistered_enum should NOT satisfy EnumSerializable concept");
+
+// =============================================================================
+// log_level Serialization Tests
+// =============================================================================
+
+class LogLevelSerializationTest : public ::testing::Test {};
+
+TEST_F(LogLevelSerializationTest, ToStringConvertsAllValues) {
+    EXPECT_EQ(enum_to_string(log_level::trace), "TRACE");
+    EXPECT_EQ(enum_to_string(log_level::debug), "DEBUG");
+    EXPECT_EQ(enum_to_string(log_level::info), "INFO");
+    EXPECT_EQ(enum_to_string(log_level::warning), "WARNING");
+    EXPECT_EQ(enum_to_string(log_level::error), "ERROR");
+    EXPECT_EQ(enum_to_string(log_level::critical), "CRITICAL");
+    EXPECT_EQ(enum_to_string(log_level::off), "OFF");
+}
+
+TEST_F(LogLevelSerializationTest, ToStringHandlesAliases) {
+    // warn is an alias for warning (same numeric value)
+    EXPECT_EQ(enum_to_string(log_level::warn), "WARNING");
+    // fatal is an alias for critical (same numeric value)
+    EXPECT_EQ(enum_to_string(log_level::fatal), "CRITICAL");
+}
+
+TEST_F(LogLevelSerializationTest, FromStringParsesValidValues) {
+    auto trace_result = enum_from_string<log_level>("TRACE");
+    ASSERT_TRUE(trace_result.is_ok());
+    EXPECT_EQ(trace_result.value(), log_level::trace);
+
+    auto debug_result = enum_from_string<log_level>("DEBUG");
+    ASSERT_TRUE(debug_result.is_ok());
+    EXPECT_EQ(debug_result.value(), log_level::debug);
+
+    auto info_result = enum_from_string<log_level>("INFO");
+    ASSERT_TRUE(info_result.is_ok());
+    EXPECT_EQ(info_result.value(), log_level::info);
+
+    auto warning_result = enum_from_string<log_level>("WARNING");
+    ASSERT_TRUE(warning_result.is_ok());
+    EXPECT_EQ(warning_result.value(), log_level::warning);
+
+    auto error_result = enum_from_string<log_level>("ERROR");
+    ASSERT_TRUE(error_result.is_ok());
+    EXPECT_EQ(error_result.value(), log_level::error);
+
+    auto critical_result = enum_from_string<log_level>("CRITICAL");
+    ASSERT_TRUE(critical_result.is_ok());
+    EXPECT_EQ(critical_result.value(), log_level::critical);
+
+    auto off_result = enum_from_string<log_level>("OFF");
+    ASSERT_TRUE(off_result.is_ok());
+    EXPECT_EQ(off_result.value(), log_level::off);
+}
+
+TEST_F(LogLevelSerializationTest, FromStringIsCaseInsensitive) {
+    auto lower = enum_from_string<log_level>("debug");
+    ASSERT_TRUE(lower.is_ok());
+    EXPECT_EQ(lower.value(), log_level::debug);
+
+    auto mixed = enum_from_string<log_level>("DeBuG");
+    ASSERT_TRUE(mixed.is_ok());
+    EXPECT_EQ(mixed.value(), log_level::debug);
+}
+
+TEST_F(LogLevelSerializationTest, FromStringReturnsErrorForInvalidValues) {
+    auto result = enum_from_string<log_level>("INVALID");
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().module, "logger_interface");
+}
+
+TEST_F(LogLevelSerializationTest, LegacyToStringWorks) {
+    EXPECT_EQ(to_string(log_level::info), "INFO");
+    EXPECT_EQ(to_string(log_level::error), "ERROR");
+}
+
+TEST_F(LogLevelSerializationTest, LegacyFromStringWorks) {
+    EXPECT_EQ(from_string("INFO"), log_level::info);
+    EXPECT_EQ(from_string("ERROR"), log_level::error);
+    // Aliases should work
+    EXPECT_EQ(from_string("WARN"), log_level::warning);
+    EXPECT_EQ(from_string("FATAL"), log_level::critical);
+    // Invalid returns default (info)
+    EXPECT_EQ(from_string("INVALID"), log_level::info);
+}
+
+// =============================================================================
+// metric_type Serialization Tests
+// =============================================================================
+
+class MetricTypeSerializationTest : public ::testing::Test {};
+
+TEST_F(MetricTypeSerializationTest, ToStringConvertsAllValues) {
+    EXPECT_EQ(enum_to_string(metric_type::gauge), "GAUGE");
+    EXPECT_EQ(enum_to_string(metric_type::counter), "COUNTER");
+    EXPECT_EQ(enum_to_string(metric_type::histogram), "HISTOGRAM");
+    EXPECT_EQ(enum_to_string(metric_type::summary), "SUMMARY");
+}
+
+TEST_F(MetricTypeSerializationTest, FromStringParsesValidValues) {
+    auto gauge_result = enum_from_string<metric_type>("GAUGE");
+    ASSERT_TRUE(gauge_result.is_ok());
+    EXPECT_EQ(gauge_result.value(), metric_type::gauge);
+
+    auto counter_result = enum_from_string<metric_type>("COUNTER");
+    ASSERT_TRUE(counter_result.is_ok());
+    EXPECT_EQ(counter_result.value(), metric_type::counter);
+
+    auto histogram_result = enum_from_string<metric_type>("HISTOGRAM");
+    ASSERT_TRUE(histogram_result.is_ok());
+    EXPECT_EQ(histogram_result.value(), metric_type::histogram);
+
+    auto summary_result = enum_from_string<metric_type>("SUMMARY");
+    ASSERT_TRUE(summary_result.is_ok());
+    EXPECT_EQ(summary_result.value(), metric_type::summary);
+}
+
+TEST_F(MetricTypeSerializationTest, FromStringIsCaseInsensitive) {
+    auto lower = enum_from_string<metric_type>("gauge");
+    ASSERT_TRUE(lower.is_ok());
+    EXPECT_EQ(lower.value(), metric_type::gauge);
+}
+
+TEST_F(MetricTypeSerializationTest, FromStringReturnsErrorForInvalidValues) {
+    auto result = enum_from_string<metric_type>("INVALID");
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().module, "monitoring_interface");
+}
+
+TEST_F(MetricTypeSerializationTest, LegacyFunctionsWork) {
+    EXPECT_EQ(to_string(metric_type::gauge), "GAUGE");
+    auto result = metric_type_from_string("COUNTER");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value(), metric_type::counter);
+}
+
+// =============================================================================
+// health_status Serialization Tests
+// =============================================================================
+
+class HealthStatusSerializationTest : public ::testing::Test {};
+
+TEST_F(HealthStatusSerializationTest, ToStringConvertsAllValues) {
+    EXPECT_EQ(enum_to_string(health_status::healthy), "HEALTHY");
+    EXPECT_EQ(enum_to_string(health_status::degraded), "DEGRADED");
+    EXPECT_EQ(enum_to_string(health_status::unhealthy), "UNHEALTHY");
+    EXPECT_EQ(enum_to_string(health_status::unknown), "UNKNOWN");
+}
+
+TEST_F(HealthStatusSerializationTest, FromStringParsesValidValues) {
+    auto healthy_result = enum_from_string<health_status>("HEALTHY");
+    ASSERT_TRUE(healthy_result.is_ok());
+    EXPECT_EQ(healthy_result.value(), health_status::healthy);
+
+    auto degraded_result = enum_from_string<health_status>("DEGRADED");
+    ASSERT_TRUE(degraded_result.is_ok());
+    EXPECT_EQ(degraded_result.value(), health_status::degraded);
+
+    auto unhealthy_result = enum_from_string<health_status>("UNHEALTHY");
+    ASSERT_TRUE(unhealthy_result.is_ok());
+    EXPECT_EQ(unhealthy_result.value(), health_status::unhealthy);
+
+    auto unknown_result = enum_from_string<health_status>("UNKNOWN");
+    ASSERT_TRUE(unknown_result.is_ok());
+    EXPECT_EQ(unknown_result.value(), health_status::unknown);
+}
+
+TEST_F(HealthStatusSerializationTest, FromStringIsCaseInsensitive) {
+    auto lower = enum_from_string<health_status>("healthy");
+    ASSERT_TRUE(lower.is_ok());
+    EXPECT_EQ(lower.value(), health_status::healthy);
+}
+
+TEST_F(HealthStatusSerializationTest, LegacyToStringWorks) {
+    EXPECT_EQ(to_string(health_status::healthy), "HEALTHY");
+    EXPECT_EQ(to_string(health_status::unhealthy), "UNHEALTHY");
+}
+
+// =============================================================================
+// health_check_type Serialization Tests
+// =============================================================================
+
+class HealthCheckTypeSerializationTest : public ::testing::Test {};
+
+TEST_F(HealthCheckTypeSerializationTest, ToStringConvertsAllValues) {
+    EXPECT_EQ(enum_to_string(health_check_type::liveness), "LIVENESS");
+    EXPECT_EQ(enum_to_string(health_check_type::readiness), "READINESS");
+    EXPECT_EQ(enum_to_string(health_check_type::startup), "STARTUP");
+    EXPECT_EQ(enum_to_string(health_check_type::dependency), "DEPENDENCY");
+    EXPECT_EQ(enum_to_string(health_check_type::custom), "CUSTOM");
+}
+
+TEST_F(HealthCheckTypeSerializationTest, FromStringParsesValidValues) {
+    auto liveness_result = enum_from_string<health_check_type>("LIVENESS");
+    ASSERT_TRUE(liveness_result.is_ok());
+    EXPECT_EQ(liveness_result.value(), health_check_type::liveness);
+
+    auto readiness_result = enum_from_string<health_check_type>("READINESS");
+    ASSERT_TRUE(readiness_result.is_ok());
+    EXPECT_EQ(readiness_result.value(), health_check_type::readiness);
+
+    auto startup_result = enum_from_string<health_check_type>("STARTUP");
+    ASSERT_TRUE(startup_result.is_ok());
+    EXPECT_EQ(startup_result.value(), health_check_type::startup);
+
+    auto dependency_result = enum_from_string<health_check_type>("DEPENDENCY");
+    ASSERT_TRUE(dependency_result.is_ok());
+    EXPECT_EQ(dependency_result.value(), health_check_type::dependency);
+
+    auto custom_result = enum_from_string<health_check_type>("CUSTOM");
+    ASSERT_TRUE(custom_result.is_ok());
+    EXPECT_EQ(custom_result.value(), health_check_type::custom);
+}
+
+TEST_F(HealthCheckTypeSerializationTest, FromStringIsCaseInsensitive) {
+    auto lower = enum_from_string<health_check_type>("liveness");
+    ASSERT_TRUE(lower.is_ok());
+    EXPECT_EQ(lower.value(), health_check_type::liveness);
+}
+
+TEST_F(HealthCheckTypeSerializationTest, FromStringReturnsErrorForInvalidValues) {
+    auto result = enum_from_string<health_check_type>("INVALID");
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().module, "health_check");
+}
+
+TEST_F(HealthCheckTypeSerializationTest, LegacyFunctionsWork) {
+    EXPECT_EQ(to_string(health_check_type::liveness), "LIVENESS");
+    auto result = health_check_type_from_string("READINESS");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value(), health_check_type::readiness);
+}
+
+// =============================================================================
+// Round-trip Tests
+// =============================================================================
+
+class RoundTripSerializationTest : public ::testing::Test {};
+
+TEST_F(RoundTripSerializationTest, LogLevelRoundTrip) {
+    for (auto level : {log_level::trace, log_level::debug, log_level::info,
+                       log_level::warning, log_level::error, log_level::critical,
+                       log_level::off}) {
+        auto str = enum_to_string(level);
+        auto result = enum_from_string<log_level>(str);
+        ASSERT_TRUE(result.is_ok()) << "Failed for " << str;
+        EXPECT_EQ(result.value(), level) << "Round-trip failed for " << str;
+    }
+}
+
+TEST_F(RoundTripSerializationTest, MetricTypeRoundTrip) {
+    for (auto type : {metric_type::gauge, metric_type::counter,
+                      metric_type::histogram, metric_type::summary}) {
+        auto str = enum_to_string(type);
+        auto result = enum_from_string<metric_type>(str);
+        ASSERT_TRUE(result.is_ok()) << "Failed for " << str;
+        EXPECT_EQ(result.value(), type) << "Round-trip failed for " << str;
+    }
+}
+
+TEST_F(RoundTripSerializationTest, HealthStatusRoundTrip) {
+    for (auto status : {health_status::healthy, health_status::degraded,
+                        health_status::unhealthy, health_status::unknown}) {
+        auto str = enum_to_string(status);
+        auto result = enum_from_string<health_status>(str);
+        ASSERT_TRUE(result.is_ok()) << "Failed for " << str;
+        EXPECT_EQ(result.value(), status) << "Round-trip failed for " << str;
+    }
+}
+
+TEST_F(RoundTripSerializationTest, HealthCheckTypeRoundTrip) {
+    for (auto type : {health_check_type::liveness, health_check_type::readiness,
+                      health_check_type::startup, health_check_type::dependency,
+                      health_check_type::custom}) {
+        auto str = enum_to_string(type);
+        auto result = enum_from_string<health_check_type>(str);
+        ASSERT_TRUE(result.is_ok()) << "Failed for " << str;
+        EXPECT_EQ(result.value(), type) << "Round-trip failed for " << str;
+    }
+}


### PR DESCRIPTION
Closes #293

## Summary
- Create `enum_serialization.h` with `EnumSerializable` concept and generic `enum_to_string`/`enum_from_string` template functions
- Add `enum_traits` specializations for `log_level`, `metric_type`, `health_status`, and `health_check_type`
- Replace duplicated switch/case patterns with trait-based template usage
- Maintain backward compatibility with existing `to_string()` and `from_string()` functions

## Test Plan
- [x] All 25 new unit tests pass (`common_enum_serialization_test`)
- [x] Existing `common_health_monitoring_test` passes
- [x] Existing `common_concepts_test` passes
- [x] Existing `common_log_functions_test` passes
- [x] Full project builds successfully