### PR TITLE
refactor(error): add decentralized error category infrastructure

### DIFF
--- a/include/kcenon/common/error/error_category.h
+++ b/include/kcenon/common/error/error_category.h
@@ -1,0 +1,432 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file error_category.h
+ * @brief Decentralized error category system for improved system isolation.
+ *
+ * This file provides the infrastructure for decentralized error handling:
+ * - error_category: Abstract base class for system-specific error categories
+ * - common_error_category: Implementation for common/shared error codes
+ * - typed_error_code: Type-safe error code that carries its category
+ *
+ * Design Philosophy:
+ * This design follows std::error_category pattern from <system_error> but
+ * provides additional features specific to the kcenon ecosystem:
+ * - Integration with Result<T> pattern
+ * - Module-based categorization for better debugging
+ * - Support for detailed error messages
+ *
+ * Migration Path:
+ * - Phase 1 (this file): Infrastructure classes
+ * - Phase 2: Migrate common errors to common_error_category
+ * - Phase 3: Create system-specific categories in dependent systems
+ * - Phase 4: Deprecate centralized error_codes.h
+ *
+ * Thread Safety:
+ * - error_category implementations should be stateless singletons
+ * - error_code objects are safe for concurrent reads
+ * - For shared mutable access, users must provide synchronization
+ *
+ * @see https://github.com/kcenon/common_system/issues/300
+ */
+
+#pragma once
+
+#include <functional>
+#include <string>
+#include <string_view>
+
+namespace kcenon::common {
+
+/**
+ * @class error_category
+ * @brief Abstract base class for error code categories.
+ *
+ * Each system can define its own error category by inheriting from this class.
+ * Categories provide:
+ * - A unique name for identification
+ * - Human-readable messages for error codes
+ * - Equivalence comparison between different categories
+ *
+ * Example implementation:
+ * @code
+ * class network_error_category : public error_category {
+ * public:
+ *     static const network_error_category& instance() {
+ *         static network_error_category instance;
+ *         return instance;
+ *     }
+ *
+ *     std::string_view name() const noexcept override { return "network"; }
+ *
+ *     std::string message(int code) const override {
+ *         switch (code) {
+ *             case 1: return "Connection failed";
+ *             case 2: return "Timeout";
+ *             default: return "Unknown network error";
+ *         }
+ *     }
+ * };
+ * @endcode
+ */
+class error_category {
+public:
+    /**
+     * @brief Virtual destructor for proper cleanup of derived classes.
+     */
+    virtual ~error_category() = default;
+
+    /**
+     * @brief Returns the unique name of this error category.
+     *
+     * The name should be a short, descriptive identifier for the category.
+     * Examples: "common", "network", "database", "logger"
+     *
+     * @return Category name as a string view (must be valid for lifetime of category)
+     */
+    virtual std::string_view name() const noexcept = 0;
+
+    /**
+     * @brief Returns a human-readable message for the given error code.
+     *
+     * @param code The error code value
+     * @return Human-readable error message
+     */
+    virtual std::string message(int code) const = 0;
+
+    /**
+     * @brief Checks if an error code in this category is equivalent to another.
+     *
+     * The default implementation checks for exact category and code match.
+     * Derived classes can override this to provide semantic equivalence
+     * (e.g., "timeout" errors from different systems may be equivalent).
+     *
+     * @param code Error code in this category
+     * @param other_category Category of the other error code
+     * @param other_code The other error code value
+     * @return true if the error codes are semantically equivalent
+     */
+    virtual bool equivalent(int code,
+                          const error_category& other_category,
+                          int other_code) const noexcept {
+        return (this == &other_category) && (code == other_code);
+    }
+
+    /**
+     * @brief Equality comparison between categories.
+     *
+     * Categories are compared by identity (address), not by name.
+     * This ensures that two different categories with the same name
+     * are not considered equal.
+     *
+     * @param other Category to compare with
+     * @return true if same category instance
+     */
+    bool operator==(const error_category& other) const noexcept {
+        return this == &other;
+    }
+
+    /**
+     * @brief Inequality comparison between categories.
+     */
+    bool operator!=(const error_category& other) const noexcept {
+        return !(*this == other);
+    }
+
+    /**
+     * @brief Less-than comparison for use in ordered containers.
+     */
+    bool operator<(const error_category& other) const noexcept {
+        return std::less<const error_category*>()(this, &other);
+    }
+
+protected:
+    /**
+     * @brief Protected default constructor.
+     *
+     * Categories should be accessed through their singleton instance(),
+     * not constructed directly.
+     */
+    error_category() = default;
+
+    // Non-copyable, non-movable (singleton pattern)
+    error_category(const error_category&) = delete;
+    error_category& operator=(const error_category&) = delete;
+    error_category(error_category&&) = delete;
+    error_category& operator=(error_category&&) = delete;
+};
+
+// Forward declaration
+class typed_error_code;
+
+/**
+ * @class common_error_category
+ * @brief Error category for common/shared error codes.
+ *
+ * This category contains error codes that are truly common across all systems:
+ * - Success/failure indicators
+ * - Generic errors (invalid_argument, not_found, etc.)
+ * - Resource errors (out_of_memory, timeout)
+ *
+ * System-specific errors should NOT be added here. Instead, each system
+ * should define its own error category.
+ */
+class common_error_category : public error_category {
+public:
+    /**
+     * @brief Common error codes.
+     *
+     * These are error codes that apply universally across all systems.
+     * System-specific error codes should be defined in their respective
+     * error categories.
+     */
+    enum codes : int {
+        success = 0,
+        unknown_error = -1,
+        invalid_argument = -2,
+        not_found = -3,
+        permission_denied = -4,
+        timeout = -5,
+        cancelled = -6,
+        not_initialized = -7,
+        already_exists = -8,
+        out_of_memory = -9,
+        io_error = -10,
+        operation_not_supported = -11,
+        internal_error = -99
+    };
+
+    /**
+     * @brief Returns the singleton instance of common_error_category.
+     *
+     * Thread-safe due to C++11 static local variable initialization.
+     *
+     * @return Reference to the singleton instance
+     */
+    static const common_error_category& instance() noexcept {
+        static common_error_category inst;
+        return inst;
+    }
+
+    /**
+     * @brief Returns the category name.
+     * @return "common"
+     */
+    std::string_view name() const noexcept override {
+        return "common";
+    }
+
+    /**
+     * @brief Returns a human-readable message for the error code.
+     * @param code Error code value
+     * @return Error message
+     */
+    std::string message(int code) const override {
+        switch (code) {
+            case success: return "Success";
+            case unknown_error: return "Unknown error";
+            case invalid_argument: return "Invalid argument";
+            case not_found: return "Not found";
+            case permission_denied: return "Permission denied";
+            case timeout: return "Operation timed out";
+            case cancelled: return "Operation was cancelled";
+            case not_initialized: return "Not initialized";
+            case already_exists: return "Already exists";
+            case out_of_memory: return "Out of memory";
+            case io_error: return "I/O error";
+            case operation_not_supported: return "Operation not supported";
+            case internal_error: return "Internal error";
+            default: return "Unknown common error (code: " + std::to_string(code) + ")";
+        }
+    }
+
+private:
+    common_error_category() = default;
+};
+
+/**
+ * @class typed_error_code
+ * @brief A type-safe error code that carries its category.
+ *
+ * typed_error_code encapsulates both an error code value and a reference to its
+ * category. This allows:
+ * - Clear identification of error origin (via category name)
+ * - Human-readable error messages
+ * - Comparison between error codes from different systems
+ *
+ * @note This class is named typed_error_code to avoid conflicts with the
+ *       existing error_code alias (error_code = error_info) in result/core.h.
+ *       A future migration will deprecate the alias and rename this class
+ *       to error_code.
+ *
+ * Example usage:
+ * @code
+ * // Create a typed error code
+ * typed_error_code ec(common_error_category::timeout, common_error_category::instance());
+ *
+ * // Check for error
+ * if (ec) {
+ *     std::cout << "Error: " << ec.message() << std::endl;
+ *     std::cout << "Category: " << ec.category().name() << std::endl;
+ * }
+ *
+ * // Create using make_typed_error_code helper
+ * auto ec2 = make_typed_error_code(common_error_category::not_found);
+ * @endcode
+ */
+class typed_error_code {
+public:
+    /**
+     * @brief Default constructor creates a success error code.
+     */
+    typed_error_code() noexcept
+        : code_(0)
+        , category_(&common_error_category::instance()) {}
+
+    /**
+     * @brief Constructs an error code with the given value and category.
+     *
+     * @param code Error code value
+     * @param category Reference to the error category
+     */
+    typed_error_code(int code, const error_category& category) noexcept
+        : code_(code)
+        , category_(&category) {}
+
+    /**
+     * @brief Constructs from common_error_category::codes enum.
+     *
+     * Convenience constructor for common error codes.
+     *
+     * @param code Common error code enum value
+     */
+    typed_error_code(common_error_category::codes code) noexcept
+        : code_(static_cast<int>(code))
+        , category_(&common_error_category::instance()) {}
+
+    /**
+     * @brief Returns the error code value.
+     */
+    int value() const noexcept { return code_; }
+
+    /**
+     * @brief Returns the error category.
+     */
+    const error_category& category() const noexcept { return *category_; }
+
+    /**
+     * @brief Returns a human-readable error message.
+     *
+     * Delegates to the category's message() method.
+     */
+    std::string message() const { return category_->message(code_); }
+
+    /**
+     * @brief Returns the category name.
+     *
+     * Convenience method equivalent to category().name().
+     */
+    std::string_view category_name() const noexcept { return category_->name(); }
+
+    /**
+     * @brief Explicit bool conversion - true if error, false if success.
+     *
+     * @return true if error code represents an error (non-zero value)
+     */
+    explicit operator bool() const noexcept { return code_ != 0; }
+
+    /**
+     * @brief Clears the error code to success state.
+     */
+    void clear() noexcept {
+        code_ = 0;
+        category_ = &common_error_category::instance();
+    }
+
+    /**
+     * @brief Assigns a new error code value and category.
+     */
+    void assign(int code, const error_category& category) noexcept {
+        code_ = code;
+        category_ = &category;
+    }
+
+    /**
+     * @brief Equality comparison.
+     *
+     * Two error codes are equal if they have the same category and value.
+     */
+    bool operator==(const typed_error_code& other) const noexcept {
+        return code_ == other.code_ && *category_ == *other.category_;
+    }
+
+    /**
+     * @brief Inequality comparison.
+     */
+    bool operator!=(const typed_error_code& other) const noexcept {
+        return !(*this == other);
+    }
+
+    /**
+     * @brief Less-than comparison for use in ordered containers.
+     */
+    bool operator<(const typed_error_code& other) const noexcept {
+        if (*category_ < *other.category_) return true;
+        if (*other.category_ < *category_) return false;
+        return code_ < other.code_;
+    }
+
+private:
+    int code_;
+    const error_category* category_;
+};
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * @brief Creates a typed_error_code from common_error_category::codes enum.
+ *
+ * @param code Common error code enum value
+ * @return typed_error_code with common_error_category
+ */
+inline typed_error_code make_typed_error_code(common_error_category::codes code) noexcept {
+    return typed_error_code(static_cast<int>(code), common_error_category::instance());
+}
+
+/**
+ * @brief Creates a typed_error_code from a code value and category.
+ *
+ * @tparam Category The error category type (must have instance() method)
+ * @param code Error code value
+ * @return typed_error_code with the specified category
+ */
+template<typename Category>
+typed_error_code make_typed_error_code(int code) noexcept {
+    return typed_error_code(code, Category::instance());
+}
+
+/**
+ * @brief Checks if a typed_error_code represents success (no error).
+ *
+ * @param ec The error code to check
+ * @return true if the error code represents success
+ */
+inline bool is_success(const typed_error_code& ec) noexcept {
+    return ec.value() == 0;
+}
+
+/**
+ * @brief Checks if a typed_error_code represents an error.
+ *
+ * @param ec The error code to check
+ * @return true if the error code represents an error
+ */
+inline bool is_error(const typed_error_code& ec) noexcept {
+    return ec.value() != 0;
+}
+
+} // namespace kcenon::common

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -508,6 +508,27 @@ set_tests_properties(common_adapter_test PROPERTIES
     LABELS "unit;adapters"
 )
 
+# Error category tests (Issue #300)
+add_executable(common_error_category_test
+    error_category_test.cpp
+)
+
+target_link_libraries(common_error_category_test PRIVATE
+    kcenon::common
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+target_compile_features(common_error_category_test PRIVATE cxx_std_20)
+
+add_test(NAME common_error_category_test COMMAND common_error_category_test)
+
+set_tests_properties(common_error_category_test PROPERTIES
+    TIMEOUT 60
+    LABELS "unit;error"
+)
+
 # ABI version tests (Sprint 2 - Task 2.4)
 # Note: These tests require the static library build to test link-time checks
 if(NOT COMMON_HEADER_ONLY AND TARGET common_system_static)
@@ -576,6 +597,7 @@ set(COMMON_TEST_TARGETS
     common_module_verification_test
     common_enum_serialization_test
     common_adapter_test
+    common_error_category_test
 )
 
 # Apply warning flags to all test targets

--- a/tests/error_category_test.cpp
+++ b/tests/error_category_test.cpp
@@ -1,0 +1,398 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file error_category_test.cpp
+ * @brief Unit tests for the decentralized error category system.
+ *
+ * These tests verify:
+ * - error_category base class functionality
+ * - common_error_category implementation
+ * - typed_error_code class with category support
+ * - Integration with Result<T>
+ *
+ * @see https://github.com/kcenon/common_system/issues/300
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/common/error/error_category.h>
+#include <kcenon/common/patterns/result.h>
+
+#include <map>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace kcenon::common {
+namespace {
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+/**
+ * @brief Custom error category for testing.
+ *
+ * Simulates a system-specific error category (e.g., network_error_category)
+ * to verify the extensibility of the error category system.
+ */
+class test_error_category : public error_category {
+public:
+    enum codes : int {
+        success = 0,
+        test_error_1 = 1,
+        test_error_2 = 2,
+        test_error_3 = 3
+    };
+
+    static const test_error_category& instance() noexcept {
+        static test_error_category inst;
+        return inst;
+    }
+
+    std::string_view name() const noexcept override {
+        return "test";
+    }
+
+    std::string message(int code) const override {
+        switch (code) {
+            case success: return "Success";
+            case test_error_1: return "Test error 1";
+            case test_error_2: return "Test error 2";
+            case test_error_3: return "Test error 3";
+            default: return "Unknown test error";
+        }
+    }
+
+private:
+    test_error_category() = default;
+};
+
+/**
+ * @brief Helper to create test category error codes.
+ */
+inline typed_error_code make_test_typed_error_code(test_error_category::codes code) noexcept {
+    return typed_error_code(static_cast<int>(code), test_error_category::instance());
+}
+
+// ============================================================================
+// error_category Tests
+// ============================================================================
+
+class ErrorCategoryTest : public ::testing::Test {};
+
+TEST_F(ErrorCategoryTest, CommonCategorySingleton) {
+    // Verify singleton pattern
+    const auto& cat1 = common_error_category::instance();
+    const auto& cat2 = common_error_category::instance();
+
+    EXPECT_EQ(&cat1, &cat2);
+}
+
+TEST_F(ErrorCategoryTest, CommonCategoryName) {
+    const auto& cat = common_error_category::instance();
+
+    EXPECT_EQ(cat.name(), "common");
+}
+
+TEST_F(ErrorCategoryTest, CommonCategoryMessages) {
+    const auto& cat = common_error_category::instance();
+
+    EXPECT_EQ(cat.message(common_error_category::success), "Success");
+    EXPECT_EQ(cat.message(common_error_category::unknown_error), "Unknown error");
+    EXPECT_EQ(cat.message(common_error_category::invalid_argument), "Invalid argument");
+    EXPECT_EQ(cat.message(common_error_category::not_found), "Not found");
+    EXPECT_EQ(cat.message(common_error_category::timeout), "Operation timed out");
+    EXPECT_EQ(cat.message(common_error_category::internal_error), "Internal error");
+}
+
+TEST_F(ErrorCategoryTest, CommonCategoryUnknownCode) {
+    const auto& cat = common_error_category::instance();
+
+    // Unknown codes should return a descriptive message
+    std::string msg = cat.message(9999);
+    EXPECT_TRUE(msg.find("Unknown") != std::string::npos ||
+                msg.find("unknown") != std::string::npos);
+}
+
+TEST_F(ErrorCategoryTest, CustomCategorySingleton) {
+    const auto& cat1 = test_error_category::instance();
+    const auto& cat2 = test_error_category::instance();
+
+    EXPECT_EQ(&cat1, &cat2);
+}
+
+TEST_F(ErrorCategoryTest, CustomCategoryName) {
+    const auto& cat = test_error_category::instance();
+
+    EXPECT_EQ(cat.name(), "test");
+}
+
+TEST_F(ErrorCategoryTest, CategoryEquality) {
+    const auto& common1 = common_error_category::instance();
+    const auto& common2 = common_error_category::instance();
+    const auto& test_cat = test_error_category::instance();
+
+    // Same category instances are equal
+    EXPECT_EQ(common1, common2);
+
+    // Different categories are not equal
+    EXPECT_NE(common1, test_cat);
+}
+
+TEST_F(ErrorCategoryTest, CategoryComparison) {
+    const auto& common_cat = common_error_category::instance();
+    const auto& test_cat = test_error_category::instance();
+
+    // Categories should have a consistent ordering
+    bool common_less = common_cat < test_cat;
+    bool test_less = test_cat < common_cat;
+
+    // Exactly one should be true (strict weak ordering)
+    EXPECT_NE(common_less, test_less);
+}
+
+// ============================================================================
+// typed_error_code Tests
+// ============================================================================
+
+class ErrorCodeTest : public ::testing::Test {};
+
+TEST_F(ErrorCodeTest, DefaultConstruction) {
+    typed_error_code ec;
+
+    EXPECT_EQ(ec.value(), 0);
+    EXPECT_EQ(ec.category(), common_error_category::instance());
+    EXPECT_FALSE(ec);  // Success is "falsy"
+}
+
+TEST_F(ErrorCodeTest, ConstructWithCodeAndCategory) {
+    typed_error_code ec(common_error_category::not_found, common_error_category::instance());
+
+    EXPECT_EQ(ec.value(), common_error_category::not_found);
+    EXPECT_EQ(ec.category(), common_error_category::instance());
+    EXPECT_TRUE(ec);  // Error is "truthy"
+}
+
+TEST_F(ErrorCodeTest, ConstructFromCommonEnum) {
+    typed_error_code ec(common_error_category::timeout);
+
+    EXPECT_EQ(ec.value(), common_error_category::timeout);
+    EXPECT_EQ(ec.category(), common_error_category::instance());
+    EXPECT_EQ(ec.message(), "Operation timed out");
+}
+
+TEST_F(ErrorCodeTest, Message) {
+    typed_error_code ec(common_error_category::invalid_argument);
+
+    EXPECT_EQ(ec.message(), "Invalid argument");
+}
+
+TEST_F(ErrorCodeTest, CategoryName) {
+    typed_error_code common_ec(common_error_category::success);
+    typed_error_code test_ec = make_test_typed_error_code(test_error_category::test_error_1);
+
+    EXPECT_EQ(common_ec.category_name(), "common");
+    EXPECT_EQ(test_ec.category_name(), "test");
+}
+
+TEST_F(ErrorCodeTest, BoolConversion) {
+    typed_error_code success_ec(common_error_category::success);
+    typed_error_code error_ec(common_error_category::not_found);
+
+    EXPECT_FALSE(success_ec);
+    EXPECT_TRUE(error_ec);
+}
+
+TEST_F(ErrorCodeTest, Clear) {
+    typed_error_code ec(common_error_category::not_found);
+    EXPECT_TRUE(ec);
+
+    ec.clear();
+
+    EXPECT_FALSE(ec);
+    EXPECT_EQ(ec.value(), 0);
+}
+
+TEST_F(ErrorCodeTest, Assign) {
+    typed_error_code ec;
+    EXPECT_FALSE(ec);
+
+    ec.assign(test_error_category::test_error_2, test_error_category::instance());
+
+    EXPECT_TRUE(ec);
+    EXPECT_EQ(ec.value(), test_error_category::test_error_2);
+    EXPECT_EQ(ec.category(), test_error_category::instance());
+}
+
+TEST_F(ErrorCodeTest, Equality) {
+    typed_error_code ec1(common_error_category::not_found);
+    typed_error_code ec2(common_error_category::not_found);
+    typed_error_code ec3(common_error_category::timeout);
+    typed_error_code ec4 = make_test_typed_error_code(test_error_category::test_error_1);
+
+    // Same category and code
+    EXPECT_EQ(ec1, ec2);
+
+    // Same category, different code
+    EXPECT_NE(ec1, ec3);
+
+    // Different category
+    EXPECT_NE(ec1, ec4);
+}
+
+TEST_F(ErrorCodeTest, LessThanComparison) {
+    typed_error_code ec1(common_error_category::not_found);
+    typed_error_code ec2(common_error_category::timeout);
+    typed_error_code ec3 = make_test_typed_error_code(test_error_category::test_error_1);
+
+    // Can be used in ordered containers
+    std::set<typed_error_code> error_set;
+    error_set.insert(ec1);
+    error_set.insert(ec2);
+    error_set.insert(ec3);
+
+    EXPECT_EQ(error_set.size(), 3u);
+}
+
+TEST_F(ErrorCodeTest, UseInMap) {
+    std::map<typed_error_code, std::string> error_descriptions;
+
+    typed_error_code ec1(common_error_category::not_found);
+    typed_error_code ec2(common_error_category::timeout);
+
+    error_descriptions[ec1] = "Resource not found";
+    error_descriptions[ec2] = "Operation timeout";
+
+    EXPECT_EQ(error_descriptions[ec1], "Resource not found");
+    EXPECT_EQ(error_descriptions[ec2], "Operation timeout");
+}
+
+// ============================================================================
+// make_typed_error_code Helper Tests
+// ============================================================================
+
+class MakeErrorCodeTest : public ::testing::Test {};
+
+TEST_F(MakeErrorCodeTest, MakeCommonErrorCode) {
+    auto ec = make_typed_error_code(common_error_category::invalid_argument);
+
+    EXPECT_EQ(ec.value(), common_error_category::invalid_argument);
+    EXPECT_EQ(ec.category(), common_error_category::instance());
+}
+
+TEST_F(MakeErrorCodeTest, MakeCustomErrorCode) {
+    auto ec = make_test_typed_error_code(test_error_category::test_error_2);
+
+    EXPECT_EQ(ec.value(), test_error_category::test_error_2);
+    EXPECT_EQ(ec.category(), test_error_category::instance());
+}
+
+TEST_F(MakeErrorCodeTest, IsSuccessHelper) {
+    typed_error_code success_ec(common_error_category::success);
+    typed_error_code error_ec(common_error_category::not_found);
+
+    EXPECT_TRUE(is_success(success_ec));
+    EXPECT_FALSE(is_success(error_ec));
+}
+
+TEST_F(MakeErrorCodeTest, IsErrorHelper) {
+    typed_error_code success_ec(common_error_category::success);
+    typed_error_code error_ec(common_error_category::not_found);
+
+    EXPECT_FALSE(is_error(success_ec));
+    EXPECT_TRUE(is_error(error_ec));
+}
+
+// ============================================================================
+// Integration with Result<T> Tests
+// ============================================================================
+
+class ErrorCodeResultIntegrationTest : public ::testing::Test {};
+
+TEST_F(ErrorCodeResultIntegrationTest, ResultFromErrorCode) {
+    auto ec = make_typed_error_code(common_error_category::not_found);
+    Result<int> result(ec);
+
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, common_error_category::not_found);
+    EXPECT_EQ(result.error().message, "Not found");
+    EXPECT_EQ(result.error().module, "common");
+}
+
+TEST_F(ErrorCodeResultIntegrationTest, ResultErrFactoryWithErrorCode) {
+    auto ec = make_typed_error_code(common_error_category::timeout);
+    auto result = Result<std::string>::err(ec);
+
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, common_error_category::timeout);
+    EXPECT_EQ(result.error().message, "Operation timed out");
+}
+
+TEST_F(ErrorCodeResultIntegrationTest, ResultWithCustomCategory) {
+    auto ec = make_test_typed_error_code(test_error_category::test_error_1);
+    auto result = Result<double>::err(ec);
+
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, test_error_category::test_error_1);
+    EXPECT_EQ(result.error().message, "Test error 1");
+    EXPECT_EQ(result.error().module, "test");
+}
+
+TEST_F(ErrorCodeResultIntegrationTest, ErrorInfoFromErrorCode) {
+    auto ec = make_typed_error_code(common_error_category::invalid_argument);
+    error_info info(ec);
+
+    EXPECT_EQ(info.code, common_error_category::invalid_argument);
+    EXPECT_EQ(info.message, "Invalid argument");
+    EXPECT_EQ(info.module, "common");
+}
+
+TEST_F(ErrorCodeResultIntegrationTest, MixedUsageWithResult) {
+    // Test that both old and new error handling styles work together
+
+    // Old style: direct error_info
+    auto result1 = Result<int>::err(error_info{-1, "Old style error", "legacy"});
+
+    // New style: typed_error_code
+    auto result2 = Result<int>::err(make_typed_error_code(common_error_category::not_found));
+
+    EXPECT_TRUE(result1.is_err());
+    EXPECT_TRUE(result2.is_err());
+
+    EXPECT_EQ(result1.error().module, "legacy");
+    EXPECT_EQ(result2.error().module, "common");
+}
+
+// ============================================================================
+// Thread Safety Tests (Basic)
+// ============================================================================
+
+TEST_F(ErrorCategoryTest, CategorySingletonThreadSafety) {
+    // C++11 guarantees thread-safe initialization of static locals
+    // This test verifies the singleton can be accessed from multiple threads
+
+    std::vector<std::thread> threads;
+    std::vector<const error_category*> addresses(10, nullptr);
+
+    for (int i = 0; i < 10; ++i) {
+        threads.emplace_back([i, &addresses]() {
+            addresses[i] = &common_error_category::instance();
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // All threads should get the same address
+    for (int i = 1; i < 10; ++i) {
+        EXPECT_EQ(addresses[0], addresses[i]);
+    }
+}
+
+}  // namespace
+}  // namespace kcenon::common


### PR DESCRIPTION
## Summary

This PR implements Phase 1 of the decentralized error category system to improve system isolation and reduce coupling between components.

### Key Changes

- **error_category**: Abstract base class following `std::error_category` pattern for system-specific error categories
- **common_error_category**: Singleton implementation for common/shared error codes (success, invalid_argument, not_found, timeout, etc.)
- **typed_error_code**: Type-safe error code class that carries its category reference
- **Helper functions**: `make_typed_error_code()`, `is_success()`, `is_error()` for convenient error code creation and checking
- **Result<T> integration**: `error_info` can now be constructed from `typed_error_code` for seamless integration

### Design Decisions

- Named `typed_error_code` to avoid conflict with existing `using error_code = error_info;` alias
- Preserved backward compatibility with legacy `error_code` alias (marked deprecated)
- Categories use thread-safe singleton pattern via C++11 static local initialization
- Error codes carry both numeric value and category reference for clear origin identification

### Architecture

```
error_category (abstract base)
    ├── common_error_category (singleton)
    │   └── codes: success, unknown_error, invalid_argument, not_found, ...
    └── [future] system-specific categories
        ├── network_error_category
        ├── database_error_category
        └── ...

typed_error_code
    ├── value(): int
    ├── category(): error_category&
    └── message(): string (from category)
```

### Future Phases (not in this PR)

- **Phase 2**: Migrate common errors to `common_error_category`
- **Phase 3**: Create system-specific categories in dependent systems
- **Phase 4**: Deprecate centralized `error_codes.h`

## Test Plan

- [x] Unit tests for `error_category` base class functionality
- [x] Unit tests for `common_error_category` implementation
- [x] Unit tests for `typed_error_code` class with category support
- [x] Integration tests with `Result<T>`
- [x] Thread safety tests for singleton pattern
- [x] All 113 existing tests pass
- [x] Build succeeds on macOS with Clang

Closes #300