### PR TITLE
docs(readme): add ecosystem-wide compiler requirements matrix

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -82,6 +82,22 @@ common_system (기반 계층 - 의존성 없음)
        └── database_system (Result<T> 및 IExecutor 사용)
 ```
 
+### 생태계 전체 컴파일러 요구사항
+
+여러 시스템을 함께 사용할 때는 의존성 체인에서 **가장 높은** 요구사항을 사용하세요:
+
+| 사용 시나리오 | GCC | Clang | MSVC | 비고 |
+|---------------|-----|-------|------|------|
+| common_system 단독 | 11+ | 14+ | 2022+ | 기준선 |
+| + thread_system | **13+** | **17+** | 2022+ | 더 높은 요구사항 |
+| + logger_system | 11+ | 14+ | 2022+ | thread_system 선택적 |
+| + container_system | 11+ | 14+ | 2022+ | common_system 사용 |
+| + monitoring_system | **13+** | **17+** | 2022+ | thread_system 필요 |
+| + database_system | **13+** | **17+** | 2022+ | 전체 생태계 |
+| + network_system | **13+** | **17+** | 2022+ | thread_system 필요 |
+
+> **참고**: thread_system에 의존하는 시스템을 사용하는 경우 GCC 13+ 또는 Clang 17+가 필요합니다.
+
 ---
 
 ## 설치

--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ common_system (Foundation Layer - No Dependencies)
        └── database_system (uses Result<T> and IExecutor)
 ```
 
+### Ecosystem-Wide Compiler Requirements
+
+When using multiple systems together, use the **highest** requirement from your dependency chain:
+
+| Usage Scenario | GCC | Clang | MSVC | Notes |
+|----------------|-----|-------|------|-------|
+| common_system only | 11+ | 14+ | 2022+ | Baseline |
+| + thread_system | **13+** | **17+** | 2022+ | Higher requirements |
+| + logger_system | 11+ | 14+ | 2022+ | Optional thread_system |
+| + container_system | 11+ | 14+ | 2022+ | Uses common_system |
+| + monitoring_system | **13+** | **17+** | 2022+ | Requires thread_system |
+| + database_system | **13+** | **17+** | 2022+ | Full ecosystem |
+| + network_system | **13+** | **17+** | 2022+ | Requires thread_system |
+
+> **Note**: If using any system that depends on thread_system, you need GCC 13+ or Clang 17+.
+
 ---
 
 ## Installation


### PR DESCRIPTION
## Summary

- Add comprehensive compiler requirements matrix to README.md
- Add corresponding Korean translation to README.kr.md
- Document actual minimum compiler versions for ecosystem combinations
- Highlight that thread_system dependencies require GCC 13+/Clang 17+

Closes #323

## Test Plan

- [ ] Verify table renders correctly on GitHub
- [ ] Verify Korean translation is accurate
- [ ] Confirm requirements match actual system dependencies