### PR TITLE
test: add unit tests for database_interface, failure_window, and error_codes coverage

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -658,6 +658,69 @@ set_tests_properties(common_result_helpers_test PROPERTIES
     LABELS "unit;patterns"
 )
 
+# Database interface tests (Issue #358)
+add_executable(common_database_interface_test
+    database_interface_test.cpp
+)
+
+target_link_libraries(common_database_interface_test PRIVATE
+    kcenon::common
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+target_compile_features(common_database_interface_test PRIVATE cxx_std_17)
+
+add_test(NAME common_database_interface_test COMMAND common_database_interface_test)
+
+set_tests_properties(common_database_interface_test PROPERTIES
+    TIMEOUT 60
+    LABELS "unit;interfaces;database"
+)
+
+# Failure window tests (Issue #358)
+add_executable(common_failure_window_test
+    failure_window_test.cpp
+)
+
+target_link_libraries(common_failure_window_test PRIVATE
+    kcenon::common
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+target_compile_features(common_failure_window_test PRIVATE cxx_std_17)
+
+add_test(NAME common_failure_window_test COMMAND common_failure_window_test)
+
+set_tests_properties(common_failure_window_test PROPERTIES
+    TIMEOUT 120
+    LABELS "unit;resilience"
+)
+
+# Error codes tests (Issue #358)
+add_executable(common_error_codes_test
+    error_codes_test.cpp
+)
+
+target_link_libraries(common_error_codes_test PRIVATE
+    kcenon::common
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+target_compile_features(common_error_codes_test PRIVATE cxx_std_17)
+
+add_test(NAME common_error_codes_test COMMAND common_error_codes_test)
+
+set_tests_properties(common_error_codes_test PROPERTIES
+    TIMEOUT 60
+    LABELS "unit;error"
+)
+
 # Enable testing
 enable_testing()
 
@@ -708,6 +771,9 @@ set(COMMON_TEST_TARGETS
     common_circular_buffer_test
     common_object_pool_test
     common_result_helpers_test
+    common_database_interface_test
+    common_failure_window_test
+    common_error_codes_test
 )
 
 # Apply warning flags to all test targets

--- a/tests/database_interface_test.cpp
+++ b/tests/database_interface_test.cpp
@@ -1,0 +1,312 @@
+/**
+ * @file database_interface_test.cpp
+ * @brief Unit tests for database interface types and IDatabase contract.
+ *
+ * Tests the database type aliases and mock IDatabase implementation:
+ * - database_value variant construction with all 5 types
+ * - database_row map construction and key lookup
+ * - database_result multi-row iteration
+ * - database_null comparison semantics
+ * - Mock IDatabase interface contract
+ *
+ * @date 2026-02-21
+ */
+
+#include <gtest/gtest.h>
+#include <kcenon/common/interfaces/database_interface.h>
+
+using namespace kcenon::common;
+using namespace kcenon::common::interfaces;
+
+// ============================================================================
+// Mock IDatabase implementation for interface contract testing
+// ============================================================================
+
+class MockDatabase : public IDatabase {
+public:
+    VoidResult connect(const std::string& connection_string) override
+    {
+        connection_string_ = connection_string;
+        connected_ = true;
+        return VoidResult::ok({});
+    }
+
+    VoidResult disconnect() override
+    {
+        connected_ = false;
+        return VoidResult::ok({});
+    }
+
+    Result<database_result> execute_query(const std::string& query) override
+    {
+        last_query_ = query;
+        return Result<database_result>::ok(query_result_);
+    }
+
+    VoidResult execute_command(const std::string& command) override
+    {
+        last_command_ = command;
+        return VoidResult::ok({});
+    }
+
+    VoidResult begin_transaction() override
+    {
+        in_transaction_ = true;
+        return VoidResult::ok({});
+    }
+
+    VoidResult commit() override
+    {
+        in_transaction_ = false;
+        return VoidResult::ok({});
+    }
+
+    VoidResult rollback() override
+    {
+        in_transaction_ = false;
+        return VoidResult::ok({});
+    }
+
+    bool is_connected() const override
+    {
+        return connected_;
+    }
+
+    // Test helpers
+    void set_query_result(database_result result) { query_result_ = std::move(result); }
+    std::string last_query() const { return last_query_; }
+    std::string last_command() const { return last_command_; }
+    bool in_transaction() const { return in_transaction_; }
+
+private:
+    bool connected_ = false;
+    bool in_transaction_ = false;
+    std::string connection_string_;
+    std::string last_query_;
+    std::string last_command_;
+    database_result query_result_;
+};
+
+// ============================================================================
+// database_null tests
+// ============================================================================
+
+TEST(DatabaseInterfaceTest, DatabaseNullDefaultConstruction)
+{
+    database_null null1;
+    database_null null2;
+    // database_null is an empty struct - verify it can be constructed
+    (void)null1;
+    (void)null2;
+}
+
+// ============================================================================
+// database_value variant tests
+// ============================================================================
+
+TEST(DatabaseInterfaceTest, DatabaseValueNullType)
+{
+    database_value val{database_null{}};
+    EXPECT_TRUE(std::holds_alternative<database_null>(val));
+    EXPECT_EQ(val.index(), 0);
+}
+
+TEST(DatabaseInterfaceTest, DatabaseValueStringType)
+{
+    database_value val{std::string("hello")};
+    EXPECT_TRUE(std::holds_alternative<std::string>(val));
+    EXPECT_EQ(std::get<std::string>(val), "hello");
+}
+
+TEST(DatabaseInterfaceTest, DatabaseValueInt64Type)
+{
+    database_value val{static_cast<std::int64_t>(42)};
+    EXPECT_TRUE(std::holds_alternative<std::int64_t>(val));
+    EXPECT_EQ(std::get<std::int64_t>(val), 42);
+}
+
+TEST(DatabaseInterfaceTest, DatabaseValueDoubleType)
+{
+    database_value val{3.14};
+    EXPECT_TRUE(std::holds_alternative<double>(val));
+    EXPECT_DOUBLE_EQ(std::get<double>(val), 3.14);
+}
+
+TEST(DatabaseInterfaceTest, DatabaseValueBoolType)
+{
+    database_value val_true{true};
+    database_value val_false{false};
+    EXPECT_TRUE(std::holds_alternative<bool>(val_true));
+    EXPECT_TRUE(std::get<bool>(val_true));
+    EXPECT_FALSE(std::get<bool>(val_false));
+}
+
+TEST(DatabaseInterfaceTest, DatabaseValueReassignment)
+{
+    database_value val{std::string("initial")};
+    EXPECT_TRUE(std::holds_alternative<std::string>(val));
+
+    val = static_cast<std::int64_t>(100);
+    EXPECT_TRUE(std::holds_alternative<std::int64_t>(val));
+    EXPECT_EQ(std::get<std::int64_t>(val), 100);
+}
+
+// ============================================================================
+// database_row tests
+// ============================================================================
+
+TEST(DatabaseInterfaceTest, DatabaseRowConstruction)
+{
+    database_row row;
+    row["name"] = database_value{std::string("Alice")};
+    row["age"] = database_value{static_cast<std::int64_t>(30)};
+    row["score"] = database_value{95.5};
+    row["active"] = database_value{true};
+    row["nickname"] = database_value{database_null{}};
+
+    EXPECT_EQ(row.size(), 5u);
+}
+
+TEST(DatabaseInterfaceTest, DatabaseRowKeyLookup)
+{
+    database_row row;
+    row["id"] = database_value{static_cast<std::int64_t>(1)};
+    row["email"] = database_value{std::string("test@example.com")};
+
+    EXPECT_EQ(std::get<std::int64_t>(row["id"]), 1);
+    EXPECT_EQ(std::get<std::string>(row["email"]), "test@example.com");
+}
+
+TEST(DatabaseInterfaceTest, DatabaseRowMissingKey)
+{
+    database_row row;
+    row["name"] = database_value{std::string("Bob")};
+
+    // Accessing non-existent key via find
+    auto it = row.find("missing");
+    EXPECT_EQ(it, row.end());
+}
+
+// ============================================================================
+// database_result tests
+// ============================================================================
+
+TEST(DatabaseInterfaceTest, DatabaseResultMultiRowIteration)
+{
+    database_result result;
+
+    database_row row1;
+    row1["id"] = database_value{static_cast<std::int64_t>(1)};
+    row1["name"] = database_value{std::string("Alice")};
+
+    database_row row2;
+    row2["id"] = database_value{static_cast<std::int64_t>(2)};
+    row2["name"] = database_value{std::string("Bob")};
+
+    result.push_back(row1);
+    result.push_back(row2);
+
+    EXPECT_EQ(result.size(), 2u);
+
+    // Iterate and verify
+    std::vector<std::string> names;
+    for (const auto& row : result) {
+        names.push_back(std::get<std::string>(row.at("name")));
+    }
+    EXPECT_EQ(names[0], "Alice");
+    EXPECT_EQ(names[1], "Bob");
+}
+
+TEST(DatabaseInterfaceTest, DatabaseResultEmpty)
+{
+    database_result result;
+    EXPECT_TRUE(result.empty());
+    EXPECT_EQ(result.size(), 0u);
+}
+
+// ============================================================================
+// Mock IDatabase interface contract tests
+// ============================================================================
+
+TEST(DatabaseInterfaceTest, MockConnectAndDisconnect)
+{
+    MockDatabase db;
+    EXPECT_FALSE(db.is_connected());
+
+    auto connect_result = db.connect("host=localhost dbname=test");
+    EXPECT_TRUE(connect_result.is_ok());
+    EXPECT_TRUE(db.is_connected());
+
+    auto disconnect_result = db.disconnect();
+    EXPECT_TRUE(disconnect_result.is_ok());
+    EXPECT_FALSE(db.is_connected());
+}
+
+TEST(DatabaseInterfaceTest, MockExecuteQuery)
+{
+    MockDatabase db;
+    db.connect("host=localhost");
+
+    // Set up expected result
+    database_result expected;
+    database_row row;
+    row["count"] = database_value{static_cast<std::int64_t>(42)};
+    expected.push_back(row);
+    db.set_query_result(expected);
+
+    auto result = db.execute_query("SELECT count(*) FROM users");
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().size(), 1u);
+    EXPECT_EQ(std::get<std::int64_t>(result.value()[0].at("count")), 42);
+    EXPECT_EQ(db.last_query(), "SELECT count(*) FROM users");
+}
+
+TEST(DatabaseInterfaceTest, MockExecuteCommand)
+{
+    MockDatabase db;
+    db.connect("host=localhost");
+
+    auto result = db.execute_command("INSERT INTO users (name) VALUES ('test')");
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(db.last_command(), "INSERT INTO users (name) VALUES ('test')");
+}
+
+TEST(DatabaseInterfaceTest, MockTransactionLifecycle)
+{
+    MockDatabase db;
+    db.connect("host=localhost");
+
+    EXPECT_FALSE(db.in_transaction());
+
+    auto begin_result = db.begin_transaction();
+    EXPECT_TRUE(begin_result.is_ok());
+    EXPECT_TRUE(db.in_transaction());
+
+    auto commit_result = db.commit();
+    EXPECT_TRUE(commit_result.is_ok());
+    EXPECT_FALSE(db.in_transaction());
+}
+
+TEST(DatabaseInterfaceTest, MockTransactionRollback)
+{
+    MockDatabase db;
+    db.connect("host=localhost");
+
+    db.begin_transaction();
+    EXPECT_TRUE(db.in_transaction());
+
+    auto rollback_result = db.rollback();
+    EXPECT_TRUE(rollback_result.is_ok());
+    EXPECT_FALSE(db.in_transaction());
+}
+
+TEST(DatabaseInterfaceTest, PolymorphicAccess)
+{
+    auto db = std::make_unique<MockDatabase>();
+    IDatabase* base_ptr = db.get();
+
+    auto result = base_ptr->connect("host=localhost");
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_TRUE(base_ptr->is_connected());
+    base_ptr->disconnect();
+}

--- a/tests/error_codes_test.cpp
+++ b/tests/error_codes_test.cpp
@@ -1,0 +1,254 @@
+/**
+ * @file error_codes_test.cpp
+ * @brief Unit tests for error code registry and helper functions.
+ *
+ * Tests the centralized error code system:
+ * - get_error_message() for all common_errors range
+ * - get_error_message() for each system range boundary
+ * - get_error_message() for unknown codes
+ * - get_category_name() boundary tests for all 8 category ranges
+ *
+ * @date 2026-02-21
+ */
+
+#include <gtest/gtest.h>
+#include <kcenon/common/error/error_codes.h>
+#include <string>
+
+using namespace kcenon::common::error;
+
+// ============================================================================
+// get_error_message: Common errors (-1 to -99)
+// ============================================================================
+
+TEST(ErrorCodesTest, GetErrorMessageSuccess)
+{
+    EXPECT_EQ(get_error_message(codes::common_errors::success), "Success");
+}
+
+TEST(ErrorCodesTest, GetErrorMessageCommonErrors)
+{
+    EXPECT_EQ(get_error_message(codes::common_errors::invalid_argument), "Invalid argument");
+    EXPECT_EQ(get_error_message(codes::common_errors::not_found), "Not found");
+    EXPECT_EQ(get_error_message(codes::common_errors::permission_denied), "Permission denied");
+    EXPECT_EQ(get_error_message(codes::common_errors::timeout), "Timeout");
+    EXPECT_EQ(get_error_message(codes::common_errors::cancelled), "Cancelled");
+    EXPECT_EQ(get_error_message(codes::common_errors::not_initialized), "Not initialized");
+    EXPECT_EQ(get_error_message(codes::common_errors::already_exists), "Already exists");
+    EXPECT_EQ(get_error_message(codes::common_errors::out_of_memory), "Out of memory");
+    EXPECT_EQ(get_error_message(codes::common_errors::io_error), "I/O error");
+    EXPECT_EQ(get_error_message(codes::common_errors::network_error), "Network error");
+    EXPECT_EQ(get_error_message(codes::common_errors::registry_frozen), "Registry is frozen");
+    EXPECT_EQ(get_error_message(codes::common_errors::internal_error), "Internal error");
+}
+
+// ============================================================================
+// get_error_message: thread_system errors
+// ============================================================================
+
+TEST(ErrorCodesTest, GetErrorMessageThreadSystem)
+{
+    EXPECT_EQ(get_error_message(codes::thread_system::pool_full), "Thread pool full");
+    EXPECT_EQ(get_error_message(codes::thread_system::pool_shutdown), "Thread pool shutdown");
+    EXPECT_EQ(get_error_message(codes::thread_system::job_rejected), "Job rejected");
+    EXPECT_EQ(get_error_message(codes::thread_system::job_timeout), "Job timeout");
+}
+
+// ============================================================================
+// get_error_message: logger_system errors
+// ============================================================================
+
+TEST(ErrorCodesTest, GetErrorMessageLoggerSystem)
+{
+    EXPECT_EQ(get_error_message(codes::logger_system::file_open_failed), "Failed to open log file");
+    EXPECT_EQ(get_error_message(codes::logger_system::file_write_failed), "Failed to write to log file");
+    EXPECT_EQ(get_error_message(codes::logger_system::file_rotation_failed), "Log file rotation failed");
+}
+
+// ============================================================================
+// get_error_message: monitoring_system errors
+// ============================================================================
+
+TEST(ErrorCodesTest, GetErrorMessageMonitoringSystem)
+{
+    EXPECT_EQ(get_error_message(codes::monitoring_system::metric_not_found), "Metric not found");
+    EXPECT_EQ(get_error_message(codes::monitoring_system::storage_full), "Metric storage full");
+}
+
+// ============================================================================
+// get_error_message: container_system errors
+// ============================================================================
+
+TEST(ErrorCodesTest, GetErrorMessageContainerSystem)
+{
+    EXPECT_EQ(get_error_message(codes::container_system::value_type_mismatch), "Value type mismatch");
+    EXPECT_EQ(get_error_message(codes::container_system::serialization_failed), "Serialization failed");
+    EXPECT_EQ(get_error_message(codes::container_system::pool_exhausted), "Memory pool exhausted");
+}
+
+// ============================================================================
+// get_error_message: database_system errors
+// ============================================================================
+
+TEST(ErrorCodesTest, GetErrorMessageDatabaseSystem)
+{
+    EXPECT_EQ(get_error_message(codes::database_system::connection_failed), "Database connection failed");
+    EXPECT_EQ(get_error_message(codes::database_system::pool_exhausted), "Connection pool exhausted");
+    EXPECT_EQ(get_error_message(codes::database_system::query_failed), "Database query failed");
+}
+
+// ============================================================================
+// get_error_message: network_system errors
+// ============================================================================
+
+TEST(ErrorCodesTest, GetErrorMessageNetworkSystem)
+{
+    EXPECT_EQ(get_error_message(codes::network_system::connection_failed), "Network connection failed");
+    EXPECT_EQ(get_error_message(codes::network_system::send_failed), "Network send failed");
+    EXPECT_EQ(get_error_message(codes::network_system::server_not_started), "Server not started");
+}
+
+// ============================================================================
+// get_error_message: pacs_system errors
+// ============================================================================
+
+TEST(ErrorCodesTest, GetErrorMessagePacsSystem)
+{
+    EXPECT_EQ(get_error_message(codes::pacs_system::file_not_found), "DICOM file not found");
+    EXPECT_EQ(get_error_message(codes::pacs_system::file_read_error), "Failed to read DICOM file");
+    EXPECT_EQ(get_error_message(codes::pacs_system::file_write_error), "Failed to write DICOM file");
+    EXPECT_EQ(get_error_message(codes::pacs_system::invalid_dicom_file), "Invalid DICOM file format");
+    EXPECT_EQ(get_error_message(codes::pacs_system::missing_dicm_prefix), "Missing DICM prefix");
+    EXPECT_EQ(get_error_message(codes::pacs_system::invalid_meta_info), "Invalid File Meta Information");
+    EXPECT_EQ(get_error_message(codes::pacs_system::missing_transfer_syntax), "Missing Transfer Syntax");
+    EXPECT_EQ(get_error_message(codes::pacs_system::unsupported_transfer_syntax), "Unsupported Transfer Syntax");
+    EXPECT_EQ(get_error_message(codes::pacs_system::element_not_found), "DICOM element not found");
+    EXPECT_EQ(get_error_message(codes::pacs_system::value_conversion_error), "Value conversion failed");
+    EXPECT_EQ(get_error_message(codes::pacs_system::decode_error), "DICOM decode error");
+    EXPECT_EQ(get_error_message(codes::pacs_system::encode_error), "DICOM encode error");
+    EXPECT_EQ(get_error_message(codes::pacs_system::association_rejected), "DICOM association rejected");
+    EXPECT_EQ(get_error_message(codes::pacs_system::storage_failed), "DICOM storage failed");
+}
+
+// ============================================================================
+// get_error_message: Unknown error codes
+// ============================================================================
+
+TEST(ErrorCodesTest, GetErrorMessageUnknownCode)
+{
+    EXPECT_EQ(get_error_message(-999), "Unknown error");
+    EXPECT_EQ(get_error_message(-1000), "Unknown error");
+    EXPECT_EQ(get_error_message(999), "Unknown error");
+    EXPECT_EQ(get_error_message(-50), "Unknown error");
+}
+
+// ============================================================================
+// get_category_name: All category ranges
+// ============================================================================
+
+TEST(ErrorCodesTest, GetCategoryNameSuccess)
+{
+    EXPECT_EQ(get_category_name(0), "Success");
+    EXPECT_EQ(get_category_name(1), "Success");
+    EXPECT_EQ(get_category_name(100), "Success");
+}
+
+TEST(ErrorCodesTest, GetCategoryNameCommon)
+{
+    // Common range: -1 to -99
+    EXPECT_EQ(get_category_name(-1), "Common");
+    EXPECT_EQ(get_category_name(-50), "Common");
+    EXPECT_EQ(get_category_name(-99), "Common");
+}
+
+TEST(ErrorCodesTest, GetCategoryNameThreadSystem)
+{
+    // ThreadSystem range: -100 to -199
+    EXPECT_EQ(get_category_name(-100), "ThreadSystem");
+    EXPECT_EQ(get_category_name(-150), "ThreadSystem");
+    EXPECT_EQ(get_category_name(-199), "ThreadSystem");
+}
+
+TEST(ErrorCodesTest, GetCategoryNameLoggerSystem)
+{
+    // LoggerSystem range: -200 to -299
+    EXPECT_EQ(get_category_name(-200), "LoggerSystem");
+    EXPECT_EQ(get_category_name(-250), "LoggerSystem");
+    EXPECT_EQ(get_category_name(-299), "LoggerSystem");
+}
+
+TEST(ErrorCodesTest, GetCategoryNameMonitoringSystem)
+{
+    // MonitoringSystem range: -300 to -399
+    EXPECT_EQ(get_category_name(-300), "MonitoringSystem");
+    EXPECT_EQ(get_category_name(-350), "MonitoringSystem");
+    EXPECT_EQ(get_category_name(-399), "MonitoringSystem");
+}
+
+TEST(ErrorCodesTest, GetCategoryNameContainerSystem)
+{
+    // ContainerSystem range: -400 to -499
+    EXPECT_EQ(get_category_name(-400), "ContainerSystem");
+    EXPECT_EQ(get_category_name(-450), "ContainerSystem");
+    EXPECT_EQ(get_category_name(-499), "ContainerSystem");
+}
+
+TEST(ErrorCodesTest, GetCategoryNameDatabaseSystem)
+{
+    // DatabaseSystem range: -500 to -599
+    EXPECT_EQ(get_category_name(-500), "DatabaseSystem");
+    EXPECT_EQ(get_category_name(-550), "DatabaseSystem");
+    EXPECT_EQ(get_category_name(-599), "DatabaseSystem");
+}
+
+TEST(ErrorCodesTest, GetCategoryNameNetworkSystem)
+{
+    // NetworkSystem range: -600 to -699
+    EXPECT_EQ(get_category_name(-600), "NetworkSystem");
+    EXPECT_EQ(get_category_name(-650), "NetworkSystem");
+    EXPECT_EQ(get_category_name(-699), "NetworkSystem");
+}
+
+TEST(ErrorCodesTest, GetCategoryNamePACSSystem)
+{
+    // PACSSystem range: -700 and beyond
+    EXPECT_EQ(get_category_name(-700), "PACSSystem");
+    EXPECT_EQ(get_category_name(-750), "PACSSystem");
+    EXPECT_EQ(get_category_name(-799), "PACSSystem");
+    EXPECT_EQ(get_category_name(-1000), "PACSSystem");
+}
+
+// ============================================================================
+// get_category_name: Boundary values between categories
+// ============================================================================
+
+TEST(ErrorCodesTest, GetCategoryNameBoundaryValues)
+{
+    // Exact boundary between Common and ThreadSystem
+    EXPECT_EQ(get_category_name(-99), "Common");
+    EXPECT_EQ(get_category_name(-100), "ThreadSystem");
+
+    // Exact boundary between ThreadSystem and LoggerSystem
+    EXPECT_EQ(get_category_name(-199), "ThreadSystem");
+    EXPECT_EQ(get_category_name(-200), "LoggerSystem");
+
+    // Exact boundary between LoggerSystem and MonitoringSystem
+    EXPECT_EQ(get_category_name(-299), "LoggerSystem");
+    EXPECT_EQ(get_category_name(-300), "MonitoringSystem");
+
+    // Exact boundary between MonitoringSystem and ContainerSystem
+    EXPECT_EQ(get_category_name(-399), "MonitoringSystem");
+    EXPECT_EQ(get_category_name(-400), "ContainerSystem");
+
+    // Exact boundary between ContainerSystem and DatabaseSystem
+    EXPECT_EQ(get_category_name(-499), "ContainerSystem");
+    EXPECT_EQ(get_category_name(-500), "DatabaseSystem");
+
+    // Exact boundary between DatabaseSystem and NetworkSystem
+    EXPECT_EQ(get_category_name(-599), "DatabaseSystem");
+    EXPECT_EQ(get_category_name(-600), "NetworkSystem");
+
+    // Exact boundary between NetworkSystem and PACSSystem
+    EXPECT_EQ(get_category_name(-699), "NetworkSystem");
+    EXPECT_EQ(get_category_name(-700), "PACSSystem");
+}

--- a/tests/failure_window_test.cpp
+++ b/tests/failure_window_test.cpp
@@ -1,0 +1,210 @@
+/**
+ * @file failure_window_test.cpp
+ * @brief Unit tests for failure_window sliding time window.
+ *
+ * Tests the failure_window class independently from circuit_breaker:
+ * - Direct construction with various window durations
+ * - record_failure() + get_failure_count() sequence
+ * - reset() clears all recorded failures
+ * - is_empty() on fresh vs populated window
+ * - Expiry behavior: failures older than window_duration are discarded
+ * - Thread safety of concurrent operations
+ *
+ * @date 2026-02-21
+ */
+
+#include <gtest/gtest.h>
+#include <kcenon/common/resilience/failure_window.h>
+#include <thread>
+#include <vector>
+
+using namespace kcenon::common::resilience;
+
+// Test construction with various durations
+TEST(FailureWindowTest, ConstructionWithVariousDurations)
+{
+    failure_window w1(std::chrono::milliseconds(100));
+    failure_window w2(std::chrono::milliseconds(1000));
+    failure_window w3(std::chrono::milliseconds(60000));
+
+    EXPECT_EQ(w1.get_failure_count(), 0u);
+    EXPECT_EQ(w2.get_failure_count(), 0u);
+    EXPECT_EQ(w3.get_failure_count(), 0u);
+}
+
+// Test record_failure increments count
+TEST(FailureWindowTest, RecordFailureIncrementsCount)
+{
+    failure_window window(std::chrono::seconds(60));
+
+    window.record_failure();
+    EXPECT_EQ(window.get_failure_count(), 1u);
+
+    window.record_failure();
+    EXPECT_EQ(window.get_failure_count(), 2u);
+
+    window.record_failure();
+    EXPECT_EQ(window.get_failure_count(), 3u);
+}
+
+// Test reset clears all failures
+TEST(FailureWindowTest, ResetClearsAllFailures)
+{
+    failure_window window(std::chrono::seconds(60));
+
+    window.record_failure();
+    window.record_failure();
+    window.record_failure();
+    EXPECT_EQ(window.get_failure_count(), 3u);
+
+    window.reset();
+    EXPECT_EQ(window.get_failure_count(), 0u);
+}
+
+// Test is_empty on fresh window
+TEST(FailureWindowTest, IsEmptyOnFreshWindow)
+{
+    failure_window window(std::chrono::seconds(60));
+    EXPECT_TRUE(window.is_empty());
+}
+
+// Test is_empty on populated window
+TEST(FailureWindowTest, IsEmptyOnPopulatedWindow)
+{
+    failure_window window(std::chrono::seconds(60));
+    window.record_failure();
+    EXPECT_FALSE(window.is_empty());
+}
+
+// Test is_empty after reset
+TEST(FailureWindowTest, IsEmptyAfterReset)
+{
+    failure_window window(std::chrono::seconds(60));
+    window.record_failure();
+    EXPECT_FALSE(window.is_empty());
+
+    window.reset();
+    EXPECT_TRUE(window.is_empty());
+}
+
+// Test expiry behavior: failures older than window are discarded
+TEST(FailureWindowTest, ExpiryDiscardsOldFailures)
+{
+    failure_window window(std::chrono::milliseconds(100));
+
+    // Record failures
+    window.record_failure();
+    window.record_failure();
+    EXPECT_EQ(window.get_failure_count(), 2u);
+
+    // Wait for window to expire
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+    // Old failures should be discarded
+    EXPECT_EQ(window.get_failure_count(), 0u);
+    EXPECT_TRUE(window.is_empty());
+}
+
+// Test partial expiry: only old failures are removed
+TEST(FailureWindowTest, PartialExpiry)
+{
+    failure_window window(std::chrono::milliseconds(200));
+
+    // Record initial failures
+    window.record_failure();
+    window.record_failure();
+
+    // Wait for partial expiry
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+    // Record new failure (within window)
+    window.record_failure();
+
+    // Wait for initial failures to expire but new one to remain
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Only the recent failure should remain
+    EXPECT_EQ(window.get_failure_count(), 1u);
+}
+
+// Test multiple record-query cycles
+TEST(FailureWindowTest, MultipleRecordQueryCycles)
+{
+    failure_window window(std::chrono::seconds(60));
+
+    for (int i = 0; i < 10; ++i) {
+        window.record_failure();
+    }
+    EXPECT_EQ(window.get_failure_count(), 10u);
+
+    window.reset();
+    EXPECT_EQ(window.get_failure_count(), 0u);
+
+    for (int i = 0; i < 5; ++i) {
+        window.record_failure();
+    }
+    EXPECT_EQ(window.get_failure_count(), 5u);
+}
+
+// Test thread safety with concurrent record_failure and get_failure_count
+TEST(FailureWindowTest, ThreadSafetyConcurrentAccess)
+{
+    failure_window window(std::chrono::seconds(60));
+
+    const int thread_count = 8;
+    const int operations_per_thread = 100;
+    std::vector<std::thread> threads;
+
+    // Launch threads that concurrently record failures
+    for (int i = 0; i < thread_count; ++i) {
+        threads.emplace_back([&window]() {
+            for (int j = 0; j < operations_per_thread; ++j) {
+                window.record_failure();
+                (void)window.get_failure_count();
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // All failures should be recorded
+    EXPECT_EQ(window.get_failure_count(),
+              static_cast<std::size_t>(thread_count * operations_per_thread));
+}
+
+// Test thread safety with concurrent record, reset, and query
+TEST(FailureWindowTest, ThreadSafetyConcurrentMixedOperations)
+{
+    failure_window window(std::chrono::seconds(60));
+
+    std::vector<std::thread> threads;
+
+    // Writers
+    for (int i = 0; i < 4; ++i) {
+        threads.emplace_back([&window]() {
+            for (int j = 0; j < 50; ++j) {
+                window.record_failure();
+            }
+        });
+    }
+
+    // Readers
+    for (int i = 0; i < 4; ++i) {
+        threads.emplace_back([&window]() {
+            for (int j = 0; j < 50; ++j) {
+                (void)window.get_failure_count();
+                (void)window.is_empty();
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // Should not crash - exact count depends on timing
+    auto count = window.get_failure_count();
+    EXPECT_GE(count, 0u);
+}


### PR DESCRIPTION
Closes #358

## Summary
- Add `database_interface_test.cpp` (18 tests): Mock IDatabase implementation with all 8 interface methods, `database_value` variant construction with all 5 types, `database_row` map operations, `database_result` multi-row iteration, `database_null` construction
- Add `failure_window_test.cpp` (11 tests): Direct construction, `record_failure()`/`get_failure_count()` sequence, `reset()`, `is_empty()`, sliding window expiry behavior, thread safety with concurrent access
- Add `error_codes_test.cpp` (20 tests): `get_error_message()` for all common_errors, thread_system, logger_system, monitoring_system, container_system, database_system, network_system, and pacs_system ranges; unknown code handling; `get_category_name()` for all 8 category ranges with boundary value tests
- Update `tests/CMakeLists.txt` with 3 new test targets

## Test Plan
- [x] All 49 new tests compile without warnings
- [x] All tests pass locally (18 + 11 + 20 = 49 tests)
- [x] failure_window expiry uses short window durations (100-200ms) to avoid flaky wall-clock tests
- [x] error_codes tests cover every category boundary value
- [x] CI pipeline passes