### PR TITLE
refactor(di): add module registrar support to unified_bootstrapper

### DIFF
--- a/include/kcenon/common/concepts/service.h
+++ b/include/kcenon/common/concepts/service.h
@@ -307,5 +307,42 @@ concept DisposableService = requires(T t) {
     { t.dispose() } -> std::same_as<void>;
 };
 
+/**
+ * @concept ModuleRegistrar
+ * @brief A class-based module registrar for ecosystem DI integration.
+ *
+ * Module registrars provide a standardized way for subsystem modules
+ * (logger_system, monitoring_system, etc.) to register their services
+ * with the service container.
+ *
+ * Registrars must provide:
+ * - A static module_name() returning the module identifier
+ * - A register_services() method that registers services with the container
+ *
+ * Example usage:
+ * @code
+ * class LoggerModule {
+ * public:
+ *     static constexpr std::string_view module_name() { return "logger"; }
+ *
+ *     VoidResult register_services(IServiceContainer& container) {
+ *         return container.register_factory<ILogger>(
+ *             [](IServiceContainer&) { return std::make_shared<ConsoleLogger>(); },
+ *             service_lifetime::singleton
+ *         );
+ *     }
+ * };
+ *
+ * static_assert(ModuleRegistrar<LoggerModule>);
+ * @endcode
+ *
+ * @see unified_bootstrapper.h for registration with the bootstrapper
+ */
+template<typename T>
+concept ModuleRegistrar = requires(T registrar, di::IServiceContainer& container) {
+    { T::module_name() } -> std::convertible_to<std::string_view>;
+    { registrar.register_services(container) };
+};
+
 } // namespace concepts
 } // namespace kcenon::common


### PR DESCRIPTION
Closes #366
Part of #363

## Summary

- Add `ModuleRegistrar` C++20 concept for compile-time validation of module registration classes
- Add dynamic module registration API to `unified_bootstrapper` (`register_module()`, `unregister_module()`, `registered_modules()`, `is_module_registered()`)
- Support both function-based and class-based (concept-constrained) registration
- Modules registered before `initialize()` are deferred and called during init; modules registered after are called immediately
- Simplify `register_optional_services()` by integrating dynamic module dispatch alongside legacy `#ifdef` guards
- Add 12 unit tests covering pre/post-init registration, duplicates, ordering, failure propagation, and concept-based registration

## Context

This is Phase 1+2 of the DI container consolidation effort (#363):

**Phase 1 (Audit)** identified that:
| System | DI Implementation | Migration Effort |
|--------|------------------|-----------------|
| monitoring_system | Already delegates to `service_container` | Minimal |
| logger_system | `lightweight_di_container` + bridge adapter | Medium |
| database_system | `database_coordinator` + bridge adapter | High |

**Phase 2 (Enhancement)** adds the module registrar infrastructure that downstream systems will use to register their services with the unified container.

Remaining phases tracked in: #367 (logger), #368 (monitoring), #369 (database)

## Test Plan

- [x] All 37 unified_bootstrapper tests pass (12 new)
- [x] All 122 project tests pass with no regressions
- [x] Full build succeeds with no warnings
- [x] Compile-time `static_assert` verifies `ModuleRegistrar` concept