### PR TITLE
feat(cmake): add unified compiler version enforcement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,10 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # Include feature flags configuration module
 include(cmake/features.cmake)
 
+# Include compiler requirements check
+include(cmake/KcenonCompilerRequirements.cmake)
+kcenon_check_compiler_requirements()
+
 # Options
 option(COMMON_BUILD_TESTS "Build unit tests for common_system" ON)
 option(COMMON_BUILD_INTEGRATION_TESTS "Build integration tests for common_system" ON)
@@ -168,10 +172,12 @@ if(COMMON_BUILD_MODULES)
     if(CMAKE_VERSION VERSION_LESS "3.28")
         message(WARNING "C++20 modules require CMake 3.28+. Disabling module build.")
         set(COMMON_BUILD_MODULES OFF)
-    # Check for AppleClang (does not support module dependency scanning)
+    # Check compiler version requirements for modules
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         message(WARNING "AppleClang does not support C++20 module dependency scanning. "
-                        "Use Clang 16+, GCC 14+, or MSVC 2022. Disabling module build.")
+                        "Use Clang ${KCENON_MIN_CLANG_MODULE_VERSION}+, "
+                        "GCC ${KCENON_MIN_GCC_MODULE_VERSION}+, or "
+                        "MSVC ${KCENON_MIN_MSVC_MODULE_VERSION}+. Disabling module build.")
         set(COMMON_BUILD_MODULES OFF)
     # Check generator (modules require Ninja or Visual Studio 17.4+)
     elseif(NOT CMAKE_GENERATOR MATCHES "Ninja" AND NOT CMAKE_GENERATOR MATCHES "Visual Studio")
@@ -179,6 +185,8 @@ if(COMMON_BUILD_MODULES)
                         "Current generator: ${CMAKE_GENERATOR}. Disabling module build.")
         set(COMMON_BUILD_MODULES OFF)
     else()
+        # Verify module-capable compiler version
+        kcenon_check_compiler_requirements(MODULES)
         message(STATUS "C++20 module build enabled")
 
         # Create module library target
@@ -280,6 +288,7 @@ install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/common_systemConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/common_systemConfigVersion.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/features.cmake"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/KcenonCompilerRequirements.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/common_system
 )
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,19 @@ auto result = load_config("app.conf")
 
 | Dependency | Version | Required | Description |
 |------------|---------|----------|-------------|
-| C++20 Compiler | GCC 11+ / Clang 14+ / MSVC 2022+ / Apple Clang 14+ | Yes | C++20 features required |
-| CMake | 3.20+ | Yes | Build system |
+| C++20 Compiler | GCC 11+ / Clang 14+ / MSVC 2022+ / Apple Clang 14+ | Yes | C++20 features (concepts) |
+| CMake | 3.28+ | Yes | Build system |
+
+### Compiler Requirements
+
+common_system enforces minimum compiler versions at CMake configure time via
+`KcenonCompilerRequirements.cmake`. Downstream systems can include this module
+for consistent enforcement.
+
+| Build Mode | GCC | Clang | MSVC | Apple Clang |
+|------------|-----|-------|------|-------------|
+| **Header-only** (default) | 11+ | 14+ | 2022 (19.30+) | 14+ |
+| **C++20 Modules** (optional) | 14+ | 16+ | 2022 17.4 (19.34+) | Not supported |
 
 ### Dependency Flow
 
@@ -86,17 +97,19 @@ common_system (Foundation Layer - No Dependencies)
 
 When using multiple systems together, use the **highest** requirement from your dependency chain:
 
-| Usage Scenario | GCC | Clang | MSVC | Notes |
-|----------------|-----|-------|------|-------|
-| common_system only | 11+ | 14+ | 2022+ | Baseline |
-| + thread_system | **13+** | **17+** | 2022+ | Higher requirements |
-| + logger_system | 11+ | 14+ | 2022+ | Optional thread_system |
-| + container_system | 11+ | 14+ | 2022+ | Uses common_system |
-| + monitoring_system | **13+** | **17+** | 2022+ | Requires thread_system |
-| + database_system | **13+** | **17+** | 2022+ | Full ecosystem |
-| + network_system | **13+** | **17+** | 2022+ | Requires thread_system |
+| Usage Scenario | GCC | Clang | MSVC | Apple Clang | Notes |
+|----------------|-----|-------|------|-------------|-------|
+| common_system only | 11+ | 14+ | 2022+ | 14+ | Baseline |
+| + thread_system | **13+** | **17+** | 2022+ | 14+ | Higher requirements |
+| + logger_system | 11+ | 14+ | 2022+ | 14+ | Optional thread_system |
+| + container_system | 11+ | 14+ | 2022+ | 14+ | Uses common_system |
+| + monitoring_system | **13+** | **17+** | 2022+ | 14+ | Requires thread_system |
+| + database_system | **13+** | **17+** | 2022+ | 14+ | Full ecosystem |
+| + network_system | **13+** | **17+** | 2022+ | 14+ | Requires thread_system |
 
 > **Note**: If using any system that depends on thread_system, you need GCC 13+ or Clang 17+.
+> All systems can include `KcenonCompilerRequirements.cmake` from common_system for
+> automated version enforcement at configure time.
 
 ---
 

--- a/cmake/KcenonCompilerRequirements.cmake
+++ b/cmake/KcenonCompilerRequirements.cmake
@@ -1,0 +1,166 @@
+# BSD 3-Clause License
+# Copyright (c) 2025, kcenon
+# See the LICENSE file in the project root for full license information.
+
+#[=============================================================================[
+KcenonCompilerRequirements.cmake - Unified compiler version enforcement
+
+This module provides a single function to verify that the current compiler
+meets the minimum version requirements for the KCENON ecosystem.
+
+Downstream systems should include this module and call the check function
+during their CMake configuration:
+
+    include(KcenonCompilerRequirements)
+    kcenon_check_compiler_requirements()
+
+    # For module builds, also check module-capable versions:
+    kcenon_check_compiler_requirements(MODULES)
+
+Minimum Compiler Requirements (Header-Only):
+    GCC          11.0+
+    Clang        14.0+
+    MSVC         19.30+ (Visual Studio 2022)
+    Apple Clang  14.0+
+
+Minimum Compiler Requirements (C++20 Modules):
+    GCC          14.0+
+    Clang        16.0+
+    MSVC         19.34+ (Visual Studio 2022 17.4)
+    Apple Clang  Not supported
+
+#]=============================================================================]
+
+include_guard(GLOBAL)
+
+# --- Version constants ---
+
+# Header-only minimum versions
+set(KCENON_MIN_GCC_VERSION          "11.0" CACHE INTERNAL "")
+set(KCENON_MIN_CLANG_VERSION        "14.0" CACHE INTERNAL "")
+set(KCENON_MIN_MSVC_VERSION         "19.30" CACHE INTERNAL "")
+set(KCENON_MIN_APPLECLANG_VERSION   "14.0" CACHE INTERNAL "")
+
+# Module build minimum versions
+set(KCENON_MIN_GCC_MODULE_VERSION   "14.0" CACHE INTERNAL "")
+set(KCENON_MIN_CLANG_MODULE_VERSION "16.0" CACHE INTERNAL "")
+set(KCENON_MIN_MSVC_MODULE_VERSION  "19.34" CACHE INTERNAL "")
+
+#[=============================================================================[
+kcenon_check_compiler_requirements([MODULES] [WARNING_ONLY])
+
+Check that the current compiler meets KCENON ecosystem minimum requirements.
+
+Options:
+    MODULES       Also check module-capable compiler versions
+    WARNING_ONLY  Emit warnings instead of fatal errors (for informational use)
+
+Examples:
+    # Basic check (header-only requirements)
+    kcenon_check_compiler_requirements()
+
+    # Check including module support
+    kcenon_check_compiler_requirements(MODULES)
+
+    # Non-fatal check for diagnostic purposes
+    kcenon_check_compiler_requirements(WARNING_ONLY)
+#]=============================================================================]
+function(kcenon_check_compiler_requirements)
+    cmake_parse_arguments(PARSE_ARGV 0 ARG "MODULES;WARNING_ONLY" "" "")
+
+    if(ARG_WARNING_ONLY)
+        set(_MSG_TYPE WARNING)
+    else()
+        set(_MSG_TYPE FATAL_ERROR)
+    endif()
+
+    set(_COMPILER_ID "${CMAKE_CXX_COMPILER_ID}")
+    set(_COMPILER_VER "${CMAKE_CXX_COMPILER_VERSION}")
+
+    # --- Header-only checks ---
+    if(_COMPILER_ID STREQUAL "GNU")
+        if(_COMPILER_VER VERSION_LESS "${KCENON_MIN_GCC_VERSION}")
+            message(${_MSG_TYPE}
+                "KCENON ecosystem requires GCC >= ${KCENON_MIN_GCC_VERSION}. "
+                "Detected GCC ${_COMPILER_VER}. "
+                "Please upgrade your compiler.")
+        endif()
+
+    elseif(_COMPILER_ID STREQUAL "Clang")
+        if(_COMPILER_VER VERSION_LESS "${KCENON_MIN_CLANG_VERSION}")
+            message(${_MSG_TYPE}
+                "KCENON ecosystem requires Clang >= ${KCENON_MIN_CLANG_VERSION}. "
+                "Detected Clang ${_COMPILER_VER}. "
+                "Please upgrade your compiler.")
+        endif()
+
+    elseif(_COMPILER_ID STREQUAL "AppleClang")
+        if(_COMPILER_VER VERSION_LESS "${KCENON_MIN_APPLECLANG_VERSION}")
+            message(${_MSG_TYPE}
+                "KCENON ecosystem requires Apple Clang >= ${KCENON_MIN_APPLECLANG_VERSION}. "
+                "Detected Apple Clang ${_COMPILER_VER}. "
+                "Please upgrade Xcode or Command Line Tools.")
+        endif()
+
+    elseif(_COMPILER_ID STREQUAL "MSVC")
+        if(_COMPILER_VER VERSION_LESS "${KCENON_MIN_MSVC_VERSION}")
+            message(${_MSG_TYPE}
+                "KCENON ecosystem requires MSVC >= ${KCENON_MIN_MSVC_VERSION} (Visual Studio 2022). "
+                "Detected MSVC ${_COMPILER_VER}. "
+                "Please upgrade to Visual Studio 2022 or later.")
+        endif()
+
+    else()
+        message(WARNING
+            "KCENON: Unrecognized compiler '${_COMPILER_ID}' version ${_COMPILER_VER}. "
+            "Supported compilers: GCC ${KCENON_MIN_GCC_VERSION}+, "
+            "Clang ${KCENON_MIN_CLANG_VERSION}+, "
+            "MSVC ${KCENON_MIN_MSVC_VERSION}+ (VS 2022), "
+            "Apple Clang ${KCENON_MIN_APPLECLANG_VERSION}+.")
+    endif()
+
+    # --- Module build checks ---
+    if(ARG_MODULES)
+        if(_COMPILER_ID STREQUAL "GNU")
+            if(_COMPILER_VER VERSION_LESS "${KCENON_MIN_GCC_MODULE_VERSION}")
+                message(${_MSG_TYPE}
+                    "KCENON C++20 modules require GCC >= ${KCENON_MIN_GCC_MODULE_VERSION}. "
+                    "Detected GCC ${_COMPILER_VER}. "
+                    "Disable modules with -DCOMMON_BUILD_MODULES=OFF or upgrade GCC.")
+            endif()
+
+        elseif(_COMPILER_ID STREQUAL "Clang")
+            if(_COMPILER_VER VERSION_LESS "${KCENON_MIN_CLANG_MODULE_VERSION}")
+                message(${_MSG_TYPE}
+                    "KCENON C++20 modules require Clang >= ${KCENON_MIN_CLANG_MODULE_VERSION}. "
+                    "Detected Clang ${_COMPILER_VER}. "
+                    "Disable modules with -DCOMMON_BUILD_MODULES=OFF or upgrade Clang.")
+            endif()
+
+        elseif(_COMPILER_ID STREQUAL "AppleClang")
+            message(${_MSG_TYPE}
+                "Apple Clang does not support C++20 module dependency scanning. "
+                "Use Clang ${KCENON_MIN_CLANG_MODULE_VERSION}+, "
+                "GCC ${KCENON_MIN_GCC_MODULE_VERSION}+, or "
+                "MSVC ${KCENON_MIN_MSVC_MODULE_VERSION}+ instead. "
+                "Disable modules with -DCOMMON_BUILD_MODULES=OFF.")
+
+        elseif(_COMPILER_ID STREQUAL "MSVC")
+            if(_COMPILER_VER VERSION_LESS "${KCENON_MIN_MSVC_MODULE_VERSION}")
+                message(${_MSG_TYPE}
+                    "KCENON C++20 modules require MSVC >= ${KCENON_MIN_MSVC_MODULE_VERSION} "
+                    "(Visual Studio 2022 17.4+). "
+                    "Detected MSVC ${_COMPILER_VER}. "
+                    "Disable modules with -DCOMMON_BUILD_MODULES=OFF or upgrade.")
+            endif()
+        endif()
+    endif()
+
+    # --- Summary ---
+    if(ARG_MODULES)
+        message(STATUS "KCENON compiler check: ${_COMPILER_ID} ${_COMPILER_VER} "
+                       "(modules enabled)")
+    else()
+        message(STATUS "KCENON compiler check: ${_COMPILER_ID} ${_COMPILER_VER}")
+    endif()
+endfunction()

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -83,8 +83,8 @@ The foundation library with no external KCENON dependencies. All other systems d
 - C++20 concepts for type validation
 
 **External Dependencies:**
-- C++20 compiler (GCC 10+, Clang 12+, MSVC 19.29+)
-- CMake 3.16+
+- C++20 compiler (GCC 11+, Clang 14+, MSVC 19.30+ / VS 2022, Apple Clang 14+)
+- CMake 3.28+
 - (Optional) yaml-cpp for YAML configuration support
 - (Optional) GTest for testing
 

--- a/include/kcenon/common/config/feature_flags.h
+++ b/include/kcenon/common/config/feature_flags.h
@@ -247,7 +247,8 @@
 // Static Assertions for Minimum Requirements
 //==============================================================================
 
-// Ensure C++17 minimum
-static_assert(KCENON_HAS_CPP17,
-    "common_system requires C++17 or later. "
-    "Please compile with -std=c++17 or higher.");
+// Ensure C++20 minimum (required since v0.2.0 for concepts support)
+static_assert(KCENON_HAS_CPP20,
+    "common_system requires C++20 or later. "
+    "Please compile with -std=c++20 or higher. "
+    "Minimum compilers: GCC 11+, Clang 14+, MSVC 2022+, Apple Clang 14+.");


### PR DESCRIPTION
Closes #364

## Summary

- Add `cmake/KcenonCompilerRequirements.cmake` shared module for unified compiler version enforcement across the KCENON ecosystem
- Enforce minimum versions at CMake configure time: GCC 11+, Clang 14+, MSVC 2022+, Apple Clang 14+ (header-only); GCC 14+, Clang 16+ (modules)
- Update `feature_flags.h` static_assert from C++17 to C++20 to match actual project requirements
- Fix documentation inconsistencies between README.md and COMPATIBILITY.md
- Install the new CMake module alongside `features.cmake` for downstream consumption

## Phase 1 Audit Results

All C++20 features in common_system are gated behind `KCENON_HAS_*` feature detection macros. The codebase genuinely compiles on GCC 11/Clang 14 in header-only mode. C++20 modules require GCC 14+/Clang 16+ (optional, disabled by default).

## Downstream Integration

Downstream systems can include the module for consistent enforcement:

```cmake
include(KcenonCompilerRequirements)
kcenon_check_compiler_requirements()
```

Downstream CI and CMakeLists.txt integration is planned as a follow-up task.

## Test Plan

- [x] CMake configure succeeds with compiler check message
- [x] 29/30 tests pass (1 pre-existing sandbox-related failure)
- [x] Build completes without errors
- [x] KcenonCompilerRequirements.cmake installed alongside features.cmake