### PR TITLE
chore: unify version to 0.1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.28)
-project(common_system VERSION 0.2.0.0 LANGUAGES CXX)
+project(common_system VERSION 0.1.0.0 LANGUAGES CXX)
 
 # =============================================================================
 # BUILD ORDER DOCUMENTATION

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-common-system",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "port-version": 0,
   "description": "High-performance C++20 foundation library providing Result<T> pattern, interfaces, and common utilities",
   "homepage": "https://github.com/kcenon/common_system",


### PR DESCRIPTION
## Summary
- Unify CMake project version to 0.1.0.0
- Unify vcpkg version to 0.1.0
- Part of ecosystem-wide version normalization for SOUP compliance

## Changes
- CMakeLists.txt: VERSION 0.2.0.0 → 0.1.0.0
- vcpkg.json: version 1.0.0 → 0.1.0

## Test plan
- [x] CI build passes on all platforms
- [x] No breaking changes (version number only)