### PR TITLE
fix(version): sync version_info in common.h with CMake project version

### DIFF
--- a/include/kcenon/common/common.h
+++ b/include/kcenon/common/common.h
@@ -113,7 +113,7 @@ struct version_info {
     /// Major version - incremented for breaking changes
     static constexpr int major = 0;
     /// Minor version - incremented for new features
-    static constexpr int minor = 2;
+    static constexpr int minor = 1;
     /// Patch version - incremented for bug fixes
     static constexpr int patch = 0;
     /**
@@ -129,7 +129,7 @@ struct version_info {
      */
     static constexpr int tweak = 0;
     /// Version as human-readable string (MAJOR.MINOR.PATCH.TWEAK format)
-    static constexpr const char* string = "0.2.0.0";
+    static constexpr const char* string = "0.1.0.0";
 };
 
 } // namespace kcenon::common


### PR DESCRIPTION
## Summary
- Align `version_info` struct in `common.h` (was `0.2.0.0`) with CMake `project(VERSION 0.1.0.0)`
- The CMake project version is the canonical source of truth; `common.h` was ahead by one minor version
- Future improvement: generate `version_info` via `configure_file()` from CMake (tracked as follow-up in #392)

## Test plan
- [ ] CI builds pass on all platforms (Ubuntu, macOS, Windows)
- [ ] `version_info::string` returns `"0.1.0.0"` matching CMake project version
- [ ] `abi_version.h` (already CMake-generated) remains consistent
- [ ] No downstream compile failures from version check `static_assert`s

Closes #392