### PR TITLE
chore(docs): replace GIT_TAG main with pinned release tag in FetchContent examples

### DIFF
--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -575,7 +575,8 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
+    GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(common_system)
 target_link_libraries(my_app PRIVATE kcenon::common)

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -632,7 +632,8 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
+    GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(common_system)
 target_link_libraries(my_app PRIVATE kcenon::common)

--- a/docs/advanced/STRUCTURE.md
+++ b/docs/advanced/STRUCTURE.md
@@ -197,7 +197,8 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
+    GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(common_system)
 

--- a/docs/guides/MODULE_MIGRATION.kr.md
+++ b/docs/guides/MODULE_MIGRATION.kr.md
@@ -78,7 +78,8 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
+    GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(common_system)
 

--- a/docs/guides/MODULE_MIGRATION.md
+++ b/docs/guides/MODULE_MIGRATION.md
@@ -78,7 +78,8 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
+    GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(common_system)
 

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -34,7 +34,8 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
+    GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(common_system)
 


### PR DESCRIPTION
Closes #402

## Summary

- Replace `GIT_TAG main` with `GIT_TAG v0.1.0` in all FetchContent documentation examples
- Add `GIT_SHALLOW TRUE` to all examples for efficient shallow cloning
- Applies to 6 documentation files (EN and KR variants)

## Why

Using `main` as a `GIT_TAG` is a moving target:
- Breaks build reproducibility across CI runs
- Violates SOUP version traceability requirements (IEC 62304 §8.1.2)
- Any breaking change pushed to `main` cascades failures to all downstream consumers

## Files Modified

- `docs/guides/QUICK_START.md`
- `docs/advanced/STRUCTURE.md`
- `docs/PROJECT_STRUCTURE.md`
- `docs/guides/MODULE_MIGRATION.md`
- `docs/PROJECT_STRUCTURE.kr.md`
- `docs/guides/MODULE_MIGRATION.kr.md`

## Related Cross-Repo PRs

Companion cmake changes in downstream repos (same branch name `chore/issue-402-fetchcontent-tagged-releases`):
- **container_system**: Updates `UNIFIED_COMMON_SYSTEM_GIT_TAG` default from `"main"` to `"v0.1.0"` and adds CMake WARNING when `"main"` is used
- **logger_system**: Updates `unified_find_dependency()` default `GIT_TAG` from `"main"` to `"v0.1.0"` and adds CMake WARNING

## Note

This PR completes the documentation portion of #402. The cmake runtime enforcement
(container_system, logger_system) requires git release tags to be created first
(see #401). The default value `"v0.1.0"` matches the current project version in
`vcpkg.json` and `CMakeLists.txt`.

## Test Plan

- [ ] Verify all 6 documentation files no longer contain `GIT_TAG main`
- [ ] Confirm `GIT_SHALLOW TRUE` is present in all FetchContent examples
- [ ] Verify companion PRs in container_system and logger_system are consistent