### PR TITLE
docs: pin FetchContent examples to release tags

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -121,7 +121,7 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0
 )
 FetchContent_MakeAvailable(common_system)
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0
 )
 FetchContent_MakeAvailable(common_system)
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -122,14 +122,10 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/kcenon/common_system.git
   GIT_TAG        v0.1.0
 )
-
-# Avoid — non-reproducible
-FetchContent_Declare(
-  common_system
-  GIT_REPOSITORY https://github.com/kcenon/common_system.git
-  GIT_TAG        main
-)
 ```
+
+Avoid floating refs such as branch names in production or CI configurations,
+because they make builds non-reproducible.
 
 ### vcpkg Overlay Port
 

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -1174,7 +1174,7 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0
 )
 FetchContent_MakeAvailable(common_system)
 


### PR DESCRIPTION
## Summary
- pin the remaining top-level FetchContent examples in `README.md`, `README.kr.md`, and `docs/FEATURES.kr.md` from floating `main` to the released `v0.1.0` tag
- remove the contradictory `VERSIONING.md` example that still showed `GIT_TAG main`
- replace that example with explicit guidance to avoid floating refs in CI and production because they break reproducibility

## Changes
- update the English and Korean README FetchContent snippets to `GIT_TAG v0.1.0`
- update the Korean features document to match the released tag used elsewhere in the repository
- simplify `VERSIONING.md` so the tagged example remains the only code sample and the warning about branch refs is expressed as prose

## Verification
- searched the repository for remaining `GIT_TAG main` examples after the change and confirmed none remain in the modified top-level docs
- reviewed the four modified documents to confirm all top-level FetchContent guidance now matches the release workflow introduced for #401
- tests not run (documentation-only change)

Refs #401
