### PR TITLE
docs: update ecosystem release pin matrix

### DIFF
--- a/DEPENDENCY_MATRIX.md
+++ b/DEPENDENCY_MATRIX.md
@@ -157,16 +157,17 @@ All references must use tagged versions — never `main` branch. See [VERSIONING
 
 | Library | Latest Release | FetchContent GIT_TAG | vcpkg REF |
 |---------|---------------|----------------------|-----------|
-| common_system | — (pre-release) | `v0.1.0` (pending) | `v0.1.0` (pending) |
-| thread_system | — (pre-release) | `v0.1.0` (pending) | `v0.1.0` (pending) |
-| container_system | — (pre-release) | `v0.1.0` (pending) | `v0.1.0` (pending) |
-| logger_system | — (pre-release) | `v0.1.0` (pending) | `v0.1.0` (pending) |
-| monitoring_system | — (pre-release) | `v0.1.0` (pending) | `v0.1.0` (pending) |
-| database_system | — (pre-release) | `v0.1.0` (pending) | `v0.1.0` (pending) |
-| network_system | — (pre-release) | `v0.1.0` (pending) | `v0.1.0` (pending) |
+| common_system | `v0.1.0` | `v0.1.0` | `v0.1.0` |
+| thread_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
+| container_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
+| logger_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
+| monitoring_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
+| database_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
+| network_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
 
 > Update this table after each tagged release per [VERSIONING.md § Ecosystem Compatibility Matrix](./VERSIONING.md).
 > Tracking issue: [#401](https://github.com/kcenon/common_system/issues/401)
+> Verified against GitHub releases/tags on 2026-03-09 (Asia/Seoul).
 
 ## Maintenance
 


### PR DESCRIPTION
## Summary
- update `DEPENDENCY_MATRIX.md` after the published `common_system` `v0.1.0` release so the matrix points at a real tagged release instead of a placeholder
- replace downstream placeholder `v0.1.0` entries with `pending first tag` wording to avoid implying releases that do not exist yet
- record when the matrix was verified against GitHub releases and tags so the table remains auditable

## Changes
- set the `common_system` `Latest Release`, `FetchContent GIT_TAG`, and `vcpkg REF` columns to `v0.1.0`
- update the thread, container, logger, monitoring, database, and network rows to show `— (no release yet)` / `— (pending first tag)` instead of placeholder versions
- add a dated verification note below the table for the 2026-03-09 Asia/Seoul check

## Verification
- checked GitHub Releases for `common_system` and confirmed `v0.1.0` is published
- checked the current tag/release state for `thread_system`, `container_system`, `logger_system`, `monitoring_system`, `database_system`, and `network_system`
- reviewed the rendered `DEPENDENCY_MATRIX.md` table locally to confirm the updated wording is consistent

Refs #401
