### PR TITLE
docs(deps): mark fmt as deprecated in ecosystem SOUP documentation

### DIFF
--- a/DEPENDENCY_MATRIX.md
+++ b/DEPENDENCY_MATRIX.md
@@ -16,7 +16,7 @@ does not use that dependency.
 |-----------|---------|:------:|:------:|:------:|:---------:|:----------:|:--------:|:-------:|:------------------:|
 | GTest | BSD-3-Clause | 1.14.0 | 1.14.0 | 1.14.0 | 1.14.0 | 1.14.0 | 1.14.0 | 1.14.0 | **1.14.0** |
 | Benchmark | Apache-2.0 | 1.8.3 | 1.8.3 | 1.8.3 | 1.8.3 | — | 1.8.3 | 1.8.3 | **1.8.3** |
-| fmt | MIT | — | — | 10.2.1 | 10.2.1 | — | 10.2.1 | 10.2.1 | **10.2.1** (migrate to std::format) |
+| fmt | MIT | — | — | 10.2.1 | 10.2.1 | — | 10.2.1 | 10.2.1 | ~~**10.2.1**~~ (removing — see [#406](https://github.com/kcenon/common_system/issues/406)) |
 | ASIO | BSL-1.0 | — | — | — | — | — | 1.30.2 | 1.30.2 | **1.30.2** |
 | OpenSSL | Apache-2.0 | — | — | 3.3.0 | — | — | 3.3.0 | 3.3.0 | **3.3.0** |
 | zlib | zlib | — | — | — | — | — | — | 1.3.1 | **1.3.1** |
@@ -98,7 +98,7 @@ Issues identified during SBOM analysis that require resolution.
 | gRPC minimum differs in network_system | network_system requires >= 1.50.0, ecosystem standard is 1.51.1 | [network_system#792](https://github.com/kcenon/network_system/issues/792) |
 | ASIO minimum differs in database_system | database_system requires >= 1.29.0, override is 1.30.2 | [database_system#400](https://github.com/kcenon/database_system/issues/400) |
 | OpenSSL minimum differs in database_system | database_system requires >= 3.0.0, ecosystem standard is 3.3.0 | [database_system#402](https://github.com/kcenon/database_system/issues/402) |
-| fmt planned for removal | thread_system completed migration to std::format; 3 systems remain | [logger#457](https://github.com/kcenon/logger_system/issues/457), [database#399](https://github.com/kcenon/database_system/issues/399), [network#791](https://github.com/kcenon/network_system/issues/791) |
+| fmt planned for removal | thread_system completed migration to std::format; 3 systems remain | Epic: [#406](https://github.com/kcenon/common_system/issues/406) · [logger#457](https://github.com/kcenon/logger_system/issues/457) · [database#399](https://github.com/kcenon/database_system/issues/399) · [network#791](https://github.com/kcenon/network_system/issues/791) |
 | vcpkg baseline differs in thread_system | thread_system uses different vcpkg-configuration.json baseline | — |
 
 ## Ecosystem Internal Dependencies

--- a/docs/SOUP-LIST.md
+++ b/docs/SOUP-LIST.md
@@ -15,11 +15,14 @@ must be license-compatible with BSD-3-Clause.
 |---------|-----------|-----------|---------------|
 | common_system | kcenon/common_system | None | gtest, benchmark |
 | thread_system | kcenon/thread_system | libiconv | spdlog, gtest, benchmark |
-| network_system | kcenon/network_system | asio, fmt, zlib | openssl, gtest, benchmark |
-| logger_system | kcenon/logger_system | fmt | openssl, spdlog, opentelemetry-cpp, protobuf, grpc, gtest, benchmark |
-| container_system | kcenon/container_system | None | fmt, gtest, benchmark |
-| database_system | kcenon/database_system | fmt, asio | libmariadb, libpq, libpqxx, sqlite3, mongo-cxx-driver, hiredis, openssl, spdlog, gtest, benchmark |
+| network_system | kcenon/network_system | asio, ~~fmt~~†, zlib | openssl, gtest, benchmark |
+| logger_system | kcenon/logger_system | ~~fmt~~† | openssl, spdlog, opentelemetry-cpp, protobuf, grpc, gtest, benchmark |
+| container_system | kcenon/container_system | None | ~~fmt~~†, gtest, benchmark |
+| database_system | kcenon/database_system | ~~fmt~~†, asio | libmariadb, libpq, libpqxx, sqlite3, mongo-cxx-driver, hiredis, openssl, spdlog, gtest, benchmark |
 | monitoring_system | kcenon/monitoring_system | None | grpc, protobuf, gtest |
+
+> † **fmt** is being removed from the ecosystem in favour of C++20 `std::format`.
+> thread_system has completed migration. Remaining projects tracked in [#406](https://github.com/kcenon/common_system/issues/406).
 
 ## SOUP Catalog
 
@@ -124,7 +127,10 @@ features.
 Components whose failure causes reduced functionality but does not compromise
 core operations.
 
-#### fmt
+#### fmt *(Deprecated — removal in progress)*
+
+> **Migration Status**: thread_system completed. logger_system, database_system, and network_system
+> migration is in progress. Replacement: C++20 `std::format`. Tracking: [#406](https://github.com/kcenon/common_system/issues/406).
 
 | Field | Value |
 |-------|-------|
@@ -132,11 +138,12 @@ core operations.
 | SPDX License | MIT |
 | Minimum Version | 10.0.0 (network, logger, container), 10.2.1 (database) |
 | Projects | network_system (core), database_system (core), logger_system (core), container_system (fmt-support feature) |
-| Purpose | String formatting |
+| Purpose | String formatting (being replaced by C++20 `std::format`) |
 | Linking | Header-only or shared |
 | BSD-3 Compatible | Yes |
 | Risk Classification | **Medium** |
 | Anomaly Impact | Formatting errors → log corruption, display issues |
+| Deprecation | Scheduled for removal upon completion of [#406](https://github.com/kcenon/common_system/issues/406) |
 
 #### zlib
 


### PR DESCRIPTION
## Summary

Part of #406 — fmt → C++20 `std::format` migration Epic

Updates ecosystem-level documentation to reflect the ongoing fmt removal.
Code changes (actual fmt → std::format migration) are tracked in individual
repo sub-issues: logger_system#457, database_system#399, network_system#791.

## Changes

### DEPENDENCY_MATRIX.md
- Mark fmt Ecosystem Standard column with strikethrough and link to Epic #406
- Add `#406` epic link to Known Version Discrepancies tracking entry (alongside existing per-repo links)

### docs/SOUP-LIST.md
- Strike through `fmt` in the Ecosystem Overview table for all 4 remaining projects (network, logger, container, database) with a footnote explaining the migration
- Add a deprecation header and migration status callout block to the fmt SOUP catalog entry
- Add a `Deprecation` field pointing to Epic #406

## Why these files

`DEPENDENCY_MATRIX.md` and `SOUP-LIST.md` serve as the single source of truth for SOUP tracking (IEC 62304 §8.1.2). Auditors must be able to see:
- Which SOUP items are active vs. being removed
- Where to find the migration tracking
- Which projects have already completed the migration (thread_system ✅)

## Test Plan

- Verify markdown renders correctly on GitHub (strikethrough, footnotes, callout blocks)
- Confirm all links resolve to open issues in the correct repositories