### PR TITLE
docs(deps): extend dependency governance to pacs_system and pin yaml-cpp

### DIFF
--- a/DEPENDENCY_MATRIX.md
+++ b/DEPENDENCY_MATRIX.md
@@ -117,6 +117,8 @@ Tier 3: monitoring_system       -> common_system, thread_system
          database_system        -> common_system + DB backends
    |
 Tier 4: network_system          -> common_system, thread_system, container_system
+   |
+Tier 5: pacs_system             -> common_system, container_system, network_system
 ```
 
 ## vcpkg Baseline Tracking
@@ -164,6 +166,7 @@ All references must use tagged versions — never `main` branch. See [VERSIONING
 | monitoring_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
 | database_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
 | network_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
+| pacs_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
 
 > Update this table after each tagged release per [VERSIONING.md § Ecosystem Compatibility Matrix](./VERSIONING.md).
 > Tracking issue: [#401](https://github.com/kcenon/common_system/issues/401)

--- a/docs/SOUP-LIST.md
+++ b/docs/SOUP-LIST.md
@@ -13,7 +13,7 @@ must be license-compatible with BSD-3-Clause.
 
 | Project | Repository | Core SOUP | Optional SOUP |
 |---------|-----------|-----------|---------------|
-| common_system | kcenon/common_system | None | gtest, benchmark |
+| common_system | kcenon/common_system | None | yaml-cpp, gtest, benchmark |
 | thread_system | kcenon/thread_system | libiconv | spdlog, gtest, benchmark |
 | network_system | kcenon/network_system | asio, ~~fmt~~†, zlib | openssl, grpc, protobuf, gtest, benchmark |
 | logger_system | kcenon/logger_system | ~~fmt~~† | openssl, spdlog, opentelemetry-cpp, protobuf, grpc, gtest, benchmark |
@@ -245,6 +245,21 @@ Compatibility notes:
 ### Low Risk
 
 Components whose failure has minimal operational impact.
+
+#### yaml-cpp
+
+| Field | Value |
+|-------|-------|
+| Name | yaml-cpp |
+| SPDX License | MIT |
+| Minimum Version | 0.9.0 |
+| Projects | common_system (yaml config feature, optional) |
+| Purpose | YAML configuration file parsing |
+| Linking | Static or dynamic |
+| BSD-3 Compatible | Yes |
+| Risk Classification | **Low** |
+| Anomaly Impact | YAML config unavailable; fallback to other config methods |
+| Notes | Optional feature, gated by `BUILD_WITH_YAML_CPP` CMake option. Detected at build time via `find_package(yaml-cpp QUIET)`. |
 
 #### libiconv
 

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -29,7 +29,7 @@ common_system is a header-only/compiled C++20 foundation library with **no requi
 
 | ID | Name | Manufacturer | Version | License | Usage | Safety Class | Known Anomalies |
 |----|------|-------------|---------|---------|-------|-------------|-----------------|
-| SOUP-001 | [yaml-cpp](https://github.com/jbeder/yaml-cpp) | Jesse Beder | Latest | MIT | YAML configuration file parsing (optional feature, detected at build time) | A | None |
+| SOUP-001 | [yaml-cpp](https://github.com/jbeder/yaml-cpp) | Jesse Beder | 0.9.0 | MIT | YAML configuration file parsing (optional feature, detected at build time) | A | None |
 
 ---
 
@@ -39,7 +39,7 @@ common_system is a header-only/compiled C++20 foundation library with **no requi
 |----|------|-------------|---------|---------|-------|--------------|
 | SOUP-T01 | [Google Test](https://github.com/google/googletest) | Google | 1.14.0 | BSD-3-Clause | Unit testing framework (includes GMock) | Required |
 | SOUP-T02 | [Google Benchmark](https://github.com/google/benchmark) | Google | 1.8.3 | Apache-2.0 | Performance benchmarking framework | Not required |
-| SOUP-T03 | [Doxygen](https://www.doxygen.nl/) | Dimitri van Heesch | Latest | GPL-2.0 | API documentation generation (build tool only) | Not required |
+| SOUP-T03 | [Doxygen](https://www.doxygen.nl/) | Dimitri van Heesch | 1.16.1 | GPL-2.0 | API documentation generation (build tool only) | Not required |
 
 ---
 
@@ -69,6 +69,20 @@ All SOUP versions are pinned in `vcpkg.json` via the `overrides` field:
 The vcpkg baseline is locked in `vcpkg-configuration.json` to ensure reproducible builds.
 
 ---
+
+## Optional/Unpinned SOUP Policy
+
+All SOUP entries — including optional dependencies — **must** have a uniquely
+identifiable version. Using `Latest` or a branch name is not acceptable for
+IEC 62304 compliance.
+
+| Situation | Required Action |
+|-----------|-----------------|
+| Dependency pinned in `vcpkg.json` overrides | Use the pinned version string |
+| Dependency resolved via `find_package(... QUIET)` | Document the minimum tested version and the version used in CI |
+| Dependency not yet pinned | Mark as **"unresolved — not for production"** and create a tracking issue |
+
+Optional SOUP that cannot be version-pinned must not be enabled in production builds.
 
 ## Version Update Process
 


### PR DESCRIPTION
## Summary

- Add pacs_system as **Tier 5** in the ecosystem dependency graph (depends on common, container, network)
- Pin yaml-cpp version from `Latest` to `0.9.0` and Doxygen from `Latest` to `1.16.1` in SOUP.md
- Add yaml-cpp to SOUP-LIST.md catalog with full risk classification
- Add governance policy for optional/unpinned SOUP entries (no `Latest` allowed per IEC 62304)

## Rationale

The dependency matrix stopped at Tier 4 (network_system), omitting the product layer (pacs_system). Additionally, `Latest` is not a uniquely identifiable SOUP version per IEC 62304 §8.1.2 requirements.

## Test plan

- [x] CI passes (documentation-only changes)
- [x] DEPENDENCY_MATRIX.md tier graph includes Tier 5
- [x] No SOUP entry uses `Latest` as version

Closes #418