### PR TITLE
feat(release): add reusable release workflow and FetchContent pin checker

### DIFF
--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -1,0 +1,168 @@
+# Reusable Release Workflow Template
+#
+# This workflow can be called from other ecosystem repositories to standardize
+# the release process. It validates version consistency, builds, tests, and
+# publishes a GitHub Release with auto-generated changelog.
+#
+# Usage in another repository:
+#
+#   name: Release
+#   on:
+#     push:
+#       tags: ['v[0-9]+.[0-9]+.[0-9]+']
+#   jobs:
+#     release:
+#       uses: kcenon/common_system/.github/workflows/release-template.yml@main
+#       with:
+#         project-name: thread_system
+#       permissions:
+#         contents: write
+#
+# See: VERSIONING.md for the ecosystem versioning policy
+
+name: Reusable Release
+
+on:
+  workflow_call:
+    inputs:
+      project-name:
+        description: 'Name of the project (used in CMakeLists.txt project() call)'
+        required: true
+        type: string
+      cmake-build-type:
+        description: 'CMake build type'
+        required: false
+        type: string
+        default: 'Release'
+      build-tests:
+        description: 'Whether to build and run tests'
+        required: false
+        type: boolean
+        default: true
+      vcpkg-enabled:
+        description: 'Whether to use vcpkg for dependency management'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    name: Validate / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - os: ubuntu-22.04
+          - os: macos-latest
+          - os: windows-2022
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify version consistency
+        shell: bash
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CMAKE_VERSION=$(grep -m1 "project(${{ inputs.project-name }}" CMakeLists.txt | \
+            sed -E 's/.*VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          VCPKG_VERSION=$(grep '"version"' vcpkg.json | head -1 | \
+            sed -E 's/.*"version": "([^"]+)".*/\1/')
+
+          echo "Tag version:    $TAG_VERSION"
+          echo "CMake version:  $CMAKE_VERSION"
+          echo "vcpkg version:  $VCPKG_VERSION"
+
+          if [[ "$TAG_VERSION" != "$CMAKE_VERSION" ]]; then
+            echo "ERROR: Tag version ($TAG_VERSION) does not match CMakeLists.txt ($CMAKE_VERSION)"
+            exit 1
+          fi
+          if [[ "$TAG_VERSION" != "$VCPKG_VERSION" ]]; then
+            echo "ERROR: Tag version ($TAG_VERSION) does not match vcpkg.json ($VCPKG_VERSION)"
+            exit 1
+          fi
+          echo "Version consistency check passed: $TAG_VERSION"
+
+  publish:
+    name: Publish Release
+    needs: validate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Find previous tag
+        id: previous_tag
+        shell: bash
+        run: |
+          previous_tag=$(git describe --tags --abbrev=0 "${GITHUB_SHA}^" 2>/dev/null || true)
+          echo "tag=$previous_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog from conventional commits
+        id: changelog
+        if: steps.previous_tag.outputs.tag != ''
+        uses: requarks/changelog-action@v1
+        with:
+          token: ${{ github.token }}
+          fromTag: ${{ github.ref_name }}
+          toTag: ${{ steps.previous_tag.outputs.tag }}
+          writeToFile: false
+          useGitmojis: false
+
+      - name: Build release notes
+        shell: bash
+        env:
+          PREVIOUS_TAG: ${{ steps.previous_tag.outputs.tag }}
+          CHANGELOG: ${{ steps.changelog.outputs.changes }}
+          PROJECT_NAME: ${{ inputs.project-name }}
+        run: |
+          cat <<EOF > RELEASE_NOTES.md
+          ## ${PROJECT_NAME} ${GITHUB_REF_NAME}
+
+          ### Installation
+
+          **CMake FetchContent** — pin to this release:
+          \`\`\`cmake
+          FetchContent_Declare(
+            ${PROJECT_NAME}
+            GIT_REPOSITORY https://github.com/kcenon/${PROJECT_NAME}.git
+            GIT_TAG        ${GITHUB_REF_NAME}
+          )
+          \`\`\`
+          EOF
+
+          {
+            echo
+            echo "## Changelog"
+            echo
+            if [[ -n "$PREVIOUS_TAG" ]]; then
+              printf '%s\n' "$CHANGELOG"
+            else
+              echo "Initial release."
+            fi
+          } >> RELEASE_NOTES.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "${{ inputs.project-name }} ${{ github.ref_name }}"
+          body_path: RELEASE_NOTES.md
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -85,9 +85,31 @@ git push origin vX.Y.Z
 
 Pushing the tag automatically triggers the `release.yml` workflow, which:
 
-1. Validates version consistency across all three locations
+1. Validates version consistency across CMakeLists.txt, vcpkg.json, and Git tag
 2. Builds and tests on Ubuntu, macOS, and Windows
 3. Publishes a GitHub Release with auto-generated changelog from conventional commits
+
+### Reusable Release Workflow
+
+Ecosystem repositories can use the shared release workflow template instead of
+maintaining their own:
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+on:
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
+jobs:
+  release:
+    uses: kcenon/common_system/.github/workflows/release-template.yml@main
+    with:
+      project-name: <your_project_name>
+    permissions:
+      contents: write
+```
+
+See `.github/workflows/release-template.yml` for all available inputs.
 
 ### Step 4 — Verify the release
 

--- a/scripts/check_fetchcontent_pins.sh
+++ b/scripts/check_fetchcontent_pins.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# check_fetchcontent_pins.sh — Verify no FetchContent declaration uses branch refs
+#
+# Usage:
+#   ./scripts/check_fetchcontent_pins.sh [SEARCH_DIR]
+#
+# Scans CMakeLists.txt and *.cmake files for FetchContent_Declare blocks
+# that reference `main`, `master`, or `HEAD` in GIT_TAG — these produce
+# non-reproducible builds and violate the ecosystem versioning policy.
+#
+# See: VERSIONING.md § Consumer Guide
+
+set -euo pipefail
+
+SEARCH_DIR="${1:-.}"
+EXIT_CODE=0
+VIOLATIONS=()
+
+echo "Checking FetchContent GIT_TAG pins..."
+echo "Search directory: $SEARCH_DIR"
+echo ""
+
+# Find all CMake files
+while IFS= read -r cmake_file; do
+    # Look for GIT_TAG with branch names instead of version tags
+    while IFS= read -r line; do
+        line_num=$(echo "$line" | cut -d: -f1)
+        content=$(echo "$line" | cut -d: -f2-)
+
+        # Check for branch references
+        if echo "$content" | grep -qiE 'GIT_TAG\s+(main|master|HEAD|develop)\b'; then
+            VIOLATIONS+=("$cmake_file:$line_num: $content")
+            EXIT_CODE=1
+        fi
+    done < <(grep -n -i 'GIT_TAG' "$cmake_file" 2>/dev/null || true)
+done < <(find "$SEARCH_DIR" \( -name "CMakeLists.txt" -o -name "*.cmake" \) -not -path "*/build/*" -not -path "*/.git/*" 2>/dev/null)
+
+if [ ${#VIOLATIONS[@]} -gt 0 ]; then
+    echo "VIOLATIONS FOUND:"
+    echo ""
+    for v in "${VIOLATIONS[@]}"; do
+        echo "  $v"
+    done
+    echo ""
+    echo "FetchContent GIT_TAG must use versioned tags (e.g., v0.1.0), not branch names."
+    echo "See VERSIONING.md for the ecosystem versioning policy."
+else
+    echo "All FetchContent GIT_TAG references use versioned tags."
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

- Add `release-template.yml` reusable workflow for ecosystem-wide standardized releases
- Add `scripts/check_fetchcontent_pins.sh` to detect branch refs in FetchContent GIT_TAG
- Update VERSIONING.md with reusable workflow usage documentation

## Context

This is part of the ecosystem-wide semantic versioning initiative (#401). The reusable workflow lets all 7+ ecosystem repos share a single release pipeline (version validation → changelog → GitHub Release). The pin checker prevents non-reproducible builds from branch references.

## Reusable Workflow Usage

```yaml
jobs:
  release:
    uses: kcenon/common_system/.github/workflows/release-template.yml@main
    with:
      project-name: thread_system
```

## Test plan

- [x] CI passes — all completed checks pass, remaining queued
- [x] `check_fetchcontent_pins.sh` correctly flags `GIT_TAG main` patterns — verified locally
- [x] `release-template.yml` syntax validates (workflow_call trigger) — verified

Ref #401