### PR TITLE
chore(release): bump version to 0.2.0 for stable release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.28)
-project(common_system VERSION 0.1.0 LANGUAGES CXX)
+project(common_system VERSION 0.2.0 LANGUAGES CXX)
 
 # =============================================================================
 # BUILD ORDER DOCUMENTATION

--- a/DEPENDENCY_MATRIX.md
+++ b/DEPENDENCY_MATRIX.md
@@ -156,7 +156,7 @@ All references must use tagged versions — never `main` branch. See [VERSIONING
 
 | Library | Latest Release | FetchContent GIT_TAG | vcpkg REF |
 |---------|---------------|----------------------|-----------|
-| common_system | `v0.1.0` | `v0.1.0` | `v0.1.0` |
+| common_system | `v0.2.0` | `v0.2.0` | `v0.2.0` |
 | thread_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
 | container_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
 | logger_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
@@ -167,7 +167,7 @@ All references must use tagged versions — never `main` branch. See [VERSIONING
 
 > Update this table after each tagged release per [VERSIONING.md § Ecosystem Compatibility Matrix](./VERSIONING.md).
 > Tracking issue: [#401](https://github.com/kcenon/common_system/issues/401)
-> Verified against GitHub releases/tags on 2026-03-09 (Asia/Seoul).
+> Verified against GitHub releases/tags on 2026-03-11 (Asia/Seoul).
 
 ## Maintenance
 

--- a/README.kr.md
+++ b/README.kr.md
@@ -121,7 +121,7 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG v0.1.0
+    GIT_TAG v0.2.0
 )
 FetchContent_MakeAvailable(common_system)
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG v0.1.0
+    GIT_TAG v0.2.0
 )
 FetchContent_MakeAvailable(common_system)
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -142,7 +142,7 @@ Pin to a specific release tag rather than a branch:
 FetchContent_Declare(
   common_system
   GIT_REPOSITORY https://github.com/kcenon/common_system.git
-  GIT_TAG        v0.1.0
+  GIT_TAG        v0.2.0
 )
 ```
 
@@ -157,7 +157,7 @@ Update your overlay port's `portfile.cmake` to reference the tagged commit:
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcenon/common_system
-    REF v0.1.0
+    REF v0.2.0
     SHA512 <sha512-of-the-tag-archive>
     HEAD_REF main
 )
@@ -168,7 +168,7 @@ Regenerate the SHA512 hash after each version bump:
 ```bash
 vcpkg install --overlay-ports=./overlay-ports kcenon-common-system
 # Or compute manually:
-curl -sL https://github.com/kcenon/common_system/archive/refs/tags/v0.1.0.tar.gz | sha512sum
+curl -sL https://github.com/kcenon/common_system/archive/refs/tags/v0.2.0.tar.gz | sha512sum
 ```
 
 And update `vcpkg.json`:
@@ -176,7 +176,7 @@ And update `vcpkg.json`:
 ```json
 {
   "name": "kcenon-common-system",
-  "version": "0.1.0"
+  "version": "0.2.0"
 }
 ```
 
@@ -187,12 +187,12 @@ not permitted in production builds or CI release workflows.
 
 | Consumer | Depends on | Minimum Version |
 |----------|-----------|-----------------|
-| thread_system | common_system | v0.1.0 |
-| container_system | common_system | v0.1.0 |
-| logger_system | common_system | v0.1.0 |
-| monitoring_system | common_system | v0.1.0 |
-| database_system | common_system | v0.1.0 |
-| network_system | common_system | v0.1.0 |
+| thread_system | common_system | v0.2.0 |
+| container_system | common_system | v0.2.0 |
+| logger_system | common_system | v0.2.0 |
+| monitoring_system | common_system | v0.2.0 |
+| database_system | common_system | v0.2.0 |
+| network_system | common_system | v0.2.0 |
 
 Update this table in `DEPENDENCY_MATRIX.md` after each release that downstream projects
 adopt.

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -1161,7 +1161,7 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG v0.1.0
+    GIT_TAG v0.2.0
 )
 FetchContent_MakeAvailable(common_system)
 

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -575,7 +575,7 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
+    GIT_TAG v0.2.0  # Pin to a specific release tag; do NOT use main
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(common_system)

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -632,7 +632,7 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
+    GIT_TAG v0.2.0  # Pin to a specific release tag; do NOT use main
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(common_system)

--- a/docs/advanced/STRUCTURE.md
+++ b/docs/advanced/STRUCTURE.md
@@ -197,7 +197,7 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
+    GIT_TAG v0.2.0  # Pin to a specific release tag; do NOT use main
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(common_system)

--- a/docs/guides/MODULE_MIGRATION.kr.md
+++ b/docs/guides/MODULE_MIGRATION.kr.md
@@ -78,7 +78,7 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
+    GIT_TAG v0.2.0  # Pin to a specific release tag; do NOT use main
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(common_system)

--- a/docs/guides/MODULE_MIGRATION.md
+++ b/docs/guides/MODULE_MIGRATION.md
@@ -78,7 +78,7 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
+    GIT_TAG v0.2.0  # Pin to a specific release tag; do NOT use main
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(common_system)

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -34,7 +34,7 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
+    GIT_TAG v0.2.0  # Pin to a specific release tag; do NOT use main
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(common_system)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-common-system",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "port-version": 0,
   "description": "High-performance C++20 foundation library providing Result<T> pattern, interfaces, and common utilities",
   "homepage": "https://github.com/kcenon/common_system",


### PR DESCRIPTION
## Summary

- Bump project version from 0.1.0 to 0.2.0 in `CMakeLists.txt` and `vcpkg.json`
- Reconcile with vcpkg overlay port version (already at 0.2.0 in monitoring_system)
- Update all FetchContent `GIT_TAG` examples across 8 documentation files
- Update `DEPENDENCY_MATRIX.md` internal ecosystem version pinning table
- Update `VERSIONING.md` ecosystem compatibility matrix

### Changes since v0.1.0 (justifying MINOR bump)

- `feat(release)`: reusable release workflow and FetchContent pin checker
- `chore(deps)`: standardized on vcpkg-only package management (conan removed)
- `chore(ci)`: SOUP version drift detection
- `docs`: fmt removal finalized, transitive dependency documentation, SOUP-LIST updates
- Multiple CI dependency bumps (codeql-action, upload-artifact, scan-action)

Part of #401
Closes #428

## Test plan

- [x] Verify `CMakeLists.txt` version matches `vcpkg.json` version (both 0.2.0)
- [x] Verify release workflow version consistency check will pass with `v0.2.0` tag
- [x] Confirm all FetchContent examples reference `v0.2.0`