### PR TITLE
docs: upgrade Doxyfile to full-featured config and fix comment issues

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -4,19 +4,175 @@ PROJECT_NAME           = "common_system"
 PROJECT_NUMBER         = "1.0.0"
 PROJECT_BRIEF          = "Common interfaces and patterns for system integration"
 OUTPUT_DIRECTORY       = documents
-INPUT                  = include/kcenon/common
-FILE_PATTERNS          = *.h *.hpp *.cpp
-RECURSIVE              = YES
-EXTRACT_ALL            = YES
-GENERATE_HTML          = YES
-GENERATE_LATEX         = NO
-HTML_OUTPUT            = html
-WARN_IF_UNDOCUMENTED   = YES
-WARN_NO_PARAMDOC       = YES
+CREATE_SUBDIRS         = YES
+OUTPUT_LANGUAGE        = English
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
+                         is \
+                         provides \
+                         specifies \
+                         contains \
+                         represents \
+                         a \
+                         an \
+                         the
+ALWAYS_DETAILED_SEC    = NO
+INLINE_INHERITED_MEMB  = NO
+FULL_PATH_NAMES        = YES
+SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = YES
+MULTILINE_CPP_IS_BRIEF = YES
+INHERIT_DOCS           = YES
+SEPARATE_MEMBER_PAGES  = NO
+TAB_SIZE               = 4
+MARKDOWN_SUPPORT       = YES
+TOC_INCLUDE_HEADINGS   = 6
+AUTOLINK_SUPPORT       = YES
 BUILTIN_STL_SUPPORT    = YES
-GENERATE_TREEVIEW      = YES
-SEARCHENGINE           = YES
+SUBGROUPING            = YES
+NUM_PROC_THREADS       = 1
+TIMESTAMP              = YES
+
+# Extraction settings
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = YES
+EXTRACT_STATIC         = YES
+EXTRACT_LOCAL_CLASSES  = YES
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+CASE_SENSE_NAMES       = SYSTEM
+SHOW_INCLUDE_FILES     = YES
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = NO
+GENERATE_TODOLIST      = YES
+GENERATE_TESTLIST      = YES
+GENERATE_BUGLIST       = YES
+GENERATE_DEPRECATEDLIST= YES
+MAX_INITIALIZER_LINES  = 30
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
+
+# Warning settings
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = YES
+WARN_AS_ERROR          = NO
+WARN_FORMAT            = "$file:$line: $text"
+
+# Input settings
+INPUT                  = ./include/kcenon/common \
+                         ./src \
+                         ./README.md
+INPUT_ENCODING         = UTF-8
+FILE_PATTERNS          = *.c \
+                         *.cc \
+                         *.cxx \
+                         *.cpp \
+                         *.cppm \
+                         *.h \
+                         *.hh \
+                         *.hpp \
+                         *.tpp \
+                         *.md
+RECURSIVE              = YES
+EXCLUDE                = ./build \
+                         ./build_test \
+                         ./vcpkg \
+                         ./vcpkg_installed \
+                         ./documents
+EXCLUDE_SYMLINKS       = NO
+EXCLUDE_PATTERNS       = */CMakeFiles/* \
+                         */.git/* \
+                         */node_modules/* \
+                         */build/* \
+                         */test/*
+EXAMPLE_PATH           = ./examples
+EXAMPLE_PATTERNS       = *.cpp \
+                         *.h
+EXAMPLE_RECURSIVE      = YES
+USE_MDFILE_AS_MAINPAGE = README.md
+
+# Source browsing
 SOURCE_BROWSER         = YES
+INLINE_SOURCES         = YES
+STRIP_CODE_COMMENTS    = YES
+REFERENCED_BY_RELATION = YES
+REFERENCES_RELATION    = YES
+REFERENCES_LINK_SOURCE = YES
+SOURCE_TOOLTIPS        = YES
+VERBATIM_HEADERS       = YES
+
+# Index
+ALPHABETICAL_INDEX     = YES
+
+# HTML output
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+HTML_FILE_EXTENSION    = .html
+HTML_COLORSTYLE        = AUTO_LIGHT
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_DYNAMIC_MENUS     = YES
+HTML_CODE_FOLDING      = YES
+HTML_INDEX_NUM_ENTRIES = 100
+DISABLE_INDEX          = NO
+GENERATE_TREEVIEW      = YES
+FULL_SIDEBAR           = NO
+ENUM_VALUES_PER_LINE   = 4
+TREEVIEW_WIDTH         = 250
+SEARCHENGINE           = YES
+
+# Other output formats (disabled)
+GENERATE_LATEX         = NO
+GENERATE_RTF           = NO
+GENERATE_MAN           = NO
+GENERATE_XML           = NO
+GENERATE_DOCBOOK       = NO
+
+# Preprocessing
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = NO
+SEARCH_INCLUDES        = YES
+INCLUDE_PATH           = ./include/kcenon/common
+INCLUDE_FILE_PATTERNS  = *.h \
+                         *.hpp
 PREDEFINED             = BUILD_WITH_COMMON_SYSTEM
-EXCLUDE_PATTERNS       = */build/* */test/* */.git/*
+SKIP_FUNCTION_MACROS   = YES
+
+# External references
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+EXTERNAL_PAGES         = YES
+
+# Graph generation (requires dot from Graphviz)
+HIDE_UNDOC_RELATIONS   = YES
+HAVE_DOT               = YES
+DOT_NUM_THREADS        = 0
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+UML_LOOK               = YES
+UML_LIMIT_NUM_FIELDS   = 10
+DOT_WRAP_THRESHOLD     = 17
+TEMPLATE_RELATIONS     = YES
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = YES
+CALLER_GRAPH           = YES
+GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
+DOT_IMAGE_FORMAT       = png
+INTERACTIVE_SVG        = NO
+DOT_GRAPH_MAX_NODES    = 50
+MAX_DOT_GRAPH_DEPTH    = 0
+GENERATE_LEGEND        = YES
+DOT_CLEANUP            = YES

--- a/include/kcenon/common/interfaces/executor_interface.h
+++ b/include/kcenon/common/interfaces/executor_interface.h
@@ -59,12 +59,8 @@ public:
  * This interface defines the contract for any task executor implementation,
  * allowing modules to work with different threading backends without
  * direct dependencies.
- */
-/**
- * @class IExecutor
- * @brief Abstract interface for task execution systems.
  *
- * Phase 2: Extended with job-based execution support
+ * Extended with job-based execution support for better control and testability.
  */
 class IExecutor {
 public:
@@ -119,20 +115,13 @@ public:
 };
 
 /**
- * @brief Factory function type for creating executor instances
- */
-/**
- * @brief Factory function to create executor instances.
+ * @brief Factory function type for creating executor instances.
  */
 using ExecutorFactory = std::function<std::shared_ptr<IExecutor>()>;
 
 /**
  * @interface IExecutorProvider
- * @brief Interface for modules that provide executor implementations
- */
-/**
- * @class IExecutorProvider
- * @brief Provider for obtaining executor implementations.
+ * @brief Interface for modules that provide executor implementations.
  */
 class IExecutorProvider {
 public:

--- a/include/kcenon/common/utils/object_pool.h
+++ b/include/kcenon/common/utils/object_pool.h
@@ -36,6 +36,10 @@ class ObjectPool {
 public:
     using value_type = T;
 
+    /**
+     * @brief Construct an object pool with the specified growth factor.
+     * @param growth Number of objects to pre-allocate per expansion (minimum 1).
+     */
     explicit ObjectPool(std::size_t growth = 32)
         : growth_(growth == 0 ? 1 : growth) {}
 


### PR DESCRIPTION
## Summary
- Upgrade Doxyfile from minimal 23-line config to comprehensive ~170-line setup based on database_system template
- Enable graph generation, C++20 module support, source browsing, and cross-references
- Fix duplicate Doxygen comment blocks in `executor_interface.h`
- Add missing `@param` documentation to `ObjectPool` constructor

## Test plan
- [ ] Run `doxygen Doxyfile` and verify no new warnings
- [ ] Verify HTML output includes class graphs and call graphs
- [ ] Verify README.md appears as the documentation mainpage
- [ ] Verify `.cppm` files are included in documentation output

Closes #438