### PR TITLE
chore(release): add build/test validation to reusable release template

### DIFF
--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -15,6 +15,8 @@
 #       uses: kcenon/common_system/.github/workflows/release-template.yml@main
 #       with:
 #         project-name: thread_system
+#         cmake-configure-options: >-
+#           -DTHREAD_BUILD_TESTS=ON
 #       permissions:
 #         contents: write
 #
@@ -35,7 +37,7 @@ on:
         type: string
         default: 'Release'
       build-tests:
-        description: 'Whether to build and run tests'
+        description: 'Whether to build and run tests during validation'
         required: false
         type: boolean
         default: true
@@ -44,6 +46,11 @@ on:
         required: false
         type: boolean
         default: true
+      cmake-configure-options:
+        description: 'Additional CMake configure options (e.g., -DFOO_BUILD_TESTS=ON)'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write
@@ -90,6 +97,52 @@ jobs:
             exit 1
           fi
           echo "Version consistency check passed: $TAG_VERSION"
+
+      - name: Install Ninja (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+      - name: Install Ninja (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ninja
+
+      - name: Set up MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Set up vcpkg
+        if: inputs.vcpkg-enabled
+        uses: lukka/run-vcpkg@v11
+
+      - name: Configure CMake
+        shell: bash
+        run: |
+          cmake_args=(-B build -G Ninja)
+          cmake_args+=(-DCMAKE_BUILD_TYPE=${{ inputs.cmake-build-type }})
+          if [[ "${{ inputs.vcpkg-enabled }}" == "true" ]]; then
+            cmake_args+=(-DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake")
+          fi
+          cmake "${cmake_args[@]}" ${{ inputs.cmake-configure-options }}
+
+      - name: Build
+        shell: bash
+        run: cmake --build build --config ${{ inputs.cmake-build-type }}
+
+      - name: Test
+        if: inputs.build-tests
+        shell: bash
+        run: |
+          cd build
+          ctest -C ${{ inputs.cmake-build-type }} --output-on-failure
+
+      - name: Upload build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-validate-${{ matrix.os }}-logs
+          path: |
+            build/CMakeFiles/*.log
+            build/Testing/Temporary/
 
   publish:
     name: Publish Release

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -105,11 +105,25 @@ jobs:
     uses: kcenon/common_system/.github/workflows/release-template.yml@main
     with:
       project-name: <your_project_name>
+      cmake-configure-options: >-
+        -D<YOUR_PROJECT>_BUILD_TESTS=ON
     permissions:
       contents: write
 ```
 
-See `.github/workflows/release-template.yml` for all available inputs.
+#### Available Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `project-name` | *(required)* | Name matching `project()` in CMakeLists.txt |
+| `cmake-build-type` | `Release` | CMake build type |
+| `build-tests` | `true` | Run tests during release validation |
+| `vcpkg-enabled` | `true` | Use vcpkg for dependency management |
+| `cmake-configure-options` | `''` | Additional CMake flags (e.g., `-DFOO=ON`) |
+
+The template validates version consistency, builds on Ubuntu/macOS/Windows, runs
+tests, and publishes a GitHub Release with auto-generated changelog — all controlled
+by the inputs above.
 
 ### Step 4 — Verify the release
 


### PR DESCRIPTION
Closes #440
Part of #401

## Summary

- Add CMake build/test validation steps to `release-template.yml` validate job
- Add `cmake-configure-options` input for project-specific CMake flags
- Set up vcpkg via `lukka/run-vcpkg@v11` when `vcpkg-enabled` is true
- Upload build logs as artifacts on failure for debugging
- Update VERSIONING.md with available template input documentation

## What

The reusable release workflow template defined input parameters (`build-tests`,
`vcpkg-enabled`, `cmake-build-type`) but did not use them — the validate job only
checked version consistency without building or testing. This meant downstream
repositories using the template would publish releases without build verification.

### Changes

| File | Change |
|------|--------|
| `.github/workflows/release-template.yml` | Add build/test steps, vcpkg setup, new input |
| `VERSIONING.md` | Document available template inputs |

## Why

- Downstream repos using the template get no build verification before release publish
- The main `release.yml` includes full build/test but the reusable template does not
- Input parameters existed but were unused — confusing for adopters

## How

### Validate Job Enhancement

1. Install Ninja (Linux/macOS) and set up MSVC (Windows)
2. Set up vcpkg via `lukka/run-vcpkg@v11` (conditional on `vcpkg-enabled`)
3. Configure CMake with toolchain file and custom options
4. Build on all three platforms
5. Run tests when `build-tests` is true
6. Upload build logs on failure

### New Input: `cmake-configure-options`

Allows each downstream repo to pass project-specific CMake flags:

```yaml
uses: kcenon/common_system/.github/workflows/release-template.yml@main
with:
  project-name: thread_system
  cmake-configure-options: >-
    -DTHREAD_BUILD_TESTS=ON
```

## Test Plan

- [ ] YAML syntax validation passes (verified locally with `pyyaml`)
- [ ] Workflow file is valid GitHub Actions syntax
- [ ] CI checks pass on this PR
- [ ] Template can be consumed by downstream repos (manual verification after merge)