### PR TITLE
fix(cmake): add install rule for generated abi_version.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,12 @@ install(DIRECTORY include/
     FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
 )
 
+# Install generated abi_version.h (produced by configure_file, lives in build tree)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/include/kcenon/common/config/abi_version.h"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon/common/config
+)
+
 # Install CMake config files
 install(TARGETS common_system
     EXPORT common_systemTargets


### PR DESCRIPTION
## Summary

- Add explicit `install(FILES ...)` rule for the `configure_file`-generated `abi_version.h` header
- The existing `install(DIRECTORY include/ ...)` only copies from the source tree, missing the build-tree generated header
- Downstream vcpkg consumers can now `#include <kcenon/common/config/abi_version.h>` after installation

## Test plan

- [ ] Verify `abi_version.h` is present in the install tree under `include/kcenon/common/config/`
- [ ] Verify `vcpkg install kcenon-common-system` succeeds with the header accessible
- [ ] Verify existing install behavior for source-tree headers is unchanged

Closes #442