### PR TITLE
docs(deps): update container_system to v0.1.0 in dependency matrix

### DIFF
--- a/DEPENDENCY_MATRIX.md
+++ b/DEPENDENCY_MATRIX.md
@@ -158,7 +158,7 @@ All references must use tagged versions — never `main` branch. See [VERSIONING
 |---------|---------------|----------------------|-----------|
 | common_system | `v0.2.0` | `v0.2.0` | `v0.2.0` |
 | thread_system | `v0.3.0` | `v0.3.0` | `v0.3.0` |
-| container_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
+| container_system | `v0.1.0` | `v0.1.0` | `v0.1.0` |
 | logger_system | `v0.1.0` | `v0.1.0` | `v0.1.0` |
 | monitoring_system | `v0.1.0` | `v0.1.0` | `v0.1.0` |
 | database_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
@@ -167,7 +167,7 @@ All references must use tagged versions — never `main` branch. See [VERSIONING
 
 > Update this table after each tagged release per [VERSIONING.md § Ecosystem Compatibility Matrix](./VERSIONING.md).
 > Tracking issue: [#401](https://github.com/kcenon/common_system/issues/401)
-> Verified against GitHub releases/tags on 2026-03-13 (Asia/Seoul).
+> Verified against GitHub releases/tags on 2026-03-14 (Asia/Seoul).
 
 ## Maintenance
 


### PR DESCRIPTION
Closes kcenon/container_system#418

## Summary

- Update DEPENDENCY_MATRIX.md to reflect `container_system v0.1.0` release
- container_system v0.1.0 was tagged and released with successful builds on all 3 platforms (Ubuntu, macOS ARM64, Windows x64)
- Part of ecosystem-wide versioning initiative ([#401](https://github.com/kcenon/common_system/issues/401))

## Changes

| Before | After |
|--------|-------|
| `— (no release yet)` | `v0.1.0` |

## Verification Done

- [x] Git tag `v0.1.0` exists at commit `0fee107c`
- [x] GitHub Release published with auto-generated changelog
- [x] Release workflow passed: macOS ARM64, Windows x64, Linux x64
- [x] Version consistency: CMakeLists.txt (0.1.0) = vcpkg.json (0.1.0)

## Test Plan

- [ ] Verify DEPENDENCY_MATRIX.md renders correctly on GitHub