### PR TITLE
docs(deps): update database_system to v0.1.0 in dependency matrix

### DIFF
--- a/DEPENDENCY_MATRIX.md
+++ b/DEPENDENCY_MATRIX.md
@@ -161,7 +161,7 @@ All references must use tagged versions — never `main` branch. See [VERSIONING
 | container_system | `v0.1.0` | `v0.1.0` | `v0.1.0` |
 | logger_system | `v0.1.0` | `v0.1.0` | `v0.1.0` |
 | monitoring_system | `v0.1.0` | `v0.1.0` | `v0.1.0` |
-| database_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
+| database_system | `v0.1.0` | `v0.1.0` | `v0.1.0` |
 | network_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
 | pacs_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
 


### PR DESCRIPTION
Ref: kcenon/database_system#443

## Summary

- Update DEPENDENCY_MATRIX.md to reflect `database_system v0.1.0` release
- database_system v0.1.0 was tagged and released with successful builds on all 3 platforms
- Part of ecosystem-wide versioning initiative ([#401](https://github.com/kcenon/common_system/issues/401))

## Verification Done

- [x] Git tag `v0.1.0` exists
- [x] GitHub Release published with changelog and platform artifacts
- [x] Release workflow passed: Linux x64, macOS ARM64, Windows x64
- [x] Version consistency: CMakeLists.txt (0.1.0) = vcpkg.json (0.1.0)

## Test Plan

- [ ] Verify DEPENDENCY_MATRIX.md renders correctly on GitHub