### PR TITLE
docs(deps): update network_system version pin to v0.1.0

### DIFF
--- a/DEPENDENCY_MATRIX.md
+++ b/DEPENDENCY_MATRIX.md
@@ -162,7 +162,7 @@ All references must use tagged versions — never `main` branch. See [VERSIONING
 | logger_system | `v0.1.0` | `v0.1.0` | `v0.1.0` |
 | monitoring_system | `v0.1.0` | `v0.1.0` | `v0.1.0` |
 | database_system | `v0.1.0` | `v0.1.0` | `v0.1.0` |
-| network_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
+| network_system | `v0.1.0` | `v0.1.0` | `v0.1.0` |
 | pacs_system | — (no release yet) | — (pending first tag) | — (pending first tag) |
 
 > Update this table after each tagged release per [VERSIONING.md § Ecosystem Compatibility Matrix](./VERSIONING.md).


### PR DESCRIPTION
Closes #447

## Summary

- Update `network_system` row in DEPENDENCY_MATRIX.md from "no release yet" to `v0.1.0`
- `network_system v0.1.0` was released on 2026-03-14 but the version pinning table was not updated

## Test Plan

- [ ] Verify DEPENDENCY_MATRIX.md table renders correctly on GitHub
- [ ] Confirm `network_system v0.1.0` tag exists: `gh release view v0.1.0 --repo kcenon/network_system`