### PR TITLE
chore(cmake): Standardize export naming (kcenon:: -> common_system::)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ endif()
 # Create interface library (header-only by default)
 add_library(common_system INTERFACE)
 add_library(kcenon::common ALIAS common_system)
+add_library(common_system::common_system ALIAS common_system)
 
 # Set include directories
 target_include_directories(common_system INTERFACE
@@ -262,16 +263,16 @@ install(FILES
 
 # Install CMake config files
 install(TARGETS common_system
-    EXPORT common_systemTargets
+    EXPORT common_system-targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-install(EXPORT common_systemTargets
-    FILE common_systemTargets.cmake
-    NAMESPACE kcenon::
+install(EXPORT common_system-targets
+    FILE common_system-targets.cmake
+    NAMESPACE common_system::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/common_system
 )
 
@@ -299,9 +300,9 @@ install(FILES
 )
 
 # Export for build tree
-export(EXPORT common_systemTargets
-    FILE "${CMAKE_CURRENT_BINARY_DIR}/common_systemTargets.cmake"
-    NAMESPACE kcenon::
+export(EXPORT common_system-targets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/common_system-targets.cmake"
+    NAMESPACE common_system::
 )
 
 # Tests

--- a/cmake/common_systemConfig.cmake.in
+++ b/cmake/common_systemConfig.cmake.in
@@ -1,9 +1,26 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/common_systemTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/common_system-targets.cmake")
 
 # Include feature flags configuration module
 include("${CMAKE_CURRENT_LIST_DIR}/features.cmake")
+
+# Backward compatibility: provide kcenon:: namespace targets for existing consumers.
+# Installed targets are IMPORTED, so we use INTERFACE libraries to forward properties.
+if(TARGET common_system::common_system AND NOT TARGET kcenon::common_system)
+    add_library(kcenon::common_system INTERFACE IMPORTED)
+    set_target_properties(kcenon::common_system PROPERTIES
+        INTERFACE_LINK_LIBRARIES common_system::common_system
+    )
+endif()
+
+# Legacy short alias (kcenon::common) used by some downstream projects
+if(TARGET common_system::common_system AND NOT TARGET kcenon::common)
+    add_library(kcenon::common INTERFACE IMPORTED)
+    set_target_properties(kcenon::common PROPERTIES
+        INTERFACE_LINK_LIBRARIES common_system::common_system
+    )
+endif()
 
 # Provide old-style variables for compatibility
 set(common_system_FOUND TRUE)


### PR DESCRIPTION
## What

Standardize CMake export naming to match ecosystem conventions:
- Export name: `common_systemTargets` -> `common_system-targets`
- Namespace: `kcenon::` -> `common_system::`
- Export file: `common_systemTargets.cmake` -> `common_system-targets.cmake`

## Why

The `kcenon::` namespace is generic and does not match the package name. The ecosystem convention is `<package_name>::` with snake_case, so `common_system::` is the correct namespace for this package. The export name also lacked a separator (`common_systemTargets`), now uses the standard hyphenated form (`common_system-targets`).

Closes #457
Part of #456

## Where

| File | Change |
|------|--------|
| `CMakeLists.txt` | Updated `install(EXPORT)` and `export(EXPORT)` to use new name/namespace; added `common_system::common_system` build-tree alias |
| `cmake/common_systemConfig.cmake.in` | Updated include path; added backward compatibility INTERFACE IMPORTED targets for `kcenon::common_system` and `kcenon::common` |

## How

### Backward Compatibility

Existing consumers using `kcenon::common_system` or `kcenon::common` via `find_package(common_system)` will continue to work. The config file creates INTERFACE IMPORTED libraries that forward `INTERFACE_LINK_LIBRARIES` to the new `common_system::common_system` target.

The build-tree alias `kcenon::common` is preserved alongside the new `common_system::common_system` alias so internal tests/examples continue to compile unchanged.

### Test Plan

- [ ] CI build passes (verifies build-tree aliases work for tests/examples/benchmarks)
- [ ] Verify installed `common_system-targets.cmake` is generated with `common_system::` namespace
- [ ] Verify downstream consumers using `kcenon::common_system` or `kcenon::common` still link correctly after install