### PR TITLE
docs: standardize Doxyfile and README for vcpkg deployment

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -23,7 +23,8 @@ ALWAYS_DETAILED_SEC    = NO
 INLINE_INHERITED_MEMB  = NO
 FULL_PATH_NAMES        = YES
 SHORT_NAMES            = NO
-JAVADOC_AUTOBRIEF      = YES
+JAVADOC_AUTOBRIEF      = NO
+QT_AUTOBRIEF           = NO
 MULTILINE_CPP_IS_BRIEF = YES
 INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
@@ -34,7 +35,8 @@ AUTOLINK_SUPPORT       = YES
 BUILTIN_STL_SUPPORT    = YES
 SUBGROUPING            = YES
 NUM_PROC_THREADS       = 1
-TIMESTAMP              = YES
+TIMESTAMP              = NO
+HTML_TIMESTAMP         = NO
 
 # Extraction settings
 EXTRACT_ALL            = YES
@@ -64,6 +66,7 @@ WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
 WARN_NO_PARAMDOC       = YES
 WARN_AS_ERROR          = NO
+WARN_IF_INCOMPLETE_DOC = YES
 WARN_FORMAT            = "$file:$line: $text"
 
 # Input settings
@@ -92,6 +95,9 @@ EXCLUDE_PATTERNS       = */CMakeFiles/* \
                          */.git/* \
                          */node_modules/* \
                          */build/* \
+                         */build_*/* \
+                         */vcpkg*/* \
+                         */_deps/* \
                          */test/*
 EXAMPLE_PATH           = ./examples
 EXAMPLE_PATTERNS       = *.cpp \
@@ -145,7 +151,9 @@ SEARCH_INCLUDES        = YES
 INCLUDE_PATH           = ./include/kcenon/common
 INCLUDE_FILE_PATTERNS  = *.h \
                          *.hpp
-PREDEFINED             = BUILD_WITH_COMMON_SYSTEM
+PREDEFINED             = BUILD_WITH_COMMON_SYSTEM \
+                         COMMON_SYSTEM_EXPORT= \
+                         COMMON_SYSTEM_API=
 SKIP_FUNCTION_MACROS   = YES
 
 # External references
@@ -176,3 +184,4 @@ DOT_GRAPH_MAX_NODES    = 50
 MAX_DOT_GRAPH_DEPTH    = 0
 GENERATE_LEGEND        = YES
 DOT_CLEANUP            = YES
+DOT_PATH               =

--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ When using multiple systems together, use the **highest** requirement from your 
 
 ## Installation
 
+### Installation via vcpkg
+
+```bash
+vcpkg install kcenon-common-system
+```
+
+In your `CMakeLists.txt`:
+```cmake
+find_package(common_system CONFIG REQUIRED)
+target_link_libraries(your_target PRIVATE kcenon::common_system)
+```
+
 ### Option 1: Header-Only Usage (Simplest)
 
 ```bash


### PR DESCRIPTION
## What

### Summary
- Standardize Doxyfile settings for reproducible, vcpkg-compatible documentation builds
- Add vcpkg installation instructions to README Quick Start section
- Harden EXCLUDE_PATTERNS and PREDEFINED macros for clean Doxygen output

### Change Type
- [x] Documentation

## Why

### Related Issues
- Closes #464
- Part of #463

### Motivation
The Doxyfile and README need updates to support vcpkg deployment. Timestamps cause non-reproducible builds, export macros confuse Doxygen parsing, and users need vcpkg install instructions.

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `Doxyfile` | Standardize settings for reproducible builds and vcpkg compatibility |
| `README.md` | Add vcpkg installation subsection |

### Key Doxyfile Changes
- `TIMESTAMP=NO`, `HTML_TIMESTAMP=NO` for reproducible output
- `JAVADOC_AUTOBRIEF=NO`, `QT_AUTOBRIEF=NO` for explicit `@brief` requirement
- `WARN_IF_INCOMPLETE_DOC=YES` for stricter doc warnings
- `PREDEFINED` expanded with `COMMON_SYSTEM_EXPORT=` and `COMMON_SYSTEM_API=`
- `EXCLUDE_PATTERNS` extended with `*/build_*/*`, `*/vcpkg*/*`, `*/_deps/*`
- `DOT_PATH` explicitly declared empty

## How

### Testing
- [x] Verified Doxyfile syntax is valid
- [x] Verified README markdown renders correctly

### Breaking Changes
None