### PR TITLE
docs(doxyfile): Add ecosystem-standard ALIASES

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -156,6 +156,9 @@ PREDEFINED             = BUILD_WITH_COMMON_SYSTEM \
                          COMMON_SYSTEM_API=
 SKIP_FUNCTION_MACROS   = YES
 
+ALIASES                = "thread_safety=@par Thread Safety:^^" \
+                         "performance=@par Performance:^^"
+
 # External references
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES


### PR DESCRIPTION
## What

### Summary
Add `@thread_safety` and `@performance` custom ALIASES to Doxyfile, aligning with the ecosystem standard established by monitoring_system.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Part of kcenon/common_system#472

### Motivation
Custom ALIASES enable consistent cross-referencing of thread safety guarantees and performance characteristics in API documentation across all 8 ecosystem libraries.

## How

### Implementation Details
Added two ALIASES entries matching monitoring_system's existing configuration:
- `@thread_safety` - Documents thread safety guarantees
- `@performance` - Documents performance characteristics

### Test Plan
- [ ] Doxygen build succeeds (`build-Doxygen.yaml` workflow)
- [ ] No new warnings in Doxygen output