### PR TITLE
docs(doxygen): Add @code examples to public API headers

### DIFF
--- a/include/kcenon/common/interfaces/executor_interface.h
+++ b/include/kcenon/common/interfaces/executor_interface.h
@@ -61,6 +61,16 @@ public:
  * direct dependencies.
  *
  * Extended with job-based execution support for better control and testability.
+ *
+ * @code
+ * // Submit a task to an executor
+ * std::shared_ptr<IExecutor> executor = provider->get_executor();
+ * executor->execute([] { std::cout << "Hello from thread pool\n"; });
+ *
+ * // Submit a delayed task
+ * executor->execute_delayed(std::chrono::seconds(5),
+ *     [] { std::cout << "Delayed task\n"; });
+ * @endcode
  */
 class IExecutor {
 public:

--- a/include/kcenon/common/patterns/event_bus.h
+++ b/include/kcenon/common/patterns/event_bus.h
@@ -158,6 +158,22 @@ namespace detail {
      * subscription management and event dispatch.
      *
      * Note: This implementation avoids RTTI by using template-based type IDs.
+     *
+     * @code
+     * simple_event_bus bus;
+     *
+     * // Subscribe to an event type
+     * auto id = bus.subscribe<events::module_started_event>(
+     *     [](const events::module_started_event& e) {
+     *         std::cout << "Module started: " << e.module_name << "\n";
+     *     });
+     *
+     * // Publish an event
+     * bus.publish(events::module_started_event{"network_system"});
+     *
+     * // Unsubscribe when done
+     * bus.unsubscribe(id);
+     * @endcode
      */
     class simple_event_bus {
     public:


### PR DESCRIPTION
## What

### Summary
Add @code usage examples to core public API headers for improved Doxygen documentation.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Part of kcenon/common_system#476

### Motivation
API documentation without inline examples forces users to read source code or tests. @code blocks in Doxygen comments serve as inline tutorials directly in the generated docs.

## How

### Test Plan
- [ ] Doxygen build succeeds without warnings
- [ ] Code examples render correctly in generated HTML docs