### PR TITLE
chore(vcpkg): remove redundant overrides from vcpkg-configuration.json

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -13,12 +13,5 @@
         "kcenon-*"
       ]
     }
-  ],
-  "overrides": [
-    {
-      "name": "gtest",
-      "version": "1.14.0",
-      "port-version": 1
-    }
   ]
 }


### PR DESCRIPTION
## What

### Summary
Remove the redundant `overrides` section from `vcpkg-configuration.json` to align with the ecosystem convention of declaring overrides exclusively in `vcpkg.json`.

### Change Type
- [x] Chore (configuration cleanup)

## Why

### Related Issues
- Closes #482

### Motivation
common_system is the only repo (out of 8) that declares overrides in both `vcpkg.json` and `vcpkg-configuration.json`. When present in both, `vcpkg-configuration.json` takes precedence, making the `vcpkg.json` overrides misleading. The `vcpkg-configuration.json` version also included `"port-version": 1` which was absent from `vcpkg.json`, creating subtle inconsistency.

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `vcpkg-configuration.json` | Remove `overrides` section |

## How

### What Was Removed

```json
"overrides": [
    {
        "name": "gtest",
        "version": "1.14.0",
        "port-version": 1
    }
]
```

### What Remains (in vcpkg.json, unchanged)

```json
"overrides": [
    { "name": "gtest", "version": "1.14.0" },
    { "name": "benchmark", "version": "1.8.3" }
]
```

### Testing Done
- [x] Verified all 7 other repos use overrides only in vcpkg.json
- [x] gtest version pin remains via vcpkg.json overrides