### PR TITLE
perf(object-pool): replace std::function deleter with zero-overhead typed struct

### DIFF
--- a/benchmarks/object_pool_benchmark.cpp
+++ b/benchmarks/object_pool_benchmark.cpp
@@ -134,7 +134,7 @@ static void BM_ObjectPoolBatchAcquire(benchmark::State& state) {
     const int batch_size = state.range(0);
 
     for (auto _ : state) {
-        std::vector<std::unique_ptr<SimpleObject, std::function<void(SimpleObject*)>>> objects;
+        std::vector<ObjectPool<SimpleObject>::pointer_type> objects;
         objects.reserve(batch_size);
 
         for (int i = 0; i < batch_size; ++i) {
@@ -169,7 +169,7 @@ static void BM_ObjectPoolGrowth(benchmark::State& state) {
 
     const int total_acquires = 1000;
     for (auto _ : state) {
-        std::vector<std::unique_ptr<SimpleObject, std::function<void(SimpleObject*)>>> objects;
+        std::vector<ObjectPool<SimpleObject>::pointer_type> objects;
         objects.reserve(total_acquires);
 
         for (int i = 0; i < total_acquires; ++i) {

--- a/include/kcenon/common/utils/object_pool.h
+++ b/include/kcenon/common/utils/object_pool.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <cstddef>
-#include <functional>
 #include <memory>
 #include <mutex>
 #include <stack>
@@ -32,9 +31,30 @@ struct RawDelete {
  * storage is retained for fast reuse.
  */
 template<typename T>
+class ObjectPool;
+
+/**
+ * @brief Zero-overhead deleter for ObjectPool-managed objects.
+ *
+ * Replaces std::function<void(T*)> to avoid the heap allocation
+ * that std::function requires for type-erased callables.
+ */
+template<typename T>
+struct PoolDeleter {
+    ObjectPool<T>* pool = nullptr;
+    void operator()(T* ptr) const noexcept {
+        if (pool) {
+            pool->release(ptr);
+        }
+    }
+};
+
+template<typename T>
 class ObjectPool {
 public:
     using value_type = T;
+    using deleter_type = PoolDeleter<T>;
+    using pointer_type = std::unique_ptr<T, deleter_type>;
 
     /**
      * @brief Construct an object pool with the specified growth factor.
@@ -50,7 +70,7 @@ public:
      * @return A unique_ptr to the acquired object with a custom deleter that returns it to the pool.
      */
     template<typename... Args>
-    std::unique_ptr<T, std::function<void(T*)>> acquire(bool* reused, Args&&... args) {
+    pointer_type acquire(bool* reused, Args&&... args) {
         T* raw = nullptr;
         bool reused_local = false;
         {
@@ -70,13 +90,11 @@ public:
         }
 
         new (raw) T(std::forward<Args>(args)...);
-        return std::unique_ptr<T, std::function<void(T*)>>(raw, [this](T* ptr) {
-            this->release(ptr);
-        });
+        return pointer_type(raw, deleter_type{this});
     }
 
     template<typename... Args>
-    std::unique_ptr<T, std::function<void(T*)>> acquire(Args&&... args) {
+    pointer_type acquire(Args&&... args) {
         return acquire(static_cast<bool*>(nullptr), std::forward<Args>(args)...);
     }
 

--- a/integration_tests/performance/memory_pressure_test.cpp
+++ b/integration_tests/performance/memory_pressure_test.cpp
@@ -64,7 +64,7 @@ TEST_F(MemoryPressureTest, ObjectPoolExhaustion) {
     ObjectPool<ExpensiveObject> pool(4);
 
     // Acquire all pre-allocated objects
-    std::vector<std::unique_ptr<ExpensiveObject, std::function<void(ExpensiveObject*)>>> acquired;
+    std::vector<ObjectPool<ExpensiveObject>::pointer_type> acquired;
 
     // Acquire more than initial capacity to trigger growth
     const size_t acquire_count = 20;
@@ -92,7 +92,7 @@ TEST_F(MemoryPressureTest, ObjectPoolRecovery) {
     const size_t objects_per_cycle = 10;
 
     for (int cycle = 0; cycle < cycles; ++cycle) {
-        std::vector<std::unique_ptr<ExpensiveObject, std::function<void(ExpensiveObject*)>>> batch;
+        std::vector<ObjectPool<ExpensiveObject>::pointer_type> batch;
 
         for (size_t i = 0; i < objects_per_cycle; ++i) {
             bool reused = false;
@@ -119,7 +119,7 @@ TEST_F(MemoryPressureTest, ObjectPoolFragmentation) {
     ObjectPool<ExpensiveObject> pool(16);
 
     // Simulate fragmentation: acquire/release in random patterns
-    std::vector<std::unique_ptr<ExpensiveObject, std::function<void(ExpensiveObject*)>>> held;
+    std::vector<ObjectPool<ExpensiveObject>::pointer_type> held;
 
     for (int i = 0; i < 100; ++i) {
         // Acquire some

--- a/integration_tests/stress/stress_test.cpp
+++ b/integration_tests/stress/stress_test.cpp
@@ -347,7 +347,7 @@ TEST_F(SustainedLoadTest, MemoryStabilityOverTime) {
     const int batch_size = 100;
 
     for (int i = 0; i < iterations; ++i) {
-        std::vector<std::unique_ptr<StressEvent, std::function<void(StressEvent*)>>> batch;
+        std::vector<ObjectPool<StressEvent>::pointer_type> batch;
 
         // Acquire batch
         for (int j = 0; j < batch_size; ++j) {
@@ -498,7 +498,7 @@ TEST_F(BurstTrafficTest, ObjectPoolBurst) {
     const int burst_count = 20;
 
     for (int burst = 0; burst < burst_count; ++burst) {
-        std::vector<std::unique_ptr<StressEvent, std::function<void(StressEvent*)>>> batch;
+        std::vector<ObjectPool<StressEvent>::pointer_type> batch;
 
         // Acquire burst
         for (int i = 0; i < burst_size; ++i) {

--- a/tests/object_pool_test.cpp
+++ b/tests/object_pool_test.cpp
@@ -188,7 +188,7 @@ TEST(ObjectPoolTest, ClearRemovesAll) {
 
 TEST(ObjectPoolTest, AcquireMultipleObjects) {
     ObjectPool<SimpleObj> pool(4);
-    std::vector<std::unique_ptr<SimpleObj, std::function<void(SimpleObj*)>>> objects;
+    std::vector<ObjectPool<SimpleObj>::pointer_type> objects;
 
     for (int i = 0; i < 10; ++i) {
         objects.push_back(pool.acquire(i));
@@ -202,7 +202,7 @@ TEST(ObjectPoolTest, UniqueAddressesForConcurrentObjects) {
     ObjectPool<SimpleObj> pool(8);
     std::set<SimpleObj*> addresses;
 
-    std::vector<std::unique_ptr<SimpleObj, std::function<void(SimpleObj*)>>> objects;
+    std::vector<ObjectPool<SimpleObj>::pointer_type> objects;
     for (int i = 0; i < 8; ++i) {
         auto obj = pool.acquire(i);
         addresses.insert(obj.get());


### PR DESCRIPTION
## What

### Summary
Replace `std::function<void(T*)>` deleter in `ObjectPool::acquire()` with a zero-overhead
typed `PoolDeleter<T>` struct to eliminate per-acquisition heap allocations.

### Change Type
- [x] Performance improvement (bug fix — pool negated its own purpose)

### Affected Components
- `include/kcenon/common/utils/object_pool.h` — New `PoolDeleter<T>` struct, updated return types
- `tests/object_pool_test.cpp` — Updated explicit type references
- `benchmarks/object_pool_benchmark.cpp` — Updated explicit type references
- `integration_tests/` — Updated explicit type references

## Why

### Problem Solved
`ObjectPool::acquire()` returned `std::unique_ptr<T, std::function<void(T*)>>`. Each
`std::function` wrapping a lambda that captures `this` causes a **heap allocation per call** —
the exact allocation the pool was designed to avoid. The new `PoolDeleter<T>` struct stores
only a raw pointer to the pool, making `sizeof(pointer_type) == sizeof(T*) + sizeof(ObjectPool*)`.

### Related Issues
- Closes #484

## How

### Implementation Details
1. Added `PoolDeleter<T>` struct with `ObjectPool<T>*` member and `operator()(T*)` 
2. Added `pointer_type` and `deleter_type` type aliases to `ObjectPool<T>`
3. Replaced `std::function` return types with `pointer_type` in both `acquire()` overloads
4. Removed `<functional>` include (no longer needed in this header)
5. Updated all callers referencing the old explicit type across tests, benchmarks, and integration tests

### Testing Done
- [x] All 19 ObjectPool unit tests pass
- [x] Build succeeds with no warnings

### Breaking Changes
Callers that explicitly spell out `std::unique_ptr<T, std::function<void(T*)>>` must update to
`ObjectPool<T>::pointer_type` or use `auto`. This affects downstream repos (e.g., logger_system's
`high_performance_async_writer.cpp:25`).