### PR TITLE
chore(ci): add codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,53 @@
+# Codecov Configuration for common_system
+# https://docs.codecov.com/docs/codecovyml-reference
+
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "40...80"
+  status:
+    project:
+      default:
+        target: 40%
+        threshold: 2%
+        if_ci_failed: error
+    patch:
+      default:
+        target: 60%
+        threshold: 5%
+        if_ci_failed: error
+
+# Gradual improvement plan:
+# - Phase 1 (Current): 40% project, 60% patch
+# - Phase 2: 50% project, 70% patch
+# - Phase 3: 60% project, 80% patch
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+ignore:
+  - "tests/**/*"
+  - "benchmarks/**/*"
+  - "examples/**/*"
+  - "integration_tests/**/*"
+  - "sanitizers/**/*"
+  - "docs/**/*"
+  - "build/**/*"
+  - "build_*/**/*"
+  - "build-*/**/*"
+  - "schemas/**/*"
+  - "cmake/**/*"
+  - "scripts/**/*"
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
## Summary
- Add codecov.yml with initial coverage thresholds (40% project, 60% patch) and ignore paths for non-source directories
- Follows the same pattern used across thread_system and monitoring_system
- common_system was the only system (besides pacs_system) missing this configuration

## Test plan
- [ ] Verify codecov.yml is picked up by Codecov on next coverage report upload
- [ ] Confirm coverage thresholds are applied correctly to PRs