### PR TITLE
perf(circular-buffer): add lock-free SPSC variant

### DIFF
--- a/include/kcenon/common/utils/circular_buffer.h
+++ b/include/kcenon/common/utils/circular_buffer.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <mutex>
 #include <optional>
@@ -95,6 +96,95 @@ private:
     std::size_t head_{0};
     std::size_t tail_{0};
     std::size_t size_{0};
+};
+
+/**
+ * @brief Lock-free circular buffer for single-producer single-consumer (SPSC).
+ *
+ * Uses std::atomic head/tail with acquire/release ordering. No mutex is needed
+ * because only the producer modifies tail_ and only the consumer modifies head_.
+ * Capacity must be > 0. One slot is reserved to distinguish full from empty,
+ * so the usable capacity is exactly Capacity elements.
+ */
+template<typename T, std::size_t Capacity>
+class SPSCCircularBuffer {
+    static_assert(Capacity > 0, "SPSCCircularBuffer capacity must be greater than zero");
+
+public:
+    SPSCCircularBuffer() = default;
+
+    /**
+     * @brief Push a value (producer thread only).
+     * @return true if pushed, false if full.
+     */
+    bool push(const T& value) {
+        const auto tail = tail_.load(std::memory_order_relaxed);
+        const auto next_tail = advance(tail);
+        if (next_tail == head_.load(std::memory_order_acquire)) {
+            return false; // full
+        }
+        buffer_[tail] = value;
+        tail_.store(next_tail, std::memory_order_release);
+        return true;
+    }
+
+    bool push(T&& value) {
+        const auto tail = tail_.load(std::memory_order_relaxed);
+        const auto next_tail = advance(tail);
+        if (next_tail == head_.load(std::memory_order_acquire)) {
+            return false; // full
+        }
+        buffer_[tail] = std::move(value);
+        tail_.store(next_tail, std::memory_order_release);
+        return true;
+    }
+
+    /**
+     * @brief Pop a value (consumer thread only).
+     * @return The value if available, std::nullopt if empty.
+     */
+    [[nodiscard]] std::optional<T> pop() {
+        const auto head = head_.load(std::memory_order_relaxed);
+        if (head == tail_.load(std::memory_order_acquire)) {
+            return std::nullopt; // empty
+        }
+        auto value = std::move(buffer_[head]);
+        head_.store(advance(head), std::memory_order_release);
+        return value;
+    }
+
+    [[nodiscard]] bool empty() const noexcept {
+        return head_.load(std::memory_order_acquire)
+            == tail_.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] bool full() const noexcept {
+        return advance(tail_.load(std::memory_order_acquire))
+            == head_.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] std::size_t size() const noexcept {
+        const auto head = head_.load(std::memory_order_acquire);
+        const auto tail = tail_.load(std::memory_order_acquire);
+        if (tail >= head) {
+            return tail - head;
+        }
+        return (Capacity + 1) - head + tail;
+    }
+
+    [[nodiscard]] constexpr std::size_t capacity() const noexcept {
+        return Capacity;
+    }
+
+private:
+    static std::size_t advance(std::size_t index) noexcept {
+        return (index + 1) % (Capacity + 1);
+    }
+
+    // Internal buffer has Capacity+1 slots to distinguish full from empty
+    std::array<T, Capacity + 1> buffer_{};
+    alignas(64) std::atomic<std::size_t> head_{0};
+    alignas(64) std::atomic<std::size_t> tail_{0};
 };
 
 } // namespace kcenon::common::utils

--- a/tests/circular_buffer_test.cpp
+++ b/tests/circular_buffer_test.cpp
@@ -259,3 +259,112 @@ TEST(CircularBufferTest, WithStrings) {
     EXPECT_EQ(buf.size(), 3u);
     EXPECT_EQ(buf.pop().value(), "alpha");
 }
+
+// =============================================================================
+// SPSCCircularBuffer tests
+// =============================================================================
+
+TEST(SPSCCircularBufferTest, DefaultConstructionIsEmpty) {
+    SPSCCircularBuffer<int, 8> buf;
+    EXPECT_TRUE(buf.empty());
+    EXPECT_FALSE(buf.full());
+    EXPECT_EQ(buf.size(), 0u);
+    EXPECT_EQ(buf.capacity(), 8u);
+}
+
+TEST(SPSCCircularBufferTest, PushPopFifo) {
+    SPSCCircularBuffer<int, 4> buf;
+    EXPECT_TRUE(buf.push(1));
+    EXPECT_TRUE(buf.push(2));
+    EXPECT_TRUE(buf.push(3));
+    EXPECT_EQ(buf.size(), 3u);
+
+    EXPECT_EQ(buf.pop().value(), 1);
+    EXPECT_EQ(buf.pop().value(), 2);
+    EXPECT_EQ(buf.pop().value(), 3);
+    EXPECT_TRUE(buf.empty());
+}
+
+TEST(SPSCCircularBufferTest, PopOnEmptyReturnsNullopt) {
+    SPSCCircularBuffer<int, 4> buf;
+    EXPECT_FALSE(buf.pop().has_value());
+}
+
+TEST(SPSCCircularBufferTest, FillToCapacity) {
+    SPSCCircularBuffer<int, 3> buf;
+    EXPECT_TRUE(buf.push(1));
+    EXPECT_TRUE(buf.push(2));
+    EXPECT_TRUE(buf.push(3));
+    EXPECT_TRUE(buf.full());
+    EXPECT_FALSE(buf.push(4)); // full, no overwrite
+}
+
+TEST(SPSCCircularBufferTest, WraparoundMaintainsFifo) {
+    SPSCCircularBuffer<int, 3> buf;
+    buf.push(1);
+    buf.push(2);
+    buf.push(3);
+    EXPECT_EQ(buf.pop().value(), 1);
+    EXPECT_EQ(buf.pop().value(), 2);
+    buf.push(4);
+    buf.push(5);
+    EXPECT_EQ(buf.pop().value(), 3);
+    EXPECT_EQ(buf.pop().value(), 4);
+    EXPECT_EQ(buf.pop().value(), 5);
+    EXPECT_TRUE(buf.empty());
+}
+
+TEST(SPSCCircularBufferTest, MoveSemantics) {
+    SPSCCircularBuffer<std::string, 4> buf;
+    std::string s = "hello";
+    buf.push(std::move(s));
+    EXPECT_EQ(buf.pop().value(), "hello");
+}
+
+TEST(SPSCCircularBufferTest, CopyPush) {
+    SPSCCircularBuffer<std::string, 4> buf;
+    const std::string s = "world";
+    buf.push(s);
+    EXPECT_EQ(buf.pop().value(), "world");
+    EXPECT_EQ(s, "world");
+}
+
+TEST(SPSCCircularBufferTest, CapacityOfOne) {
+    SPSCCircularBuffer<int, 1> buf;
+    EXPECT_EQ(buf.capacity(), 1u);
+    EXPECT_TRUE(buf.push(42));
+    EXPECT_TRUE(buf.full());
+    EXPECT_FALSE(buf.push(99));
+    EXPECT_EQ(buf.pop().value(), 42);
+    EXPECT_TRUE(buf.empty());
+}
+
+TEST(SPSCCircularBufferTest, ConcurrentProducerConsumer) {
+    SPSCCircularBuffer<int, 256> buf;
+    const int count = 100000;
+    std::atomic<bool> done{false};
+
+    std::thread producer([&]() {
+        for (int i = 0; i < count; ++i) {
+            while (!buf.push(i)) {
+                // spin until space available
+            }
+        }
+        done.store(true, std::memory_order_release);
+    });
+
+    std::thread consumer([&]() {
+        int expected = 0;
+        while (expected < count) {
+            auto val = buf.pop();
+            if (val.has_value()) {
+                EXPECT_EQ(val.value(), expected);
+                ++expected;
+            }
+        }
+    });
+
+    producer.join();
+    consumer.join();
+    EXPECT_TRUE(buf.empty());
+}


### PR DESCRIPTION
## Summary

- Add `SPSCCircularBuffer<T, Capacity>` class for lock-free single-producer single-consumer scenarios
- Uses `std::atomic<size_t>` head/tail with acquire/release ordering instead of mutex
- Cache-line aligned (`alignas(64)`) head/tail to prevent false sharing
- Existing `CircularBuffer` class is unchanged

## Why

The mutex-based `CircularBuffer` has unnecessary synchronization overhead for SPSC use cases (e.g., logger batch processor queue, event pipelines). Lock-free SPSC eliminates mutex contention entirely.

Closes #485

## Test plan

- [x] 9 new unit tests added (basic ops, wraparound, move semantics, capacity-of-one, concurrent stress)
- [x] All 26 tests pass locally (17 existing + 9 new)
- [ ] CI passes on all platforms