### PR TITLE
fix(resilience): remove const_cast from circuit_breaker::get_stats

### DIFF
--- a/include/kcenon/common/resilience/circuit_breaker.h
+++ b/include/kcenon/common/resilience/circuit_breaker.h
@@ -226,7 +226,7 @@ public:
         std::lock_guard<std::mutex> lock(mutex_);
 
         const auto current_state = state_.load(std::memory_order_acquire);
-        const auto failure_count = const_cast<failure_window&>(failure_window_).get_failure_count();
+        const auto failure_count = failure_window_.get_failure_count();
 
         return {
             {"current_state", to_string(current_state)},

--- a/include/kcenon/common/resilience/failure_window.h
+++ b/include/kcenon/common/resilience/failure_window.h
@@ -59,7 +59,7 @@ public:
      * Removes expired failures before counting.
      * @return Number of failures within the time window
      */
-    [[nodiscard]] auto get_failure_count() -> std::size_t
+    [[nodiscard]] auto get_failure_count() const -> std::size_t
     {
         std::lock_guard<std::mutex> lock(mutex_);
         cleanup_expired_failures();
@@ -91,7 +91,7 @@ private:
      * @brief Remove failures outside the time window.
      * Must be called with mutex locked.
      */
-    auto cleanup_expired_failures() -> void
+    auto cleanup_expired_failures() const -> void
     {
         const auto now = clock_type::now();
         const auto cutoff = now - window_duration_;
@@ -104,8 +104,8 @@ private:
     }
 
     duration window_duration_;
-    std::deque<time_point> failures_;
-    std::mutex mutex_;
+    mutable std::deque<time_point> failures_;
+    mutable std::mutex mutex_;
 };
 
 } // namespace kcenon::common::resilience


### PR DESCRIPTION
## What

Fixes const-correctness in `circuit_breaker::get_stats()` by making `failure_window` members properly mutable, eliminating the `const_cast` workaround.

## Why

Fixes #492 -- `get_stats()` used `const_cast<failure_window&>` to call `get_failure_count()` on a const member. This is a code smell that masks a legitimate design issue: `failure_window` internally mutates (cleanup of expired entries) even during read operations, which is a valid use case for `mutable`.

## How

- `failure_window.h`: Added `mutable` to `failures_` deque and `mutex_`; marked `get_failure_count()` and `cleanup_expired_failures()` as `const`
- `circuit_breaker.h`: Removed `const_cast`, calling `get_failure_count()` directly on the const member