### PR TITLE
fix(di): return error from service_container::clear() when frozen (#494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Remove `const_cast` in `circuit_breaker::get_stats()` by making `failure_window` methods const-correct ([#492](https://github.com/kcenon/common_system/issues/492))
+- Return error from `service_container::clear()` when container is frozen ([#494](https://github.com/kcenon/common_system/issues/494))
 
 ### Changed
 

--- a/include/kcenon/common/concepts/container.h
+++ b/include/kcenon/common/concepts/container.h
@@ -155,7 +155,7 @@ concept ResizableContainer = Container<T> && requires(T t, std::size_t n) {
  */
 template<typename T>
 concept ClearableContainer = Container<T> && requires(T t) {
-    { t.clear() } -> std::same_as<void>;
+    { t.clear() };
 };
 
 /**

--- a/include/kcenon/common/concepts/service.h
+++ b/include/kcenon/common/concepts/service.h
@@ -137,7 +137,7 @@ template<typename T>
 concept ServiceContainerLike = requires(T t) {
     { t.create_scope() };
     { t.registered_services() };
-    { t.clear() } -> std::same_as<void>;
+    { t.clear() };
 };
 
 /**

--- a/include/kcenon/common/di/service_container.h
+++ b/include/kcenon/common/di/service_container.h
@@ -107,8 +107,9 @@ public:
 
     /**
      * @brief Clear all registrations.
+     * @return VoidResult - error if the container is frozen, ok otherwise
      */
-    void clear() override;
+    VoidResult clear() override;
 
     // ===== Security Controls =====
 
@@ -313,7 +314,7 @@ public:
 
     std::unique_ptr<IServiceScope> create_scope() override;
     std::vector<service_descriptor> registered_services() const override;
-    void clear() override;
+    VoidResult clear() override;
 
 protected:
     VoidResult register_factory_internal(
@@ -372,14 +373,17 @@ inline std::vector<service_descriptor> service_container::registered_services() 
     return result;
 }
 
-inline void service_container::clear() {
+inline VoidResult service_container::clear() {
     if (is_frozen()) {
         interfaces::RegistryAuditLog::log_event(interfaces::registry_event(
             interfaces::registry_action::clear_services, "",
             interfaces::source_location::current(), false,
             "Container is frozen"));
-        // Silently ignore clear when frozen to maintain API compatibility
-        return;
+        return make_error<std::monostate>(
+            error_codes::REGISTRY_FROZEN,
+            "Cannot clear services: container is frozen",
+            "di::service_container"
+        );
     }
 
     std::unique_lock lock(mutex_);
@@ -388,6 +392,8 @@ inline void service_container::clear() {
     interfaces::RegistryAuditLog::log_event(interfaces::registry_event(
         interfaces::registry_action::clear_services, "",
         interfaces::source_location::current(), true));
+
+    return VoidResult::ok({});
 }
 
 inline void service_container::freeze() {
@@ -757,9 +763,10 @@ inline std::vector<service_descriptor> service_scope::registered_services() cons
     return parent_.registered_services();
 }
 
-inline void service_scope::clear() {
+inline VoidResult service_scope::clear() {
     std::unique_lock lock(mutex_);
     scoped_instances_.clear();
+    return VoidResult::ok({});
 }
 
 inline VoidResult service_scope::register_factory_internal(

--- a/include/kcenon/common/di/service_container_interface.h
+++ b/include/kcenon/common/di/service_container_interface.h
@@ -397,8 +397,10 @@ public:
      *
      * Removes all service registrations. Existing resolved instances remain
      * valid but no services can be resolved after this call.
+     *
+     * @return VoidResult - error if the container is frozen, ok otherwise
      */
-    virtual void clear() = 0;
+    virtual VoidResult clear() = 0;
 
 protected:
     // Internal type-erased methods for implementation

--- a/tests/security_controls_test.cpp
+++ b/tests/security_controls_test.cpp
@@ -271,8 +271,10 @@ TEST_F(ServiceContainerFreezeTest, FreezePreventsClear) {
 
     container_->freeze();
 
-    // Clear should silently fail when frozen
-    container_->clear();
+    // Clear should return error when frozen
+    auto result = container_->clear();
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, error_codes::REGISTRY_FROZEN);
 
     // Service should still be registered
     EXPECT_TRUE(container_->is_registered<ITestService>());


### PR DESCRIPTION
## What

### Summary
Changes `service_container::clear()` to return `VoidResult` with an error when the container is frozen, instead of silently ignoring the call. This makes `clear()` consistent with other frozen-state operations like `register_type()` which already return errors.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `include/kcenon/common/di/service_container_interface.h` — Interface updated
- `include/kcenon/common/di/service_container.h` — Implementation updated
- `include/kcenon/common/concepts/service.h` — Concept constraint relaxed
- `include/kcenon/common/concepts/container.h` — Concept constraint relaxed
- `tests/security_controls_test.cpp` — Test updated to verify error return

## Why

### Problem Solved
`service_container::clear()` silently ignored calls when the container was frozen, which could hide bugs — callers had no way to detect that their clear request was not executed.

### Related Issues
- Closes #494

### Alternatives Considered
- Throwing an exception: Rejected for consistency with other frozen-state operations that use `VoidResult`

## How

### Implementation Details
1. Changed `IServiceContainer::clear()` return type from `void` to `VoidResult`
2. `service_container::clear()` returns `REGISTRY_FROZEN` error when frozen, matching `check_frozen_for_registration` pattern
3. `service_scope::clear()` returns `VoidResult::ok({})` (scopes are not subject to freeze)
4. Relaxed `ClearableContainer` and `ServiceContainerLike` concepts to not require `void` return type

### Testing Done
- [x] Updated `FreezePreventsClear` test to verify error code is `REGISTRY_FROZEN`

### Breaking Changes
- `IServiceContainer::clear()` return type changed from `void` to `VoidResult`
- Callers ignoring the return value will still compile (no `[[nodiscard]]`)