### PR TITLE
chore: add local vcpkg portfile for registry synchronization

### DIFF
--- a/vcpkg-ports/kcenon-common-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-common-system/portfile.cmake
@@ -1,0 +1,33 @@
+# kcenon-common-system portfile
+# High-performance C++20 foundation library (header-only)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kcenon/common_system
+    REF "v${VERSION}"
+    SHA512 7385ba3a073fea06604f71a7ffc016425408c768444cec2ec897537411926a7e1fad99f7215e6724b3668a6e227f0716dbdcdda462764f5c4e52709087751e26
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCOMMON_BUILD_TESTS=OFF
+        -DCOMMON_BUILD_INTEGRATION_TESTS=OFF
+        -DCOMMON_BUILD_EXAMPLES=OFF
+        -DCOMMON_BUILD_BENCHMARKS=OFF
+        -DCOMMON_BUILD_DOCS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME common_system
+    CONFIG_PATH lib/cmake/common_system
+)
+
+# Header-only library - remove all debug content and empty lib directories
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-ports/kcenon-common-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-common-system/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "kcenon-common-system",
+  "version": "0.2.0",
+  "port-version": 0,
+  "description": "High-performance C++20 foundation library providing Result<T> pattern, interfaces, and common utilities",
+  "homepage": "https://github.com/kcenon/common_system",
+  "license": "BSD-3-Clause",
+  "supports": "!(uwp | xbox)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `vcpkg-ports/kcenon-common-system/` with `portfile.cmake` and `vcpkg.json` mirroring the canonical vcpkg-registry

## Rationale

Standardize portfile management (Strategy B: local + registry sync) across the ecosystem, following the pattern already established by `monitoring_system`. Local portfiles enable atomic source+port changes and CI validation.

## Test plan

- [ ] Verify portfile matches the canonical registry version
- [ ] CI builds pass without regression

Ref: kcenon/vcpkg-registry#36