### PR TITLE
Add conditional find_dependency(yaml-cpp) to config template

### DIFF
--- a/cmake/common_systemConfig.cmake.in
+++ b/cmake/common_systemConfig.cmake.in
@@ -1,5 +1,14 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
+# Optional dependency: yaml-cpp (when built with BUILD_WITH_YAML_CPP=ON)
+set(_COMMON_WITH_YAML_CPP @BUILD_WITH_YAML_CPP@)
+if(_COMMON_WITH_YAML_CPP)
+    find_dependency(yaml-cpp CONFIG REQUIRED)
+endif()
+unset(_COMMON_WITH_YAML_CPP)
+
 include("${CMAKE_CURRENT_LIST_DIR}/common_system-targets.cmake")
 
 # Include feature flags configuration module


### PR DESCRIPTION
## Summary
- Add `find_dependency(yaml-cpp CONFIG REQUIRED)` to `common_systemConfig.cmake.in` when `BUILD_WITH_YAML_CPP=ON`
- Place before `include(targets.cmake)` so yaml-cpp::yaml-cpp is available when imported targets are loaded

## Test plan
- [ ] Build with `-DBUILD_WITH_YAML_CPP=ON` and verify installed config finds yaml-cpp
- [ ] Build with default settings (OFF) and verify no yaml-cpp dependency is introduced

Closes #501