### PR TITLE
fix(version): sync version_info in common.h with project version 0.2.0

### DIFF
--- a/include/kcenon/common/common.h
+++ b/include/kcenon/common/common.h
@@ -113,7 +113,7 @@ struct version_info {
     /// Major version - incremented for breaking changes
     static constexpr int major = 0;
     /// Minor version - incremented for new features
-    static constexpr int minor = 1;
+    static constexpr int minor = 2;
     /// Patch version - incremented for bug fixes
     static constexpr int patch = 0;
     /**
@@ -129,7 +129,7 @@ struct version_info {
      */
     static constexpr int tweak = 0;
     /// Version as human-readable string (MAJOR.MINOR.PATCH.TWEAK format)
-    static constexpr const char* string = "0.1.0.0";
+    static constexpr const char* string = "0.2.0.0";
 };
 
 } // namespace kcenon::common


### PR DESCRIPTION
## What

### Summary
Syncs the hardcoded `version_info` struct in `common.h` with the project version `0.2.0` declared in `CMakeLists.txt` and `vcpkg.json`.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `include/kcenon/common/common.h` — `version_info` struct

## Why

### Related Issues
- Closes #503

### Motivation
Runtime version queries via `version_info::string` returned `"0.1.0.0"` instead of `"0.2.0.0"`, creating a mismatch between compile-time project version and runtime-reported version. This could cause downstream ABI compatibility checks to reject valid installations.

## Where

| File | Lines | Description |
|------|-------|-------------|
| `include/kcenon/common/common.h` | 116 | `minor` field: 1 → 2 |
| `include/kcenon/common/common.h` | 132 | `string` field: `"0.1.0.0"` → `"0.2.0.0"` |

## How

### Implementation Details
Direct value update — minimal 2-line change aligning runtime constants with project version.

### Testing Done
- [x] Verified diff matches expected changes
- [ ] CI build and test validation

### Breaking Changes
None — corrects an existing inconsistency.