### PR TITLE
chore(cmake): standardize minimum CMake version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.20)
 project(common_system VERSION 0.2.0 LANGUAGES CXX)
 
 # =============================================================================


### PR DESCRIPTION
## What

### Summary
Lowers `cmake_minimum_required` from 3.28 to 3.20. The 3.28 requirement existed solely for C++20 module support, which is already conditionally gated at line 173.

### Change Type
- [x] Chore (maintenance)

## Why

### Related Issues
- Closes #504

### Motivation
common_system required CMake 3.28 unconditionally, but C++20 modules (`COMMON_BUILD_MODULES`) default to OFF and already have their own 3.28 version check. This forced all downstream systems to require 3.28 despite most declaring 3.16. Standardizing to 3.20 reduces the toolchain barrier while maintaining full functionality.

### Ecosystem Impact
All 8 systems now consistently require CMake 3.20:
- common_system: 3.28 → **3.20** (this PR)
- thread_system, logger_system, container_system, database_system, network_system: 3.16 → **3.20** (companion PRs)
- monitoring_system, pacs_system: already 3.20

## Where

| File | Change |
|------|--------|
| `CMakeLists.txt:1` | `VERSION 3.28` → `VERSION 3.20` |

## How

### Testing Done
- [x] C++20 module conditional check at line 173 already handles 3.28 requirement
- [ ] CI build and test validation