### PR TITLE
chore(ci): create reusable GitHub Actions composite action for ecosystem vcpkg setup

### DIFF
--- a/.github/actions/setup-vcpkg/README.md
+++ b/.github/actions/setup-vcpkg/README.md
@@ -1,0 +1,73 @@
+# Setup vcpkg Composite Action
+
+Reusable GitHub Actions composite action that bootstraps vcpkg pinned to the kcenon ecosystem baseline with intelligent caching.
+
+## Features
+
+- Pins vcpkg to a specific commit (default: ecosystem baseline) for reproducible builds
+- Caches vcpkg installation (excluding buildtrees, packages, downloads)
+- Sets `VCPKG_ROOT` and `CMAKE_TOOLCHAIN_FILE` environment variables
+- Cross-platform: Ubuntu, macOS, Windows
+
+## Usage
+
+### Basic (uses ecosystem default baseline)
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: kcenon/common_system/.github/actions/setup-vcpkg@main
+  - run: cmake -B build -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE
+```
+
+### With custom cache key
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: kcenon/common_system/.github/actions/setup-vcpkg@main
+    with:
+      extra-cache-key: 'my-project'
+```
+
+### With custom vcpkg commit
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: kcenon/common_system/.github/actions/setup-vcpkg@main
+    with:
+      vcpkg-commit: 'abc123def456'
+```
+
+### Using outputs
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: kcenon/common_system/.github/actions/setup-vcpkg@main
+    id: vcpkg
+  - run: |
+      echo "VCPKG_ROOT=${{ steps.vcpkg.outputs.vcpkg-root }}"
+      echo "Toolchain=${{ steps.vcpkg.outputs.toolchain-file }}"
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `vcpkg-commit` | No | Ecosystem baseline | vcpkg commit SHA to checkout |
+| `manifest-dir` | No | `.` | Directory containing `vcpkg.json` |
+| `extra-cache-key` | No | `''` | Additional cache key suffix |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `vcpkg-root` | Path to vcpkg installation |
+| `toolchain-file` | Path to `vcpkg.cmake` |
+
+## Environment Variables Set
+
+- `VCPKG_ROOT` — vcpkg installation path
+- `CMAKE_TOOLCHAIN_FILE` — path to vcpkg CMake toolchain

--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -1,0 +1,82 @@
+name: 'Setup vcpkg'
+description: 'Bootstrap vcpkg pinned to ecosystem baseline with caching'
+
+inputs:
+  vcpkg-commit:
+    description: 'vcpkg commit SHA to checkout (default: ecosystem baseline)'
+    required: false
+    default: 'd90a9b159c08169f39adcd1b0f1ac0ca12c4b96c'
+  manifest-dir:
+    description: 'Directory containing vcpkg.json and vcpkg-configuration.json'
+    required: false
+    default: '.'
+  extra-cache-key:
+    description: 'Additional cache key suffix for project differentiation'
+    required: false
+    default: ''
+
+outputs:
+  vcpkg-root:
+    description: 'Path to the vcpkg installation directory'
+    value: ${{ steps.setup.outputs.vcpkg-root }}
+  toolchain-file:
+    description: 'Path to vcpkg.cmake toolchain file'
+    value: ${{ steps.setup.outputs.toolchain-file }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Determine vcpkg path
+      id: paths
+      shell: bash
+      run: |
+        VCPKG_DIR="${{ github.workspace }}/vcpkg"
+        echo "vcpkg-dir=${VCPKG_DIR}" >> $GITHUB_OUTPUT
+
+    - name: Cache vcpkg
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ steps.paths.outputs.vcpkg-dir }}
+          !${{ steps.paths.outputs.vcpkg-dir }}/buildtrees
+          !${{ steps.paths.outputs.vcpkg-dir }}/packages
+          !${{ steps.paths.outputs.vcpkg-dir }}/downloads
+        key: vcpkg-${{ runner.os }}-${{ inputs.vcpkg-commit }}-${{ hashFiles(format('{0}/vcpkg.json', inputs.manifest-dir), format('{0}/vcpkg-configuration.json', inputs.manifest-dir)) }}${{ inputs.extra-cache-key && format('-{0}', inputs.extra-cache-key) || '' }}
+        restore-keys: |
+          vcpkg-${{ runner.os }}-${{ inputs.vcpkg-commit }}-
+
+    - name: Checkout vcpkg
+      shell: bash
+      run: |
+        if [ ! -d "${{ steps.paths.outputs.vcpkg-dir }}/.git" ]; then
+          git clone https://github.com/microsoft/vcpkg.git "${{ steps.paths.outputs.vcpkg-dir }}"
+        fi
+        cd "${{ steps.paths.outputs.vcpkg-dir }}"
+        git fetch origin "${{ inputs.vcpkg-commit }}" --depth=1 2>/dev/null || git fetch origin --depth=50
+        git checkout "${{ inputs.vcpkg-commit }}"
+
+    - name: Bootstrap vcpkg
+      shell: bash
+      run: |
+        cd "${{ steps.paths.outputs.vcpkg-dir }}"
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          ./bootstrap-vcpkg.bat -disableMetrics
+        else
+          ./bootstrap-vcpkg.sh -disableMetrics
+        fi
+
+    - name: Set environment variables
+      id: setup
+      shell: bash
+      run: |
+        VCPKG_DIR="${{ steps.paths.outputs.vcpkg-dir }}"
+        TOOLCHAIN="${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake"
+
+        echo "VCPKG_ROOT=${VCPKG_DIR}" >> $GITHUB_ENV
+        echo "CMAKE_TOOLCHAIN_FILE=${TOOLCHAIN}" >> $GITHUB_ENV
+
+        echo "vcpkg-root=${VCPKG_DIR}" >> $GITHUB_OUTPUT
+        echo "toolchain-file=${TOOLCHAIN}" >> $GITHUB_OUTPUT
+
+        echo "vcpkg setup complete: ${VCPKG_DIR}"
+        "${VCPKG_DIR}/vcpkg" version


### PR DESCRIPTION
## What

Create a shared GitHub Actions composite action at `.github/actions/setup-vcpkg/` that standardizes vcpkg bootstrap, version pinning, and caching across all kcenon ecosystem CI workflows.

### New Files

| File | Purpose |
|------|---------|
| `.github/actions/setup-vcpkg/action.yml` | Composite action definition |
| `.github/actions/setup-vcpkg/README.md` | Usage documentation and examples |

### Action Features

| Feature | Description |
|---------|-------------|
| Pinned checkout | Pins vcpkg to ecosystem baseline commit by default |
| Intelligent cache | Cache key includes OS, commit, manifest hashes |
| Cross-platform | Works on Ubuntu, macOS, Windows runners |
| Environment setup | Sets `VCPKG_ROOT` and `CMAKE_TOOLCHAIN_FILE` |

## Why

- Ecosystem CI workflows use 3 different patterns for vcpkg setup, with duplicated logic
- Most Pattern A projects clone vcpkg from HEAD, causing version drift from the declared baseline
- A single bug in cache key logic must be fixed in 6+ repos individually
- Centralizing setup ensures all projects use the same pinned baseline

## Where

- `.github/actions/setup-vcpkg/action.yml` — composite action
- `.github/actions/setup-vcpkg/README.md` — documentation

## How

Created a composite action that:
1. Clones microsoft/vcpkg at a pinned commit (default: ecosystem baseline `d90a9b15...`)
2. Bootstraps vcpkg with metrics disabled
3. Sets `VCPKG_ROOT` and `CMAKE_TOOLCHAIN_FILE` as environment variables
4. Caches the vcpkg directory (excluding buildtrees/packages/downloads)

Other repos can adopt this via:
```yaml
- uses: kcenon/common_system/.github/actions/setup-vcpkg@main
```

Closes #510
Part of #509