### PR TITLE
chore(vcpkg): migrate version field to version-semver

### DIFF
--- a/vcpkg-ports/kcenon-common-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-common-system/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kcenon-common-system",
-  "version": "0.2.0",
+  "version-semver": "0.2.0",
   "port-version": 0,
   "description": "High-performance C++20 foundation library providing Result<T> pattern, interfaces, and common utilities",
   "homepage": "https://github.com/kcenon/common_system",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-common-system",
-  "version": "0.2.0",
+  "version-semver": "0.2.0",
   "port-version": 0,
   "description": "High-performance C++20 foundation library providing Result<T> pattern, interfaces, and common utilities",
   "homepage": "https://github.com/kcenon/common_system",


### PR DESCRIPTION
## Summary
- Replace `"version"` with `"version-semver"` in root `vcpkg.json` and port `vcpkg-ports/kcenon-common-system/vcpkg.json`
- Uses explicit semver versioning scheme as recommended by vcpkg

## Test plan
- [ ] Verify vcpkg install still resolves the package correctly
- [ ] Verify CI passes

Closes #520
Part of #519