### PR TITLE
ci(vcpkg): add registry consumption test and port drift detection workflows

### DIFF
--- a/.github/workflows/port-sync-check.yml
+++ b/.github/workflows/port-sync-check.yml
@@ -1,0 +1,110 @@
+name: Port Sync Check
+
+on:
+  schedule:
+    # Weekly Monday 7am UTC
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-port-sync:
+    name: Detect port drift between projects and vcpkg-registry
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+    - name: Check port sync status
+      run: |
+        declare -A PROJECTS=(
+          ["common_system"]="kcenon-common-system"
+          ["thread_system"]="kcenon-thread-system"
+          ["logger_system"]="kcenon-logger-system"
+          ["container_system"]="kcenon-container-system"
+          ["monitoring_system"]="kcenon-monitoring-system"
+          ["database_system"]="kcenon-database-system"
+          ["network_system"]="kcenon-network-system"
+          ["pacs_system"]="kcenon-pacs-system"
+        )
+
+        DRIFT_COUNT=0
+        SYNC_COUNT=0
+        ERROR_COUNT=0
+
+        echo "## Port Sync Check Results" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Project | Port | portfile.cmake | vcpkg.json | Status |" >> "$GITHUB_STEP_SUMMARY"
+        echo "|---------|------|----------------|------------|--------|" >> "$GITHUB_STEP_SUMMARY"
+
+        for PROJECT in "${!PROJECTS[@]}"; do
+          PORT="${PROJECTS[$PROJECT]}"
+
+          # Get SHAs from project repo (source of truth: vcpkg-ports/)
+          PROJECT_PORTFILE_SHA=$(gh api "repos/kcenon/${PROJECT}/contents/vcpkg-ports/${PORT}/portfile.cmake" \
+            --jq '.sha' 2>/dev/null) || PROJECT_PORTFILE_SHA="NOT_FOUND"
+          PROJECT_VCPKG_JSON_SHA=$(gh api "repos/kcenon/${PROJECT}/contents/vcpkg-ports/${PORT}/vcpkg.json" \
+            --jq '.sha' 2>/dev/null) || PROJECT_VCPKG_JSON_SHA="NOT_FOUND"
+
+          # Get SHAs from vcpkg-registry
+          REGISTRY_PORTFILE_SHA=$(gh api "repos/kcenon/vcpkg-registry/contents/ports/${PORT}/portfile.cmake" \
+            --jq '.sha' 2>/dev/null) || REGISTRY_PORTFILE_SHA="NOT_FOUND"
+          REGISTRY_VCPKG_JSON_SHA=$(gh api "repos/kcenon/vcpkg-registry/contents/ports/${PORT}/vcpkg.json" \
+            --jq '.sha' 2>/dev/null) || REGISTRY_VCPKG_JSON_SHA="NOT_FOUND"
+
+          # Compare
+          PORTFILE_STATUS="--"
+          VCPKG_JSON_STATUS="--"
+          ROW_STATUS=""
+
+          if [ "$PROJECT_PORTFILE_SHA" = "NOT_FOUND" ] || [ "$REGISTRY_PORTFILE_SHA" = "NOT_FOUND" ]; then
+            PORTFILE_STATUS="missing"
+          elif [ "$PROJECT_PORTFILE_SHA" = "$REGISTRY_PORTFILE_SHA" ]; then
+            PORTFILE_STATUS="synced"
+          else
+            PORTFILE_STATUS="**DRIFT**"
+          fi
+
+          if [ "$PROJECT_VCPKG_JSON_SHA" = "NOT_FOUND" ] || [ "$REGISTRY_VCPKG_JSON_SHA" = "NOT_FOUND" ]; then
+            VCPKG_JSON_STATUS="missing"
+          elif [ "$PROJECT_VCPKG_JSON_SHA" = "$REGISTRY_VCPKG_JSON_SHA" ]; then
+            VCPKG_JSON_STATUS="synced"
+          else
+            VCPKG_JSON_STATUS="**DRIFT**"
+          fi
+
+          if [ "$PORTFILE_STATUS" = "missing" ] || [ "$VCPKG_JSON_STATUS" = "missing" ]; then
+            ROW_STATUS="Error"
+            ERROR_COUNT=$((ERROR_COUNT + 1))
+          elif [ "$PORTFILE_STATUS" = "**DRIFT**" ] || [ "$VCPKG_JSON_STATUS" = "**DRIFT**" ]; then
+            ROW_STATUS="Drift detected"
+            DRIFT_COUNT=$((DRIFT_COUNT + 1))
+          else
+            ROW_STATUS="In sync"
+            SYNC_COUNT=$((SYNC_COUNT + 1))
+          fi
+
+          echo "| ${PROJECT} | ${PORT} | ${PORTFILE_STATUS} | ${VCPKG_JSON_STATUS} | ${ROW_STATUS} |" >> "$GITHUB_STEP_SUMMARY"
+        done
+
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "### Summary" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **In sync**: ${SYNC_COUNT}" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Drift detected**: ${DRIFT_COUNT}" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Errors**: ${ERROR_COUNT}" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+
+        if [ "$DRIFT_COUNT" -gt 0 ]; then
+          echo "> **Note**: Port drift detected. Run the sync workflow or manually update the vcpkg-registry." >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+        if [ "$ERROR_COUNT" -gt 0 ]; then
+          echo "> **Warning**: Some ports could not be found. Verify repository and path names." >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+        # Informational only - do not fail the workflow on drift
+        echo "Port sync check complete: ${SYNC_COUNT} synced, ${DRIFT_COUNT} drifted, ${ERROR_COUNT} errors"

--- a/.github/workflows/vcpkg-consume-test.yml
+++ b/.github/workflows/vcpkg-consume-test.yml
@@ -1,0 +1,113 @@
+name: vcpkg Registry Consumption Test
+
+on:
+  schedule:
+    # Weekly Monday 6am UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  consume-test:
+    name: Consume kcenon-common-system from registry
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+    - name: Checkout common_system
+      uses: actions/checkout@v4
+
+    - name: Setup vcpkg
+      uses: kcenon/common_system/.github/actions/setup-vcpkg@main
+
+    - name: Create test project with vcpkg manifest
+      run: |
+        mkdir -p /tmp/consume-test
+
+        # vcpkg manifest that depends on kcenon-common-system from registry
+        cat > /tmp/consume-test/vcpkg.json << 'MANIFEST'
+        {
+          "name": "consume-test",
+          "version-string": "0.0.0",
+          "dependencies": ["kcenon-common-system"]
+        }
+        MANIFEST
+
+        # Registry configuration pointing to kcenon vcpkg-registry
+        cat > /tmp/consume-test/vcpkg-configuration.json << 'REGISTRY'
+        {
+          "default-registry": {
+            "kind": "builtin",
+            "baseline": "d90a9b159c08169f39adcd1b0f1ac0ca12c4b96c"
+          },
+          "registries": [
+            {
+              "kind": "git",
+              "repository": "https://github.com/kcenon/vcpkg-registry.git",
+              "baseline": "77cc46d5ba5e2aef1581f2ec674f83e1ac906b43",
+              "packages": ["kcenon-*"]
+            }
+          ]
+        }
+        REGISTRY
+
+        cat > /tmp/consume-test/CMakeLists.txt << 'CMAKE'
+        cmake_minimum_required(VERSION 3.20)
+        project(consume_test LANGUAGES CXX)
+
+        set(CMAKE_CXX_STANDARD 20)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+        find_package(common_system CONFIG REQUIRED)
+
+        add_executable(consume_test main.cpp)
+        target_link_libraries(consume_test PRIVATE common_system::common_system)
+        CMAKE
+
+        cat > /tmp/consume-test/main.cpp << 'CPPEOF'
+        #include <kcenon/common/patterns/result.h>
+
+        #include <iostream>
+
+        int main()
+        {
+            std::cout << "vcpkg registry consumption test passed" << std::endl;
+            return 0;
+        }
+        CPPEOF
+
+    - name: Install dependencies via vcpkg
+      run: |
+        echo "Installing kcenon-common-system from vcpkg registry..."
+        "${{ env.VCPKG_ROOT }}/vcpkg" install \
+          --x-manifest-root=/tmp/consume-test \
+          --x-install-root=/tmp/consume-test/vcpkg_installed 2>&1 || {
+          echo "::error::Failed to install kcenon-common-system from vcpkg registry"
+          exit 1
+        }
+        echo "kcenon-common-system installed successfully"
+
+    - name: Configure test project
+      run: |
+        cmake -B /tmp/consume-test/build \
+          -S /tmp/consume-test \
+          -DCMAKE_TOOLCHAIN_FILE="${{ env.CMAKE_TOOLCHAIN_FILE }}" \
+          -DVCPKG_MANIFEST_DIR=/tmp/consume-test \
+          -DVCPKG_INSTALLED_DIR=/tmp/consume-test/vcpkg_installed \
+          -DCMAKE_BUILD_TYPE=Release 2>&1 || {
+          echo "::error::CMake configure failed - find_package(common_system) may not work"
+          exit 1
+        }
+
+    - name: Build test project
+      run: |
+        cmake --build /tmp/consume-test/build --config Release 2>&1 || {
+          echo "::error::Build failed - linking against common_system::common_system may be broken"
+          exit 1
+        }
+
+    - name: Run test binary
+      run: |
+        /tmp/consume-test/build/consume_test || {
+          echo "::error::Test binary failed to execute"
+          exit 1
+        }


### PR DESCRIPTION
## Summary
Adds two new CI workflows for vcpkg registry health monitoring:

1. **vcpkg-consume-test.yml** (#523): Validates end-to-end consumption of `kcenon-common-system` from the vcpkg-registry. Creates a standalone manifest project, installs the package, and builds a minimal CMake project with `find_package(common_system)`.

2. **port-sync-check.yml** (#524): Detects drift between each project's local `vcpkg-ports/` and the central `vcpkg-registry` using GitHub API SHA comparison. Reports results in workflow summary markdown table.

Both workflows run weekly (Monday) and support manual dispatch.

Closes #523
Closes #524

## Test Plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Manual dispatch after vcpkg-registry sync (#522) to validate consumption test
- [ ] Check port-sync-check reports correct sync status after #522 merge