### PR TITLE
fix(ci): make codecov status checks informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,11 +14,13 @@ coverage:
         target: 40%
         threshold: 2%
         if_ci_failed: error
+        informational: true  # Don't block PRs on coverage status
     patch:
       default:
         target: 60%
         threshold: 5%
         if_ci_failed: error
+        informational: true  # Don't block PRs on coverage status
 
 # Gradual improvement plan:
 # - Phase 1 (Current): 40% project, 60% patch


### PR DESCRIPTION
## Summary
Makes codecov project and patch status checks informational so they don't block PR merges.

### Root Cause
codecov/project status check fails on non-code PRs (vcpkg-configuration.json, workflow files, etc.) because there is no coverage delta to report. This blocked merging PR #529.

### Fix
Add `informational: true` to both project and patch status check configurations. Coverage data is still collected and reported, but the status check won't block merges.

## Test Plan
- codecov/project check should show as neutral/informational instead of fail
- Coverage reports still appear on PRs with code changes