### PR TITLE
chore(docs): update contact info in governance files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers via [GitHub Issues](https://github.com/kcenon/common_system/issues). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **kcenon@naver.com**. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,10 @@ upgrade to the most recent version.
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability in Common System, please report it
-responsibly using [GitHub Security Advisories](https://github.com/kcenon/common_system/security/advisories/new).
+responsibly through one of the following channels:
+
+- **Email**: [kcenon@naver.com](mailto:kcenon@naver.com)
+- **GitHub Security Advisories**: [Report here](https://github.com/kcenon/common_system/security/advisories/new)
 
 **Please do NOT report security vulnerabilities through public GitHub issues.**
 


### PR DESCRIPTION
Closes #537

## Summary

- Update `CODE_OF_CONDUCT.md` enforcement contact from GitHub Issues to `kcenon@naver.com`
- Update `SECURITY.md` to add email (`kcenon@naver.com`) as primary vulnerability reporting channel alongside GitHub Security Advisories

## What

| File | Change |
|------|--------|
| `CODE_OF_CONDUCT.md` | Enforcement contact updated to email |
| `SECURITY.md` | Added email as primary reporting channel |

## Why

Issue #537 specifies `kcenon@naver.com` as the contact email for security vulnerability reporting. Email provides a private, direct communication channel — more appropriate than public GitHub Issues for sensitive reports like code of conduct violations and security vulnerabilities.

Part of kcenon/common_system#536 (Ecosystem Documentation Standardization).

## Where

Two root-level documentation files modified. No code changes.

## How

### Acceptance Criteria

- [x] `CODE_OF_CONDUCT.md` exists at project root with correct contact info
- [x] `SECURITY.md` exists at project root with correct contact info
- [x] Both files reference correct project name and contact email

### Test Plan

- Verify email address renders correctly in both files on GitHub
- Verify all links (GitHub Security Advisories, mailto) are functional