### PR TITLE
feat(cmake): provide official kcenon::common_system CMake alias target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ endif()
 # Create interface library (header-only by default)
 add_library(common_system INTERFACE)
 add_library(kcenon::common ALIAS common_system)
+add_library(kcenon::common_system ALIAS common_system)
 add_library(common_system::common_system ALIAS common_system)
 
 # Set include directories


### PR DESCRIPTION
Closes #555

## Summary

- Add `kcenon::common_system` ALIAS target to the root CMakeLists.txt for the `add_subdirectory` use case
- Downstream projects (monitoring_system, pacs_system, etc.) no longer need to create their own workaround aliases
- The `find_package` path already provided this target via `common_system-config.cmake.in`; this change closes the gap for the `add_subdirectory` path

## Test plan

- [ ] Verify CI passes (the alias is exercised by the existing build)
- [ ] Confirm that `add_subdirectory`-based consumers can use `target_link_libraries(... kcenon::common_system)` without creating a local alias
- [ ] Confirm that `find_package(common_system)` still works and provides the same target via the config file (guarded by `NOT TARGET` check)