### PR TITLE
chore: standardize license headers to short format

### DIFF
--- a/benchmarks/circuit_breaker_benchmark.cpp
+++ b/benchmarks/circuit_breaker_benchmark.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #include <benchmark/benchmark.h>

--- a/benchmarks/circular_buffer_benchmark.cpp
+++ b/benchmarks/circular_buffer_benchmark.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #include <benchmark/benchmark.h>

--- a/benchmarks/ecosystem/data_pipeline_benchmark.cpp
+++ b/benchmarks/ecosystem/data_pipeline_benchmark.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/benchmarks/ecosystem/ecosystem_harness.h
+++ b/benchmarks/ecosystem/ecosystem_harness.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/benchmarks/ecosystem/interface_overhead_benchmark.cpp
+++ b/benchmarks/ecosystem/interface_overhead_benchmark.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/benchmarks/ecosystem/request_response_benchmark.cpp
+++ b/benchmarks/ecosystem/request_response_benchmark.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/benchmarks/ecosystem/scaling_benchmark.cpp
+++ b/benchmarks/ecosystem/scaling_benchmark.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/benchmarks/event_bus_benchmark.cpp
+++ b/benchmarks/event_bus_benchmark.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #include <benchmark/benchmark.h>

--- a/benchmarks/global_logger_registry_benchmark.cpp
+++ b/benchmarks/global_logger_registry_benchmark.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #include <benchmark/benchmark.h>

--- a/benchmarks/object_pool_benchmark.cpp
+++ b/benchmarks/object_pool_benchmark.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #include <benchmark/benchmark.h>

--- a/benchmarks/result_benchmark.cpp
+++ b/benchmarks/result_benchmark.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #include <benchmark/benchmark.h>

--- a/benchmarks/service_container_benchmark.cpp
+++ b/benchmarks/service_container_benchmark.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #include <benchmark/benchmark.h>

--- a/cmake/KcenonCompilerRequirements.cmake
+++ b/cmake/KcenonCompilerRequirements.cmake
@@ -1,5 +1,5 @@
 # BSD 3-Clause License
-# Copyright (c) 2025, kcenon
+# Copyright (c) 2025, 🍀☀🌕🌥 🌊
 # See the LICENSE file in the project root for full license information.
 
 #[=============================================================================[

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -1,5 +1,5 @@
 # BSD 3-Clause License
-# Copyright (c) 2025, kcenon
+# Copyright (c) 2025, 🍀☀🌕🌥 🌊
 # See the LICENSE file in the project root for full license information.
 
 #[=============================================================================[

--- a/examples/abi_version_example.cpp
+++ b/examples/abi_version_example.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/examples/executor_example.cpp
+++ b/examples/executor_example.cpp
@@ -1,31 +1,6 @@
 // BSD 3-Clause License
-//
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// See the LICENSE file in the project root for full license information.
 
 /**
  * @file executor_example.cpp

--- a/examples/result_example.cpp
+++ b/examples/result_example.cpp
@@ -1,31 +1,6 @@
 // BSD 3-Clause License
-//
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// See the LICENSE file in the project root for full license information.
 
 /**
  * @file result_example.cpp

--- a/examples/unwrap_demo.cpp
+++ b/examples/unwrap_demo.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/adapters/adapter.h
+++ b/include/kcenon/common/adapters/adapter.h
@@ -1,7 +1,6 @@
-/*
- * BSD 3-Clause License
- * Copyright (c) 2025, kcenon
- */
+// BSD 3-Clause License
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/include/kcenon/common/adapters/adapters.h
+++ b/include/kcenon/common/adapters/adapters.h
@@ -1,7 +1,6 @@
-/*
- * BSD 3-Clause License
- * Copyright (c) 2025, kcenon
- */
+// BSD 3-Clause License
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/include/kcenon/common/adapters/smart_adapter.h
+++ b/include/kcenon/common/adapters/smart_adapter.h
@@ -1,7 +1,6 @@
-/*
- * BSD 3-Clause License
- * Copyright (c) 2025, kcenon
- */
+// BSD 3-Clause License
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/include/kcenon/common/bootstrap/system_bootstrapper.h
+++ b/include/kcenon/common/bootstrap/system_bootstrapper.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/common.h
+++ b/include/kcenon/common/common.h
@@ -1,34 +1,6 @@
-/*****************************************************************************
-BSD 3-Clause License
-
-Copyright (c) 2025, 🍀☀🌕🌥 🌊
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*****************************************************************************/
+// BSD 3-Clause License
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
 
 /**
  * @file common.h

--- a/include/kcenon/common/concepts/callable.h
+++ b/include/kcenon/common/concepts/callable.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/concepts/concepts.h
+++ b/include/kcenon/common/concepts/concepts.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/concepts/container.h
+++ b/include/kcenon/common/concepts/container.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/concepts/core.h
+++ b/include/kcenon/common/concepts/core.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/concepts/event.h
+++ b/include/kcenon/common/concepts/event.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/concepts/logger.h
+++ b/include/kcenon/common/concepts/logger.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/concepts/monitoring.h
+++ b/include/kcenon/common/concepts/monitoring.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/concepts/service.h
+++ b/include/kcenon/common/concepts/service.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/concepts/transport.h
+++ b/include/kcenon/common/concepts/transport.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/config/cli_config_parser.h
+++ b/include/kcenon/common/config/cli_config_parser.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/config/config_loader.h
+++ b/include/kcenon/common/config/config_loader.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/config/config_watcher.h
+++ b/include/kcenon/common/config/config_watcher.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/config/feature_detection.h
+++ b/include/kcenon/common/config/feature_detection.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/config/feature_flags.h
+++ b/include/kcenon/common/config/feature_flags.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/config/feature_flags_core.h
+++ b/include/kcenon/common/config/feature_flags_core.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/config/feature_system_deps.h
+++ b/include/kcenon/common/config/feature_system_deps.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/config/unified_config.h
+++ b/include/kcenon/common/config/unified_config.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/di/service_container.h
+++ b/include/kcenon/common/di/service_container.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/di/service_container_interface.h
+++ b/include/kcenon/common/di/service_container_interface.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/di/unified_bootstrapper.h
+++ b/include/kcenon/common/di/unified_bootstrapper.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/error/error_category.h
+++ b/include/kcenon/common/error/error_category.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/error/error_codes.h
+++ b/include/kcenon/common/error/error_codes.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/database_interface.h
+++ b/include/kcenon/common/interfaces/database_interface.h
@@ -1,34 +1,6 @@
-/*****************************************************************************
-BSD 3-Clause License
-
-Copyright (c) 2025, 🍀☀🌕🌥 🌊
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*****************************************************************************/
+// BSD 3-Clause License
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/include/kcenon/common/interfaces/executor_interface.h
+++ b/include/kcenon/common/interfaces/executor_interface.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/global_logger_registry.h
+++ b/include/kcenon/common/interfaces/global_logger_registry.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/logger_interface.h
+++ b/include/kcenon/common/interfaces/logger_interface.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/monitoring.h
+++ b/include/kcenon/common/interfaces/monitoring.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/monitoring/composite_health_check.h
+++ b/include/kcenon/common/interfaces/monitoring/composite_health_check.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/monitoring/health_check.h
+++ b/include/kcenon/common/interfaces/monitoring/health_check.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/monitoring/health_check_builder.h
+++ b/include/kcenon/common/interfaces/monitoring/health_check_builder.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/monitoring/health_dependency_graph.h
+++ b/include/kcenon/common/interfaces/monitoring/health_dependency_graph.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/monitoring/health_monitor.h
+++ b/include/kcenon/common/interfaces/monitoring/health_monitor.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/monitoring/metric_collector_interface.h
+++ b/include/kcenon/common/interfaces/monitoring/metric_collector_interface.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/monitoring_interface.h
+++ b/include/kcenon/common/interfaces/monitoring_interface.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/registry_audit_log.h
+++ b/include/kcenon/common/interfaces/registry_audit_log.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/stats.h
+++ b/include/kcenon/common/interfaces/stats.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/stats_interface.h
+++ b/include/kcenon/common/interfaces/stats_interface.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/stats_snapshot.h
+++ b/include/kcenon/common/interfaces/stats_snapshot.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/thread_pool_interface.h
+++ b/include/kcenon/common/interfaces/thread_pool_interface.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/transport.h
+++ b/include/kcenon/common/interfaces/transport.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/transport/http_client_interface.h
+++ b/include/kcenon/common/interfaces/transport/http_client_interface.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/interfaces/transport/udp_client_interface.h
+++ b/include/kcenon/common/interfaces/transport/udp_client_interface.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/logging/log_functions.h
+++ b/include/kcenon/common/logging/log_functions.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/logging/log_macros.h
+++ b/include/kcenon/common/logging/log_macros.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/patterns/event_bus.h
+++ b/include/kcenon/common/patterns/event_bus.h
@@ -1,34 +1,6 @@
-/*****************************************************************************
-BSD 3-Clause License
-
-Copyright (c) 2025, 🍀☀🌕🌥 🌊
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*****************************************************************************/
+// BSD 3-Clause License
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
 
 /**
  * @file event_bus.h

--- a/include/kcenon/common/patterns/result.h
+++ b/include/kcenon/common/patterns/result.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/patterns/result/compat.h
+++ b/include/kcenon/common/patterns/result/compat.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/patterns/result/core.h
+++ b/include/kcenon/common/patterns/result/core.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/patterns/result/utilities.h
+++ b/include/kcenon/common/patterns/result/utilities.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/patterns/result_helpers.h
+++ b/include/kcenon/common/patterns/result_helpers.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/resilience/circuit_breaker.h
+++ b/include/kcenon/common/resilience/circuit_breaker.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/resilience/circuit_breaker_config.h
+++ b/include/kcenon/common/resilience/circuit_breaker_config.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/resilience/circuit_state.h
+++ b/include/kcenon/common/resilience/circuit_state.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/resilience/failure_window.h
+++ b/include/kcenon/common/resilience/failure_window.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/resilience/resilience.h
+++ b/include/kcenon/common/resilience/resilience.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/utils/circular_buffer.h
+++ b/include/kcenon/common/utils/circular_buffer.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #pragma once

--- a/include/kcenon/common/utils/enum_serialization.h
+++ b/include/kcenon/common/utils/enum_serialization.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/include/kcenon/common/utils/object_pool.h
+++ b/include/kcenon/common/utils/object_pool.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #pragma once

--- a/include/kcenon/common/utils/source_location.h
+++ b/include/kcenon/common/utils/source_location.h
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/integration_tests/failures/error_handling_test.cpp
+++ b/integration_tests/failures/error_handling_test.cpp
@@ -1,33 +1,6 @@
 // BSD 3-Clause License
-//
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice,
-// this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// See the LICENSE file in the project root for full license information.
 
 #include "system_fixture.h"
 #include "test_helpers.h"

--- a/integration_tests/framework/system_fixture.h
+++ b/integration_tests/framework/system_fixture.h
@@ -1,31 +1,6 @@
 // BSD 3-Clause License
-//
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// See the LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/integration_tests/framework/test_helpers.h
+++ b/integration_tests/framework/test_helpers.h
@@ -1,31 +1,6 @@
 // BSD 3-Clause License
-//
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// See the LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/integration_tests/performance/memory_pressure_test.cpp
+++ b/integration_tests/performance/memory_pressure_test.cpp
@@ -1,31 +1,6 @@
 // BSD 3-Clause License
-//
-// Copyright (c) 2021-2025, kcenon
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
 
 #include "system_fixture.h"
 #include "test_helpers.h"

--- a/integration_tests/performance/result_performance_test.cpp
+++ b/integration_tests/performance/result_performance_test.cpp
@@ -1,31 +1,6 @@
 // BSD 3-Clause License
-//
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// See the LICENSE file in the project root for full license information.
 
 #include "system_fixture.h"
 #include "test_helpers.h"

--- a/integration_tests/scenarios/event_bus_integration_test.cpp
+++ b/integration_tests/scenarios/event_bus_integration_test.cpp
@@ -1,33 +1,6 @@
 // BSD 3-Clause License
-//
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice,
-// this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// See the LICENSE file in the project root for full license information.
 
 #include "system_fixture.h"
 #include "test_helpers.h"

--- a/integration_tests/scenarios/full_system_integration_test.cpp
+++ b/integration_tests/scenarios/full_system_integration_test.cpp
@@ -1,33 +1,6 @@
 // BSD 3-Clause License
-//
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice,
-// this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// See the LICENSE file in the project root for full license information.
 
 #include "system_fixture.h"
 #include "test_helpers.h"

--- a/integration_tests/scenarios/result_pattern_integration_test.cpp
+++ b/integration_tests/scenarios/result_pattern_integration_test.cpp
@@ -1,31 +1,6 @@
 // BSD 3-Clause License
-//
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// See the LICENSE file in the project root for full license information.
 
 #include "system_fixture.h"
 #include "test_helpers.h"

--- a/integration_tests/scenarios/runtime_binding_integration_test.cpp
+++ b/integration_tests/scenarios/runtime_binding_integration_test.cpp
@@ -1,33 +1,6 @@
 // BSD 3-Clause License
-//
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice,
-// this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// See the LICENSE file in the project root for full license information.
 
 /**
  * @file runtime_binding_integration_test.cpp

--- a/integration_tests/stress/stress_test.cpp
+++ b/integration_tests/stress/stress_test.cpp
@@ -1,31 +1,6 @@
 // BSD 3-Clause License
-//
-// Copyright (c) 2021-2025, kcenon
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
 
 #include "system_fixture.h"
 #include "test_helpers.h"

--- a/src/modules/common.cppm
+++ b/src/modules/common.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/concepts.cppm
+++ b/src/modules/concepts.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/config.cppm
+++ b/src/modules/config.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/di.cppm
+++ b/src/modules/di.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/error.cppm
+++ b/src/modules/error.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/interfaces.cppm
+++ b/src/modules/interfaces.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/interfaces/core.cppm
+++ b/src/modules/interfaces/core.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/interfaces/executor.cppm
+++ b/src/modules/interfaces/executor.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/interfaces/logger.cppm
+++ b/src/modules/interfaces/logger.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/logging.cppm
+++ b/src/modules/logging.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/patterns.cppm
+++ b/src/modules/patterns.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/result.cppm
+++ b/src/modules/result.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/result/core.cppm
+++ b/src/modules/result/core.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/result/utilities.cppm
+++ b/src/modules/result/utilities.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/src/modules/utils.cppm
+++ b/src/modules/utils.cppm
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/abi_version_test.cpp
+++ b/tests/abi_version_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #include <kcenon/common/config/abi_version.h>

--- a/tests/circular_buffer_test.cpp
+++ b/tests/circular_buffer_test.cpp
@@ -1,7 +1,6 @@
 // BSD 3-Clause License
-//
-// Copyright (c) 2025, kcenon
-// All rights reserved.
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
 
 /**
  * @file circular_buffer_test.cpp

--- a/tests/cli_config_parser_test.cpp
+++ b/tests/cli_config_parser_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #include <gtest/gtest.h>

--- a/tests/concepts_test.cpp
+++ b/tests/concepts_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/config_loader_test.cpp
+++ b/tests/config_loader_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #include <gtest/gtest.h>

--- a/tests/config_watcher_test.cpp
+++ b/tests/config_watcher_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #include <gtest/gtest.h>

--- a/tests/enum_serialization_test.cpp
+++ b/tests/enum_serialization_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/error_category_test.cpp
+++ b/tests/error_category_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/executor_test.cpp
+++ b/tests/executor_test.cpp
@@ -1,31 +1,6 @@
 // BSD 3-Clause License
-//
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// See the LICENSE file in the project root for full license information.
 
 /**
  * @file executor_test.cpp

--- a/tests/global_logger_registry_test.cpp
+++ b/tests/global_logger_registry_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/health_monitoring_test.cpp
+++ b/tests/health_monitoring_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/log_functions_test.cpp
+++ b/tests/log_functions_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,31 +1,6 @@
 // BSD 3-Clause License
-//
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// See the LICENSE file in the project root for full license information.
 
 /**
  * @file main.cpp

--- a/tests/metric_collector_interface_test.cpp
+++ b/tests/metric_collector_interface_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/module_verification_test.cpp
+++ b/tests/module_verification_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/object_pool_test.cpp
+++ b/tests/object_pool_test.cpp
@@ -1,7 +1,6 @@
 // BSD 3-Clause License
-//
-// Copyright (c) 2025, kcenon
-// All rights reserved.
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
 
 /**
  * @file object_pool_test.cpp

--- a/tests/result_helpers_test.cpp
+++ b/tests/result_helpers_test.cpp
@@ -1,7 +1,6 @@
 // BSD 3-Clause License
-//
-// Copyright (c) 2025, kcenon
-// All rights reserved.
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
 
 /**
  * @file result_helpers_test.cpp

--- a/tests/security_controls_test.cpp
+++ b/tests/security_controls_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/service_container_test.cpp
+++ b/tests/service_container_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/system_bootstrapper_test.cpp
+++ b/tests/system_bootstrapper_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/thread_safety_tests.cpp
+++ b/tests/thread_safety_tests.cpp
@@ -1,9 +1,6 @@
-/*****************************************************************************
-BSD 3-Clause License
-
-Copyright (c) 2025, 🍀☀🌕🌥 🌊
-All rights reserved.
-*****************************************************************************/
+// BSD 3-Clause License
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
 
 #include <gtest/gtest.h>
 #include "kcenon/common/patterns/result.h"

--- a/tests/transport_interface_test.cpp
+++ b/tests/transport_interface_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/unified_bootstrapper_test.cpp
+++ b/tests/unified_bootstrapper_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 /**

--- a/tests/unified_config_test.cpp
+++ b/tests/unified_config_test.cpp
@@ -1,5 +1,5 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
 #include <gtest/gtest.h>

--- a/tests/unit/exception_mapper_test.cpp
+++ b/tests/unit/exception_mapper_test.cpp
@@ -1,6 +1,6 @@
 // BSD 3-Clause License
-// Copyright (c) 2025, kcenon
-// Test for exception_mapper improvements
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
 
 #include <kcenon/common/patterns/result.h>
 #include <gtest/gtest.h>


### PR DESCRIPTION
Closes #557

## What

Standardize all BSD 3-Clause license headers across the codebase to the short 3-line format:

```cpp
// BSD 3-Clause License
// Copyright (c) {year-range}, ...
// See the LICENSE file in the project root for full license information.
```

### Change Type
- [x] Chore (maintenance)

## Why

License headers were inconsistent across the ecosystem — some files had the full 30-line BSD license text (in both C++ line-comment and C block-comment styles), some had an intermediate format, and some already used the short format but with `kcenon` as the copyright holder instead of the standardized name.

## How

### Changes Made
1. **Full license text (Format A)**: Replaced 30-line `//`-style BSD license blocks with 3-line short format — preserved original year ranges
2. **Full license text (Format B)**: Replaced `/***...***/`-style block comment license blocks with 3-line short format
3. **Copyright holder**: Replaced `kcenon` with the standardized emoji copyright holder name in all files
4. **Intermediate formats**: Fixed files with 4-5 line variants (e.g., `// All rights reserved` blocks, `/* ... */` blocks)

### Scope
- **132 files** changed across `.h`, `.hpp`, `.cpp`, `.cppm`, and `.cmake` extensions
- **No third-party files** modified
- **LICENSE file** untouched

### Verification
- `grep -r "Redistribution and use in source"` returns 0 matches
- `grep -r "Copyright.*kcenon"` returns 0 matches across source files
- `grep -r "All rights reserved"` returns 0 matches across source files

## Test Plan
- [ ] Verify `grep -r "Redistribution and use in source" --include="*.h" --include="*.cpp"` returns 0
- [ ] Verify no `kcenon` copyright holders remain
- [ ] Build passes (header-only change, no functional code modified)