### PR TITLE
docs: add SSOT documentation registry

### DIFF
--- a/docs/ADAPTER_GUIDE.md
+++ b/docs/ADAPTER_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Adapter Framework Guide
 
+> **SSOT**: This document is the single source of truth for **Adapter Framework Guide**.
+
 > **Language:** **English** | [한국어](ADAPTER_GUIDE.kr.md)
 
 **Complete Guide**: Type-Safe Adapters, Interface Adaptation, and Cross-System Integration

--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -10,6 +10,8 @@ category: "API"
 
 # common_system API 레퍼런스
 
+> **SSOT**: This document is the single source of truth for **common_system API 레퍼런스**.
+
 > **버전**: 0.2.3
 > **최종 업데이트**: 2025-12-10
 > **상태**: 개발 중 (Tier 0)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -10,6 +10,8 @@ category: "API"
 
 # common_system API Reference
 
+> **SSOT**: This document is the single source of truth for **common_system API Reference**.
+
 > **Version**: 0.2.3.0
 > **Last Updated**: 2025-12-10
 > **Status**: Production Ready (Tier 0)

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -12,6 +12,8 @@ category: "ARCH"
 
 # 시스템 아키텍처
 
+> **SSOT**: This document is the single source of truth for **시스템 아키텍처**.
+
 ## 개요
 
 이 문서는 7개의 핵심 시스템 아키텍처와 시스템 간 통합 방법을 설명합니다.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,6 +12,8 @@ category: "ARCH"
 
 # System Architecture
 
+> **SSOT**: This document is the single source of truth for **System Architecture**.
+
 ## Overview
 
 This document describes the architecture of the 7 core systems and how they integrate with each other.

--- a/docs/BENCHMARKS.kr.md
+++ b/docs/BENCHMARKS.kr.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Common System - 성능 벤치마크
 
+> **SSOT**: This document is the single source of truth for **Common System - 성능 벤치마크**.
+
 **언어:** [English](BENCHMARKS.md) | **한국어**
 
 이 문서는 Common System 프로젝트에 대한 포괄적인 성능 벤치마크 및 분석을 제공합니다.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Common System - Performance Benchmarks
 
+> **SSOT**: This document is the single source of truth for **Common System - Performance Benchmarks**.
+
 **Language:** **English** | [한국어](BENCHMARKS.kr.md)
 
 This document provides comprehensive performance benchmarks and analysis for the Common System project.

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Result<T> Best Practices
 
+> **SSOT**: This document is the single source of truth for **Result<T> Best Practices**.
+
 This guide documents the recommended patterns for creating and using `Result<T>` objects in the Common System.
 
 ## Header Structure

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # 변경 이력
 
+> **SSOT**: This document is the single source of truth for **변경 이력**.
+
 Common System 프로젝트의 모든 주요 변경 사항이 이 파일에 문서화됩니다.
 
 이 문서는 [Keep a Changelog](https://keepachangelog.com/ko/1.0.0/) 형식을 따르며,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Changelog
 
+> **SSOT**: This document is the single source of truth for **Changelog**.
+
 All notable changes to the Common System project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/docs/COMPATIBILITY.kr.md
+++ b/docs/COMPATIBILITY.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # KCENON 에코시스템 호환성 매트릭스
 
+> **SSOT**: This document is the single source of truth for **KCENON 에코시스템 호환성 매트릭스**.
+
 이 문서는 모든 KCENON 에코시스템 구성 요소 간의 버전 호환성 및 의존성 요구 사항을 정의합니다.
 
 > **Language:** [English](COMPATIBILITY.md) | **한국어**

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # KCENON Ecosystem Compatibility Matrix
 
+> **SSOT**: This document is the single source of truth for **KCENON Ecosystem Compatibility Matrix**.
+
 This document defines version compatibility and dependency requirements across all KCENON ecosystem components.
 
 > **Language:** **English** | [한국어](COMPATIBILITY.kr.md)

--- a/docs/CONFIG_GUIDE.md
+++ b/docs/CONFIG_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Configuration Subsystem Guide
 
+> **SSOT**: This document is the single source of truth for **Configuration Subsystem Guide**.
+
 > **Language:** **English** | [한국어](CONFIG_GUIDE.kr.md)
 
 **Complete Guide**: Unified Configuration, Hot-Reload File Watching, CLI Argument Parsing, and Configuration Loading

--- a/docs/DEPRECATION.kr.md
+++ b/docs/DEPRECATION.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Deprecated APIs
 
+> **SSOT**: This document is the single source of truth for **Deprecated APIs**.
+
 이 문서는 Common System 라이브러리의 모든 deprecated API, 대체 API, 마이그레이션 가이드를 제공합니다.
 
 > **Language:** [English](DEPRECATION.md) | **한국어**

--- a/docs/DEPRECATION.md
+++ b/docs/DEPRECATION.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Deprecated APIs
 
+> **SSOT**: This document is the single source of truth for **Deprecated APIs**.
+
 This document lists all deprecated APIs in the Common System library, their replacements, and migration guidance.
 
 > **Language:** **English** | [한국어](DEPRECATION.kr.md)

--- a/docs/ECOSYSTEM_BENCHMARKS.md
+++ b/docs/ECOSYSTEM_BENCHMARKS.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Ecosystem Pipeline Benchmarks
 
+> **SSOT**: This document is the single source of truth for **Ecosystem Pipeline Benchmarks**.
+
 Cross-system end-to-end integration benchmarks for the kcenon ecosystem pipeline.
 Measures interface-level overhead and integration costs across all 8 ecosystem systems.
 

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -10,6 +10,8 @@ category: "API"
 
 # Error Code Registry
 
+> **SSOT**: This document is the single source of truth for **Error Code Registry**.
+
 > **Language:** **English** | [한국어](ERROR_CODES.kr.md)
 
 Comprehensive registry of all error codes across the kcenon ecosystem systems.

--- a/docs/ERROR_CODE_REGISTRY.kr.md
+++ b/docs/ERROR_CODE_REGISTRY.kr.md
@@ -12,6 +12,8 @@ category: "API"
 
 # 에러 코드 레지스트리
 
+> **SSOT**: This document is the single source of truth for **에러 코드 레지스트리**.
+
 이 문서는 unified_system 생태계 전체에서 사용되는 모든 에러 코드의 완전한 참조를 제공합니다.
 
 ## 에러 코드 범위

--- a/docs/ERROR_CODE_REGISTRY.md
+++ b/docs/ERROR_CODE_REGISTRY.md
@@ -12,6 +12,8 @@ category: "API"
 
 # Error Code Registry
 
+> **SSOT**: This document is the single source of truth for **Error Code Registry**.
+
 This document provides a complete reference of all error codes used across the unified_system ecosystem.
 
 ## Error Code Ranges

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -10,6 +10,8 @@ category: "FEAT"
 
 # Common System - 상세 기능
 
+> **SSOT**: This document is the single source of truth for **Common System - 상세 기능**.
+
 **언어:** [English](FEATURES.md) | **한국어**
 
 이 문서는 Common System 프로젝트에서 사용 가능한 모든 기능에 대한 포괄적인 세부 정보를 제공합니다.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -10,6 +10,8 @@ category: "FEAT"
 
 # Common System - Detailed Features
 
+> **SSOT**: This document is the single source of truth for **Common System - Detailed Features**.
+
 **Language:** **English** | [한국어](FEATURES.kr.md)
 
 This document provides comprehensive details about all features available in the Common System project.

--- a/docs/FEATURE_FLAGS_GUIDE.md
+++ b/docs/FEATURE_FLAGS_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Feature Flags Framework Guide
 
+> **SSOT**: This document is the single source of truth for **Feature Flags Framework Guide**.
+
 > **Language:** **English** | [한국어](FEATURE_FLAGS_GUIDE.kr.md)
 
 **Complete Guide**: Compile-Time Feature Detection, Runtime Feature Flags, and Cross-System Integration

--- a/docs/IMPROVEMENT_PROPOSAL.md
+++ b/docs/IMPROVEMENT_PROPOSAL.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Unified System SDK Improvement Proposal
 
+> **SSOT**: This document is the single source of truth for **Unified System SDK Improvement Proposal**.
+
 > **Version:** 3.1.0
 > **Last Updated:** 2025-12-28
 > **Status:** Verified Analysis & Recommendations

--- a/docs/INTEGRATION_GUIDE.kr.md
+++ b/docs/INTEGRATION_GUIDE.kr.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # 크로스 시스템 통합 가이드
 
+> **SSOT**: This document is the single source of truth for **크로스 시스템 통합 가이드**.
+
 > **언어:** [English](INTEGRATION_GUIDE.md) | **한국어**
 
 **완전한 가이드**: 의존성 맵, 통합 패턴, 시나리오, 에러 처리, 예제

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # Cross-System Integration Guide
 
+> **SSOT**: This document is the single source of truth for **Cross-System Integration Guide**.
+
 > **Language:** **English** | [한국어](INTEGRATION_GUIDE.kr.md)
 
 **Complete Guide**: Dependency Map, Integration Patterns, Scenarios, Error Handling, and Examples

--- a/docs/PRODUCTION_GUIDE.md
+++ b/docs/PRODUCTION_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Production Deployment Guide
 
+> **SSOT**: This document is the single source of truth for **Production Deployment Guide**.
+
 > **Status**: ✅ **Complete**
 
 This guide provides comprehensive instructions for deploying kcenon ecosystem applications to production environments, covering configuration, deployment patterns, containerization, monitoring, troubleshooting, security, and upgrade procedures.

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Common System 프로덕션 품질
 
+> **SSOT**: This document is the single source of truth for **Common System 프로덕션 품질**.
+
 **언어:** [English](PRODUCTION_QUALITY.md) | **한국어**
 
 **최종 업데이트**: 2025-12-09

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Common System Production Quality
 
+> **SSOT**: This document is the single source of truth for **Common System Production Quality**.
+
 **Last Updated**: 2025-11-21
 **Status**: Under Development
 **Tier**: 0 (Foundation)

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Common System - 프로젝트 구조
 
+> **SSOT**: This document is the single source of truth for **Common System - 프로젝트 구조**.
+
 **언어:** [English](PROJECT_STRUCTURE.md) | **한국어**
 
 이 문서는 common_system 프로젝트 구조에 대한 포괄적인 개요를 제공하며, 각 디렉토리와 주요 파일의 목적을 설명합니다.

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Common System - Project Structure
 
+> **SSOT**: This document is the single source of truth for **Common System - Project Structure**.
+
 **Language:** **English** | [한국어](PROJECT_STRUCTURE.kr.md)
 
 This document provides a comprehensive overview of the common_system project structure, explaining the purpose of each directory and key files.

--- a/docs/README.kr.md
+++ b/docs/README.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Common System 문서
 
+> **SSOT**: This document is the single source of truth for **Common System 문서**.
+
 > **Language:** [English](README.md) | **한국어**
 
 common_system 문서에 오신 것을 환영합니다. 이 디렉토리에는 common system을 사용하고 통합하기 위한 포괄적인 가이드, 참조 자료 및 모범 사례가 포함되어 있습니다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 doc_id: "COM-GUID-007"
-doc_title: "Common System Documentation"
+doc_title: "Common System Documentation Registry"
 doc_version: "1.0.0"
 doc_date: "2026-04-04"
 doc_status: "Released"
@@ -8,324 +8,241 @@ project: "common_system"
 category: "GUID"
 ---
 
-# Common System Documentation
+# Common System — Documentation Registry
 
-> **Language:** **English** | [한국어](README.kr.md)
+> **SSOT**: This file is the single source of truth for the documentation index
+> of **common_system**.
 
-**Version:** 0.2.0
-**Last Updated:** 2025-11-11
-**Status:** Comprehensive
+Total documents: **83**
 
-Welcome to the common_system documentation! This is the foundational Layer 0 system providing standard interfaces, type-safe error handling (Result<T>), and core utilities for all KCENON C++ systems.
+## Document Index
 
----
+| # | doc_id | Topic | Authority Document | Status |
+|---|--------|-------|-------------------|--------|
+| 1 | COM-ARCH-001 | 시스템 아키텍처 | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
+| 2 | COM-ARCH-002 | System Architecture | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
+| 3 | COM-ARCH-003 | Common System - Project Structure | [STRUCTURE.md](./advanced/STRUCTURE.md) | Released |
+| 4 | COM-ARCH-004 | Runtime Binding Architecture | [RUNTIME_BINDING.md](./architecture/RUNTIME_BINDING.md) | Released |
+| 5 | COM-ARCH-005 | [SYSTEM_NAME] Architecture | [ARCHITECTURE_TEMPLATE.md](./contributing/templates/ARCHITECTURE_TEMPLATE.md) | Released |
+| 6 | COM-ARCH-006 | Migration Guide: Runtime Binding Pattern | [MIGRATION_RUNTIME_BINDING.md](./guides/MIGRATION_RUNTIME_BINDING.md) | Released |
+| 7 | COM-API-001 | common_system API 레퍼런스 | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
+| 8 | COM-API-002 | common_system API Reference | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
+| 9 | COM-API-003 | Error Code Registry | [ERROR_CODES.md](./ERROR_CODES.md) | Released |
+| 10 | COM-API-004 | 에러 코드 레지스트리 | [ERROR_CODE_REGISTRY.kr.md](./ERROR_CODE_REGISTRY.kr.md) | Released |
+| 11 | COM-API-005 | Error Code Registry | [ERROR_CODE_REGISTRY.md](./ERROR_CODE_REGISTRY.md) | Released |
+| 12 | COM-FEAT-001 | Common System - 상세 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
+| 13 | COM-FEAT-002 | Common System - Detailed Features | [FEATURES.md](./FEATURES.md) | Released |
+| 14 | COM-GUID-001 | Adapter Framework Guide | [ADAPTER_GUIDE.md](./ADAPTER_GUIDE.md) | Released |
+| 15 | COM-GUID-002 | Result<T> Best Practices | [BEST_PRACTICES.md](./BEST_PRACTICES.md) | Released |
+| 16 | COM-GUID-003 | Configuration Subsystem Guide | [CONFIG_GUIDE.md](./CONFIG_GUIDE.md) | Released |
+| 17 | COM-GUID-004 | Feature Flags Framework Guide | [FEATURE_FLAGS_GUIDE.md](./FEATURE_FLAGS_GUIDE.md) | Released |
+| 18 | COM-GUID-005 | Production Deployment Guide | [PRODUCTION_GUIDE.md](./PRODUCTION_GUIDE.md) | Released |
+| 19 | COM-GUID-006 | Common System 문서 | [README.kr.md](./README.kr.md) | Released |
+| 20 | COM-GUID-008 | README_TEMPLATE.md | [README_TEMPLATE.md](./README_TEMPLATE.md) | Released |
+| 21 | COM-GUID-009 | 싱글톤 패턴 가이드라인 | [SINGLETON_GUIDELINES.kr.md](./SINGLETON_GUIDELINES.kr.md) | Released |
+| 22 | COM-GUID-010 | Singleton Pattern Guidelines | [SINGLETON_GUIDELINES.md](./SINGLETON_GUIDELINES.md) | Released |
+| 23 | COM-GUID-011 | CI/CD Guide - common_system | [CI_CD_GUIDE.md](./contributing/CI_CD_GUIDE.md) | Released |
+| 24 | COM-GUID-012 | [Guide Title] | [GUIDE_TEMPLATE.md](./contributing/templates/GUIDE_TEMPLATE.md) | Released |
+| 25 | COM-GUID-013 | Best Practices for common_system | [BEST_PRACTICES.md](./guides/BEST_PRACTICES.md) | Released |
+| 26 | COM-GUID-014 | C++20 Concepts 가이드 | [CONCEPTS_GUIDE.kr.md](./guides/CONCEPTS_GUIDE.kr.md) | Released |
+| 27 | COM-GUID-015 | C++20 Concepts Guide | [CONCEPTS_GUIDE.md](./guides/CONCEPTS_GUIDE.md) | Released |
+| 28 | COM-GUID-016 | Error Code Guidelines | [ERROR_CODE_GUIDELINES.md](./guides/ERROR_CODE_GUIDELINES.md) | Released |
+| 29 | COM-GUID-017 | Error Handling 가이드라인 | [ERROR_HANDLING.kr.md](./guides/ERROR_HANDLING.kr.md) | Released |
+| 30 | COM-GUID-018 | Error Handling Guidelines | [ERROR_HANDLING.md](./guides/ERROR_HANDLING.md) | Released |
+| 31 | COM-GUID-019 | Common System - Frequently Asked Questions | [FAQ.md](./guides/FAQ.md) | Released |
+| 32 | COM-GUID-020 | Logging Best Practices | [LOGGING_BEST_PRACTICES.md](./guides/LOGGING_BEST_PRACTICES.md) | Released |
+| 33 | COM-GUID-021 | Quick Start Guide - common_system | [QUICK_START.md](./guides/QUICK_START.md) | Released |
+| 34 | COM-GUID-022 | Common System을 위한 RAII 패턴 가이드라인 | [RAII_GUIDELINES.kr.md](./guides/RAII_GUIDELINES.kr.md) | Released |
+| 35 | COM-GUID-023 | RAII Pattern Guidelines for Common System | [RAII_GUIDELINES.md](./guides/RAII_GUIDELINES.md) | Released |
+| 36 | COM-GUID-024 | 스마트 포인터 사용 가이드라인 | [SMART_POINTER_GUIDELINES.kr.md](./guides/SMART_POINTER_GUIDELINES.kr.md) | Released |
+| 37 | COM-GUID-025 | Smart Pointer Usage Guidelines | [SMART_POINTER_GUIDELINES.md](./guides/SMART_POINTER_GUIDELINES.md) | Released |
+| 38 | COM-GUID-026 | Troubleshooting Guide - common_system | [TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
+| 39 | COM-GUID-027 | Troubleshooting Guide | [TROUBLESHOOTING_LOGGING.md](./guides/TROUBLESHOOTING_LOGGING.md) | Released |
+| 40 | COM-PERF-001 | Common System - 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| 41 | COM-PERF-002 | Common System - Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| 42 | COM-PERF-003 | Ecosystem Pipeline Benchmarks | [ECOSYSTEM_BENCHMARKS.md](./ECOSYSTEM_BENCHMARKS.md) | Released |
+| 43 | COM-PERF-004 | End-to-End Benchmark Documentation | [E2E_BENCHMARKS.md](./performance/E2E_BENCHMARKS.md) | Released |
+| 44 | COM-MIGR-001 | IExecutor API Migration Guide | [IEXECUTOR_MIGRATION_GUIDE.md](./advanced/IEXECUTOR_MIGRATION_GUIDE.md) | Released |
+| 45 | COM-MIGR-002 | 마이그레이션 가이드 | [MIGRATION.kr.md](./advanced/MIGRATION.kr.md) | Released |
+| 46 | COM-MIGR-003 | Migration Guide | [MIGRATION.md](./advanced/MIGRATION.md) | Released |
+| 47 | COM-MIGR-004 | Namespace Migration Guide | [NAMESPACE_MIGRATION.md](./advanced/NAMESPACE_MIGRATION.md) | Released |
+| 48 | COM-MIGR-005 | DI Container Migration Guide | [DI_MIGRATION_GUIDE.md](./guides/DI_MIGRATION_GUIDE.md) | Released |
+| 49 | COM-MIGR-006 | fmt → std::format Migration Guide | [FMT_MIGRATION_GUIDE.md](./guides/FMT_MIGRATION_GUIDE.md) | Released |
+| 50 | COM-MIGR-007 | C++20 모듈 마이그레이션 가이드 | [MODULE_MIGRATION.kr.md](./guides/MODULE_MIGRATION.kr.md) | Released |
+| 51 | COM-MIGR-008 | C++20 Module Migration Guide | [MODULE_MIGRATION.md](./guides/MODULE_MIGRATION.md) | Released |
+| 52 | COM-MIGR-009 | Result\<T\> 마이그레이션 가이드 | [RESULT_MIGRATION_GUIDE.kr.md](./guides/RESULT_MIGRATION_GUIDE.kr.md) | Released |
+| 53 | COM-MIGR-010 | Result\<T\> Migration Guide | [RESULT_MIGRATION_GUIDE.md](./guides/RESULT_MIGRATION_GUIDE.md) | Released |
+| 54 | COM-INTR-001 | 크로스 시스템 통합 가이드 | [INTEGRATION_GUIDE.kr.md](./INTEGRATION_GUIDE.kr.md) | Released |
+| 55 | COM-INTR-002 | Cross-System Integration Guide | [INTEGRATION_GUIDE.md](./INTEGRATION_GUIDE.md) | Released |
+| 56 | COM-INTR-003 | 시스템 통합 가이드 | [INTEGRATION.kr.md](./guides/INTEGRATION.kr.md) | Released |
+| 57 | COM-INTR-004 | System Integration Guide | [INTEGRATION.md](./guides/INTEGRATION.md) | Released |
+| 58 | COM-INTR-005 | common_system 통합 정책 | [INTEGRATION_POLICY.kr.md](./guides/INTEGRATION_POLICY.kr.md) | Released |
+| 59 | COM-INTR-006 | common_system Integration Policy | [INTEGRATION_POLICY.md](./guides/INTEGRATION_POLICY.md) | Released |
+| 60 | COM-QUAL-001 | Common System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
+| 61 | COM-QUAL-002 | Common System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
+| 62 | COM-SECU-001 | CVE Scanning and SBOM Generation Guide | [CVE-SCANNING.md](./guides/CVE-SCANNING.md) | Released |
+| 63 | COM-SECU-002 | Security Best Practices | [SECURITY_BEST_PRACTICES.md](./guides/SECURITY_BEST_PRACTICES.md) | Released |
+| 64 | COM-ADR-001 | ADR-001: Standardize on vcpkg as the sole package manager | [ADR-001-vcpkg-only.md](./advanced/ADR-001-vcpkg-only.md) | Released |
+| 65 | COM-PROJ-001 | 변경 이력 | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| 66 | COM-PROJ-002 | Changelog | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| 67 | COM-PROJ-003 | KCENON 에코시스템 호환성 매트릭스 | [COMPATIBILITY.kr.md](./COMPATIBILITY.kr.md) | Released |
+| 68 | COM-PROJ-004 | KCENON Ecosystem Compatibility Matrix | [COMPATIBILITY.md](./COMPATIBILITY.md) | Released |
+| 69 | COM-PROJ-005 | Deprecated APIs | [DEPRECATION.kr.md](./DEPRECATION.kr.md) | Released |
+| 70 | COM-PROJ-006 | Deprecated APIs | [DEPRECATION.md](./DEPRECATION.md) | Released |
+| 71 | COM-PROJ-007 | Unified System SDK Improvement Proposal | [IMPROVEMENT_PROPOSAL.md](./IMPROVEMENT_PROPOSAL.md) | Released |
+| 72 | COM-PROJ-008 | Common System - 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| 73 | COM-PROJ-009 | Common System - Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| 74 | COM-PROJ-010 | Releasing common_system | [RELEASING.md](./RELEASING.md) | Released |
+| 75 | COM-PROJ-011 | Rust/C++ Feature Parity Matrix | [RUST_PARITY.md](./RUST_PARITY.md) | Released |
+| 76 | COM-PROJ-012 | SOUP Inventory — kcenon Ecosystem | [SOUP-LIST.md](./SOUP-LIST.md) | Released |
+| 77 | COM-PROJ-013 | SOUP List &mdash; common_system | [SOUP.md](./SOUP.md) | Released |
+| 78 | COM-PROJ-014 | Dependency Matrix - 상세 분석 | [DEPENDENCY_MATRIX.kr.md](./advanced/DEPENDENCY_MATRIX.kr.md) | Released |
+| 79 | COM-PROJ-015 | Dependency Matrix - Detailed Analysis | [DEPENDENCY_MATRIX.md](./advanced/DEPENDENCY_MATRIX.md) | Released |
+| 80 | COM-PROJ-016 | CHANGELOG Template | [CHANGELOG_TEMPLATE.md](./contributing/CHANGELOG_TEMPLATE.md) | Released |
+| 81 | COM-PROJ-017 | Contributing to common_system | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+| 82 | COM-PROJ-018 | Documentation Structure Guidelines | [DOCUMENTATION_GUIDELINES.md](./contributing/DOCUMENTATION_GUIDELINES.md) | Released |
+| 83 | COM-PROJ-019 | [SYSTEM_NAME] Features | [FEATURE_TEMPLATE.md](./contributing/templates/FEATURE_TEMPLATE.md) | Released |
 
-## 🚀 Quick Navigation
+## Documents by Category
 
-| I want to... | Document |
-|--------------|----------|
-| ⚡ Get started in 5 minutes | [Quick Start](guides/QUICK_START.md) |
-| 🏗️ Understand the architecture | [Architecture](01-ARCHITECTURE.md) |
-| 🔧 Integrate into my project | [Integration Guide](guides/INTEGRATION.md) |
-| ❓ Find answers to common questions | [FAQ](guides/FAQ.md) (23 Q&A) |
-| 🐛 Troubleshoot an issue | [Troubleshooting](guides/TROUBLESHOOTING.md) |
-| ✨ Learn best practices | [Best Practices](guides/BEST_PRACTICES.md) |
-| 🤝 Contribute to the project | [Contributing](contributing/CONTRIBUTING.md) |
+### Architecture (6)
 
----
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| COM-ARCH-001 | 시스템 아키텍처 | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
+| COM-ARCH-002 | System Architecture | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
+| COM-ARCH-003 | Common System - Project Structure | [STRUCTURE.md](./advanced/STRUCTURE.md) | Released |
+| COM-ARCH-004 | Runtime Binding Architecture | [RUNTIME_BINDING.md](./architecture/RUNTIME_BINDING.md) | Released |
+| COM-ARCH-005 | [SYSTEM_NAME] Architecture | [ARCHITECTURE_TEMPLATE.md](./contributing/templates/ARCHITECTURE_TEMPLATE.md) | Released |
+| COM-ARCH-006 | Migration Guide: Runtime Binding Pattern | [MIGRATION_RUNTIME_BINDING.md](./guides/MIGRATION_RUNTIME_BINDING.md) | Released |
 
-## Table of Contents
+### API Reference (5)
 
-- [Documentation Structure](#documentation-structure)
-- [Documentation by Role](#documentation-by-role)
-- [By Feature](#by-feature)
-- [Contributing to Documentation](#contributing-to-documentation)
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| COM-API-001 | common_system API 레퍼런스 | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
+| COM-API-002 | common_system API Reference | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
+| COM-API-003 | Error Code Registry | [ERROR_CODES.md](./ERROR_CODES.md) | Released |
+| COM-API-004 | 에러 코드 레지스트리 | [ERROR_CODE_REGISTRY.kr.md](./ERROR_CODE_REGISTRY.kr.md) | Released |
+| COM-API-005 | Error Code Registry | [ERROR_CODE_REGISTRY.md](./ERROR_CODE_REGISTRY.md) | Released |
 
----
+### Features (2)
 
-## Documentation Structure
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| COM-FEAT-001 | Common System - 상세 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
+| COM-FEAT-002 | Common System - Detailed Features | [FEATURES.md](./FEATURES.md) | Released |
 
-### 📘 Core Documentation
+### Guides (26)
 
-Essential documents for understanding the system:
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| COM-GUID-001 | Adapter Framework Guide | [ADAPTER_GUIDE.md](./ADAPTER_GUIDE.md) | Released |
+| COM-GUID-002 | Result<T> Best Practices | [BEST_PRACTICES.md](./BEST_PRACTICES.md) | Released |
+| COM-GUID-003 | Configuration Subsystem Guide | [CONFIG_GUIDE.md](./CONFIG_GUIDE.md) | Released |
+| COM-GUID-004 | Feature Flags Framework Guide | [FEATURE_FLAGS_GUIDE.md](./FEATURE_FLAGS_GUIDE.md) | Released |
+| COM-GUID-005 | Production Deployment Guide | [PRODUCTION_GUIDE.md](./PRODUCTION_GUIDE.md) | Released |
+| COM-GUID-006 | Common System 문서 | [README.kr.md](./README.kr.md) | Released |
+| COM-GUID-008 | README_TEMPLATE.md | [README_TEMPLATE.md](./README_TEMPLATE.md) | Released |
+| COM-GUID-009 | 싱글톤 패턴 가이드라인 | [SINGLETON_GUIDELINES.kr.md](./SINGLETON_GUIDELINES.kr.md) | Released |
+| COM-GUID-010 | Singleton Pattern Guidelines | [SINGLETON_GUIDELINES.md](./SINGLETON_GUIDELINES.md) | Released |
+| COM-GUID-011 | CI/CD Guide - common_system | [CI_CD_GUIDE.md](./contributing/CI_CD_GUIDE.md) | Released |
+| COM-GUID-012 | [Guide Title] | [GUIDE_TEMPLATE.md](./contributing/templates/GUIDE_TEMPLATE.md) | Released |
+| COM-GUID-013 | Best Practices for common_system | [BEST_PRACTICES.md](./guides/BEST_PRACTICES.md) | Released |
+| COM-GUID-014 | C++20 Concepts 가이드 | [CONCEPTS_GUIDE.kr.md](./guides/CONCEPTS_GUIDE.kr.md) | Released |
+| COM-GUID-015 | C++20 Concepts Guide | [CONCEPTS_GUIDE.md](./guides/CONCEPTS_GUIDE.md) | Released |
+| COM-GUID-016 | Error Code Guidelines | [ERROR_CODE_GUIDELINES.md](./guides/ERROR_CODE_GUIDELINES.md) | Released |
+| COM-GUID-017 | Error Handling 가이드라인 | [ERROR_HANDLING.kr.md](./guides/ERROR_HANDLING.kr.md) | Released |
+| COM-GUID-018 | Error Handling Guidelines | [ERROR_HANDLING.md](./guides/ERROR_HANDLING.md) | Released |
+| COM-GUID-019 | Common System - Frequently Asked Questions | [FAQ.md](./guides/FAQ.md) | Released |
+| COM-GUID-020 | Logging Best Practices | [LOGGING_BEST_PRACTICES.md](./guides/LOGGING_BEST_PRACTICES.md) | Released |
+| COM-GUID-021 | Quick Start Guide - common_system | [QUICK_START.md](./guides/QUICK_START.md) | Released |
+| COM-GUID-022 | Common System을 위한 RAII 패턴 가이드라인 | [RAII_GUIDELINES.kr.md](./guides/RAII_GUIDELINES.kr.md) | Released |
+| COM-GUID-023 | RAII Pattern Guidelines for Common System | [RAII_GUIDELINES.md](./guides/RAII_GUIDELINES.md) | Released |
+| COM-GUID-024 | 스마트 포인터 사용 가이드라인 | [SMART_POINTER_GUIDELINES.kr.md](./guides/SMART_POINTER_GUIDELINES.kr.md) | Released |
+| COM-GUID-025 | Smart Pointer Usage Guidelines | [SMART_POINTER_GUIDELINES.md](./guides/SMART_POINTER_GUIDELINES.md) | Released |
+| COM-GUID-026 | Troubleshooting Guide - common_system | [TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
+| COM-GUID-027 | Troubleshooting Guide | [TROUBLESHOOTING_LOGGING.md](./guides/TROUBLESHOOTING_LOGGING.md) | Released |
 
-| Document | Description | Korean | Lines |
-|----------|-------------|--------|-------|
-| [01-ARCHITECTURE.md](01-ARCHITECTURE.md) | Layer 0 foundation architecture, standard interfaces, system dependencies | [🇰🇷](01-ARCHITECTURE.kr.md) | 800+ |
+### Performance (4)
 
-### 📗 User Guides
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| COM-PERF-001 | Common System - 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| COM-PERF-002 | Common System - Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| COM-PERF-003 | Ecosystem Pipeline Benchmarks | [ECOSYSTEM_BENCHMARKS.md](./ECOSYSTEM_BENCHMARKS.md) | Released |
+| COM-PERF-004 | End-to-End Benchmark Documentation | [E2E_BENCHMARKS.md](./performance/E2E_BENCHMARKS.md) | Released |
 
-Step-by-step guides for users:
+### Migration (10)
 
-| Document | Description | Korean | Lines |
-|----------|-------------|--------|-------|
-| [QUICK_START.md](guides/QUICK_START.md) | 5-minute getting started guide for header-only integration | - | 324 |
-| [FAQ.md](guides/FAQ.md) | 23 frequently asked questions with examples | - | 1020 |
-| [TROUBLESHOOTING.md](guides/TROUBLESHOOTING.md) | Common problems, template errors, IDE configuration | - | 1221 |
-| [BEST_PRACTICES.md](guides/BEST_PRACTICES.md) | Recommended patterns for Result<T>, RAII, error handling | - | 1272 |
-| [ERROR_HANDLING.md](guides/ERROR_HANDLING.md) | Result<T> pattern usage and monadic operations | [🇰🇷](guides/ERROR_HANDLING.kr.md) | 600+ |
-| [RAII_GUIDELINES.md](guides/RAII_GUIDELINES.md) | Resource Acquisition Is Initialization patterns | [🇰🇷](guides/RAII_GUIDELINES.kr.md) | 400+ |
-| [SMART_POINTER_GUIDELINES.md](guides/SMART_POINTER_GUIDELINES.md) | unique_ptr and shared_ptr usage patterns | [🇰🇷](guides/SMART_POINTER_GUIDELINES.kr.md) | 300+ |
-| [ERROR_CODE_GUIDELINES.md](guides/ERROR_CODE_GUIDELINES.md) | Error code ranges, allocation, compile-time validation | - | 200+ |
-| [INTEGRATION.md](guides/INTEGRATION.md) | System integration patterns and examples | [🇰🇷](guides/INTEGRATION.kr.md) | 500+ |
-| [INTEGRATION_POLICY.md](guides/INTEGRATION_POLICY.md) | Official integration policy and CMake patterns | [🇰🇷](guides/INTEGRATION_POLICY.kr.md) | 300+ |
-| [MODULE_MIGRATION.md](guides/MODULE_MIGRATION.md) | C++20 module migration guide | [🇰🇷](guides/MODULE_MIGRATION.kr.md) | 200+ |
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| COM-MIGR-001 | IExecutor API Migration Guide | [IEXECUTOR_MIGRATION_GUIDE.md](./advanced/IEXECUTOR_MIGRATION_GUIDE.md) | Released |
+| COM-MIGR-002 | 마이그레이션 가이드 | [MIGRATION.kr.md](./advanced/MIGRATION.kr.md) | Released |
+| COM-MIGR-003 | Migration Guide | [MIGRATION.md](./advanced/MIGRATION.md) | Released |
+| COM-MIGR-004 | Namespace Migration Guide | [NAMESPACE_MIGRATION.md](./advanced/NAMESPACE_MIGRATION.md) | Released |
+| COM-MIGR-005 | DI Container Migration Guide | [DI_MIGRATION_GUIDE.md](./guides/DI_MIGRATION_GUIDE.md) | Released |
+| COM-MIGR-006 | fmt → std::format Migration Guide | [FMT_MIGRATION_GUIDE.md](./guides/FMT_MIGRATION_GUIDE.md) | Released |
+| COM-MIGR-007 | C++20 모듈 마이그레이션 가이드 | [MODULE_MIGRATION.kr.md](./guides/MODULE_MIGRATION.kr.md) | Released |
+| COM-MIGR-008 | C++20 Module Migration Guide | [MODULE_MIGRATION.md](./guides/MODULE_MIGRATION.md) | Released |
+| COM-MIGR-009 | Result\<T\> 마이그레이션 가이드 | [RESULT_MIGRATION_GUIDE.kr.md](./guides/RESULT_MIGRATION_GUIDE.kr.md) | Released |
+| COM-MIGR-010 | Result\<T\> Migration Guide | [RESULT_MIGRATION_GUIDE.md](./guides/RESULT_MIGRATION_GUIDE.md) | Released |
 
-### 📙 Advanced Topics
+### Integration (6)
 
-For experienced users and contributors:
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| COM-INTR-001 | 크로스 시스템 통합 가이드 | [INTEGRATION_GUIDE.kr.md](./INTEGRATION_GUIDE.kr.md) | Released |
+| COM-INTR-002 | Cross-System Integration Guide | [INTEGRATION_GUIDE.md](./INTEGRATION_GUIDE.md) | Released |
+| COM-INTR-003 | 시스템 통합 가이드 | [INTEGRATION.kr.md](./guides/INTEGRATION.kr.md) | Released |
+| COM-INTR-004 | System Integration Guide | [INTEGRATION.md](./guides/INTEGRATION.md) | Released |
+| COM-INTR-005 | common_system 통합 정책 | [INTEGRATION_POLICY.kr.md](./guides/INTEGRATION_POLICY.kr.md) | Released |
+| COM-INTR-006 | common_system Integration Policy | [INTEGRATION_POLICY.md](./guides/INTEGRATION_POLICY.md) | Released |
 
-| Document | Description | Korean | Lines |
-|----------|-------------|--------|-------|
-| [COMPATIBILITY.md](COMPATIBILITY.md) | Version compatibility matrix for KCENON ecosystem | [🇰🇷](COMPATIBILITY.kr.md) | 300+ |
-| [MIGRATION.md](advanced/MIGRATION.md) | Migration guide to common_system integration | [🇰🇷](advanced/MIGRATION.kr.md) | 400+ |
-| [IEXECUTOR_MIGRATION_GUIDE.md](advanced/IEXECUTOR_MIGRATION_GUIDE.md) | Function-based to job-based API migration | - | 200+ |
-| [NAMESPACE_MIGRATION.md](advanced/NAMESPACE_MIGRATION.md) | Namespace migration strategy and patterns | - | 150+ |
-| [DEPENDENCY_MATRIX.md](advanced/DEPENDENCY_MATRIX.md) | System dependency relationships and integration status | [🇰🇷](advanced/DEPENDENCY_MATRIX.kr.md) | 200+ |
-| [STRUCTURE.md](advanced/STRUCTURE.md) | Project directory layout and organization | - | 150+ |
-| [SINGLETON_GUIDELINES.md](SINGLETON_GUIDELINES.md) | Singleton pattern guidelines for SDOF prevention | [🇰🇷](SINGLETON_GUIDELINES.kr.md) | 300+ |
+### Quality (2)
 
-### 🤝 Contributing
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| COM-QUAL-001 | Common System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
+| COM-QUAL-002 | Common System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
 
-For contributors and maintainers:
+### Security (2)
 
-| Document | Description | Korean | Lines |
-|----------|-------------|--------|-------|
-| [CONTRIBUTING.md](contributing/CONTRIBUTING.md) | Contribution guidelines, header-only best practices, testing | - | 996 |
-| [CI_CD_GUIDE.md](contributing/CI_CD_GUIDE.md) | CI/CD pipeline, static analysis, header validation | - | 864 |
-| [CHANGELOG_TEMPLATE.md](contributing/CHANGELOG_TEMPLATE.md) | Standardized CHANGELOG format for ecosystem | - | 200+ |
-| [DOCUMENTATION_GUIDELINES.md](contributing/DOCUMENTATION_GUIDELINES.md) | Documentation structure standards for ecosystem | - | 400+ |
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| COM-SECU-001 | CVE Scanning and SBOM Generation Guide | [CVE-SCANNING.md](./guides/CVE-SCANNING.md) | Released |
+| COM-SECU-002 | Security Best Practices | [SECURITY_BEST_PRACTICES.md](./guides/SECURITY_BEST_PRACTICES.md) | Released |
 
----
+### Architecture Decision Records (1)
 
-## Documentation by Role
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| COM-ADR-001 | ADR-001: Standardize on vcpkg as the sole package manager | [ADR-001-vcpkg-only.md](./advanced/ADR-001-vcpkg-only.md) | Released |
 
-### 👤 For New Users
+### Project (19)
 
-**Getting Started Path**:
-1. **⚡ Quick Start** - [5-minute guide](guides/QUICK_START.md) to first program with Result<T>
-2. **🏗️ Architecture** - [System overview](01-ARCHITECTURE.md) and Layer 0 foundation
-3. **🔧 Integration** - [Integration guide](guides/INTEGRATION.md) with CMake examples
-4. **💡 Examples** - [FAQ](guides/FAQ.md) with 23 practical examples
-
-**When You Have Issues**:
-- Check [FAQ](guides/FAQ.md) first (23 common questions)
-- Use [Troubleshooting](guides/TROUBLESHOOTING.md) for template errors
-- Search [GitHub Issues](https://github.com/kcenon/common_system/issues)
-
-### 💻 For Experienced Developers
-
-**Advanced Usage Path**:
-1. **🏗️ Architecture** - Understand [Layer 0 foundation](01-ARCHITECTURE.md)
-2. **⚠️ Error Handling** - Master [Result<T> pattern](guides/ERROR_HANDLING.md)
-3. **✨ Best Practices** - Learn [optimization patterns](guides/BEST_PRACTICES.md)
-4. **🔍 Advanced** - Study [dependency matrix](advanced/DEPENDENCY_MATRIX.md)
-
-**Deep Dive Topics**:
-- [Error Handling](guides/ERROR_HANDLING.md) - Monadic operations and patterns
-- [RAII Guidelines](guides/RAII_GUIDELINES.md) - Resource management
-- [Smart Pointers](guides/SMART_POINTER_GUIDELINES.md) - Ownership semantics
-- [Error Codes](guides/ERROR_CODE_GUIDELINES.md) - Adding custom error codes
-
-### 🔧 For System Integrators
-
-**Integration Path**:
-1. **🔧 Integration Guide** - [System integration](guides/INTEGRATION.md)
-2. **📋 Integration Policy** - [Official requirements](guides/INTEGRATION_POLICY.md)
-3. **✨ Best Practices** - [Integration patterns](guides/BEST_PRACTICES.md#system-integration)
-4. **🐛 Troubleshooting** - [Common issues](guides/TROUBLESHOOTING.md)
-
-**Migration Resources**:
-- [Migration Guide](advanced/MIGRATION.md) - Adopt common_system integration
-- [IExecutor Migration](advanced/IEXECUTOR_MIGRATION_GUIDE.md) - Update executor usage
-- [Namespace Migration](advanced/NAMESPACE_MIGRATION.md) - Namespace changes
-- [Dependency Matrix](advanced/DEPENDENCY_MATRIX.md) - System relationships
-- [Compatibility Matrix](COMPATIBILITY.md) - Version requirements across ecosystem
-
-### 🤝 For Contributors
-
-**Contribution Path**:
-1. **🤝 Contributing** - [How to contribute](contributing/CONTRIBUTING.md)
-2. **🚀 CI/CD** - [Pipeline documentation](contributing/CI_CD_GUIDE.md)
-3. **🏗️ Architecture** - [System internals](01-ARCHITECTURE.md)
-4. **📊 Structure** - [Project organization](advanced/STRUCTURE.md)
-
-**Development Resources**:
-- [Code Style](contributing/CONTRIBUTING.md#code-style-guidelines)
-- [Testing Guide](contributing/CI_CD_GUIDE.md#running-checks-locally)
-- [Header-Only Best Practices](contributing/CONTRIBUTING.md#header-only-library-guidelines)
-
----
-
-## By Feature
-
-### ⚠️ Result<T> Pattern
-
-| Topic | Document | Section |
-|-------|----------|---------|
-| Usage | [Error Handling](guides/ERROR_HANDLING.md) | Result<T> Pattern |
-| Best Practices | [Best Practices](guides/BEST_PRACTICES.md) | Error Handling |
-| FAQ | [FAQ](guides/FAQ.md) | Result<T> Usage |
-| Examples | [Quick Start](guides/QUICK_START.md) | First Program |
-
-### 🔗 Standard Interfaces
-
-| Topic | Document | Section |
-|-------|----------|---------|
-| ILogger | [Architecture](01-ARCHITECTURE.md) | Standard Interfaces |
-| IMonitor | [Architecture](01-ARCHITECTURE.md) | Standard Interfaces |
-| IExecutor | [Architecture](01-ARCHITECTURE.md) | Standard Interfaces |
-| Migration | [IExecutor Migration](advanced/IEXECUTOR_MIGRATION_GUIDE.md) | Job-Based API |
-
-### 🛡️ RAII Patterns
-
-| Topic | Document | Section |
-|-------|----------|---------|
-| Guidelines | [RAII Guidelines](guides/RAII_GUIDELINES.md) | Resource Management |
-| Smart Pointers | [Smart Pointer Guidelines](guides/SMART_POINTER_GUIDELINES.md) | Ownership |
-| Best Practices | [Best Practices](guides/BEST_PRACTICES.md) | RAII Patterns |
-| Examples | [FAQ](guides/FAQ.md) | RAII Usage |
-
-### 🔧 System Integration
-
-| Topic | Document | Section |
-|-------|----------|---------|
-| Quick Integration | [Integration](guides/INTEGRATION.md) | Quick Start |
-| CMake Patterns | [Integration Policy](guides/INTEGRATION_POLICY.md) | CMake Config |
-| Migration | [Migration Guide](advanced/MIGRATION.md) | Step-by-Step |
-| Dependencies | [Dependency Matrix](advanced/DEPENDENCY_MATRIX.md) | System Graph |
-
-### 🐛 Error Codes
-
-| Topic | Document | Section |
-|-------|----------|---------|
-| Guidelines | [Error Code Guidelines](guides/ERROR_CODE_GUIDELINES.md) | Allocation |
-| Adding Codes | [Error Code Guidelines](guides/ERROR_CODE_GUIDELINES.md) | New Codes |
-| Validation | [Error Code Guidelines](guides/ERROR_CODE_GUIDELINES.md) | Compile-Time |
-| Troubleshooting | [Troubleshooting](guides/TROUBLESHOOTING.md) | Error Codes |
-
----
-
-## Project Information
-
-### Current Status
-- **Version**: 0.1.0.0 (Layer 0 Foundation)
-- **Type**: Header-Only Library
-- **C++ Standard**: C++17 (C++20 for optional features)
-- **License**: BSD 3-Clause
-- **Test Status**: Under Development
-
-### Layer 0 Foundation
-Common system provides the foundational layer for all KCENON systems:
-- ✅ **Standard Interfaces** - ILogger, IMonitor, IExecutor abstractions
-- ✅ **Result<T> Pattern** - Type-safe error handling with monadic operations
-- ✅ **RAII Support** - Resource management utilities and guidelines
-- ✅ **Smart Pointer Guidelines** - Ownership semantics and best practices
-- ✅ **Error Code System** - Compile-time validated error code registry
-- ✅ **Cross-Platform** - Windows, macOS, Linux support
-
-### Key Features
-- 🎯 **Header-Only** - No build artifacts, include and use
-- 🔗 **Standard Interfaces** - Unified abstractions for logging, monitoring, execution
-- ⚠️ **Result<T> Pattern** - Type-safe error handling replacing exceptions
-- 🛡️ **RAII Patterns** - Resource safety with compile-time guarantees
-- 🔧 **System Integration** - Foundation for 6 higher-layer systems
-- 📦 **Dependency Injection** - Interface-based design for testability
-- 🧵 **Thread Safe** - Core utilities verified with TSan
-- 🔐 **Production Ready** - Used across all KCENON production systems
-
-### Dependent Systems
-Common system serves as Layer 0 foundation for:
-- **Layer 1**: thread_system, container_system
-- **Layer 2**: logger_system, monitoring_system, database_system
-- **Layer 3**: network_system
-- **Application**: messaging_system
-
----
-
-## Contributing to Documentation
-
-### Documentation Standards
-Follow the [Documentation Structure Guidelines](contributing/DOCUMENTATION_GUIDELINES.md):
-- Standard folder structure for all ecosystem systems
-- Required documents and naming conventions
-- Front matter on all documents
-- Code examples must compile
-- Bilingual support (English/Korean)
-- Cross-references with relative links
-
-Use the provided templates in `docs/contributing/templates/`:
-- [ARCHITECTURE_TEMPLATE.md](contributing/templates/ARCHITECTURE_TEMPLATE.md)
-- [FEATURE_TEMPLATE.md](contributing/templates/FEATURE_TEMPLATE.md)
-- [GUIDE_TEMPLATE.md](contributing/templates/GUIDE_TEMPLATE.md)
-
-### Areas for Improvement
-- [ ] Korean translations for new guides (FAQ, TROUBLESHOOTING, BEST_PRACTICES)
-- [ ] Video tutorials for Result<T> pattern
-- [ ] Interactive examples for RAII patterns
-- [ ] More integration scenarios
-
-### Submission Process
-1. Read [Contributing Guide](contributing/CONTRIBUTING.md)
-2. Edit markdown files
-3. Test all code examples (header-only compile checks)
-4. Update Korean translations
-5. Submit pull request
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| COM-PROJ-001 | 변경 이력 | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| COM-PROJ-002 | Changelog | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| COM-PROJ-003 | KCENON 에코시스템 호환성 매트릭스 | [COMPATIBILITY.kr.md](./COMPATIBILITY.kr.md) | Released |
+| COM-PROJ-004 | KCENON Ecosystem Compatibility Matrix | [COMPATIBILITY.md](./COMPATIBILITY.md) | Released |
+| COM-PROJ-005 | Deprecated APIs | [DEPRECATION.kr.md](./DEPRECATION.kr.md) | Released |
+| COM-PROJ-006 | Deprecated APIs | [DEPRECATION.md](./DEPRECATION.md) | Released |
+| COM-PROJ-007 | Unified System SDK Improvement Proposal | [IMPROVEMENT_PROPOSAL.md](./IMPROVEMENT_PROPOSAL.md) | Released |
+| COM-PROJ-008 | Common System - 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| COM-PROJ-009 | Common System - Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| COM-PROJ-010 | Releasing common_system | [RELEASING.md](./RELEASING.md) | Released |
+| COM-PROJ-011 | Rust/C++ Feature Parity Matrix | [RUST_PARITY.md](./RUST_PARITY.md) | Released |
+| COM-PROJ-012 | SOUP Inventory — kcenon Ecosystem | [SOUP-LIST.md](./SOUP-LIST.md) | Released |
+| COM-PROJ-013 | SOUP List &mdash; common_system | [SOUP.md](./SOUP.md) | Released |
+| COM-PROJ-014 | Dependency Matrix - 상세 분석 | [DEPENDENCY_MATRIX.kr.md](./advanced/DEPENDENCY_MATRIX.kr.md) | Released |
+| COM-PROJ-015 | Dependency Matrix - Detailed Analysis | [DEPENDENCY_MATRIX.md](./advanced/DEPENDENCY_MATRIX.md) | Released |
+| COM-PROJ-016 | CHANGELOG Template | [CHANGELOG_TEMPLATE.md](./contributing/CHANGELOG_TEMPLATE.md) | Released |
+| COM-PROJ-017 | Contributing to common_system | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+| COM-PROJ-018 | Documentation Structure Guidelines | [DOCUMENTATION_GUIDELINES.md](./contributing/DOCUMENTATION_GUIDELINES.md) | Released |
+| COM-PROJ-019 | [SYSTEM_NAME] Features | [FEATURE_TEMPLATE.md](./contributing/templates/FEATURE_TEMPLATE.md) | Released |
 
 ---
 
-## 📞 Getting Help
-
-### Documentation Issues
-- **Missing info**: [Open documentation issue](https://github.com/kcenon/common_system/issues/new?labels=documentation)
-- **Incorrect examples**: Report with details
-- **Unclear instructions**: Suggest improvements
-
-### Technical Support
-1. Check [FAQ](guides/FAQ.md) - 23 common questions
-2. Read [Troubleshooting](guides/TROUBLESHOOTING.md) - Template errors and solutions
-3. Search [GitHub Issues](https://github.com/kcenon/common_system/issues)
-4. Ask on [GitHub Discussions](https://github.com/kcenon/common_system/discussions)
-
-### Support Resources
-- **Issues**: Bug reports and feature requests
-- **Discussions**: Questions and support
-- **Pull Requests**: Code and documentation contributions
-
----
-
-## External Resources
-
-- **GitHub Repository**: [kcenon/common_system](https://github.com/kcenon/common_system)
-- **Issue Tracker**: [GitHub Issues](https://github.com/kcenon/common_system/issues)
-- **Main README**: [../README.md](../README.md)
-- **Layer Architecture**: [01-ARCHITECTURE.md](01-ARCHITECTURE.md)
-
----
-
-## Documentation Roadmap
-
-### ✅ Current (v1.0 - 2025-11-11)
-- ✅ Comprehensive architecture documentation
-- ✅ 23 FAQ questions covering all features
-- ✅ Detailed troubleshooting guide
-- ✅ Best practices documentation
-- ✅ Header-only specific guidelines
-- ✅ Integration policy and patterns
-- ✅ Migration guides
-- ✅ CI/CD documentation
-
-### 📋 Future Enhancements
-- 📝 Korean translations for new guides
-- 🎥 Video tutorials for Result<T> and RAII
-- 📊 Interactive examples with compiler explorer
-- 🌐 Multi-language support (Japanese, Chinese)
-- 📖 Case studies from dependent systems
-- 🔄 Migration guides for major versions
-
----
-
-**Common System Documentation** - Layer 0 Foundation for C++17/20 Systems
-
-**Last Updated**: 2025-11-11
-**Next Review**: 2026-02-11
+*Registry generated for issue [#563](https://github.com/kcenon/common_system/issues/563).*

--- a/docs/README_TEMPLATE.md
+++ b/docs/README_TEMPLATE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # README_TEMPLATE.md
 
+> **SSOT**: This document is the single source of truth for **README_TEMPLATE.md**.
+
 > Canonical README structure for all kcenon ecosystem projects.
 > Every project README (both `README.md` and `README.kr.md`) MUST follow
 > this 13-section layout in the order shown below.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -14,6 +14,8 @@ category: "PROJ"
 
 # Releasing common_system
 
+> **SSOT**: This document is the single source of truth for **Releasing common_system**.
+
 This document describes the versioning policy and release process for common_system
 and the broader kcenon ecosystem.
 

--- a/docs/RUST_PARITY.md
+++ b/docs/RUST_PARITY.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Rust/C++ Feature Parity Matrix
 
+> **SSOT**: This document is the single source of truth for **Rust/C++ Feature Parity Matrix**.
+
 > **Language:** **English** | [한국어](RUST_PARITY.kr.md)
 
 **Complete (Parts 1-3)**: Overall Parity Status, API Mapping, Feature Comparison, Interop, and Roadmap

--- a/docs/SINGLETON_GUIDELINES.kr.md
+++ b/docs/SINGLETON_GUIDELINES.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 싱글톤 패턴 가이드라인
 
+> **SSOT**: This document is the single source of truth for **싱글톤 패턴 가이드라인**.
+
 이 가이드는 kcenon 에코시스템 전체에서 Static Destruction Order Fiasco (SDOF) 문제를 방지하기 위한 표준화된 싱글톤 패턴 가이드라인을 수립합니다.
 
 ## 배경

--- a/docs/SINGLETON_GUIDELINES.md
+++ b/docs/SINGLETON_GUIDELINES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Singleton Pattern Guidelines
 
+> **SSOT**: This document is the single source of truth for **Singleton Pattern Guidelines**.
+
 This guide establishes standardized singleton pattern guidelines for the kcenon ecosystem to prevent Static Destruction Order Fiasco (SDOF) issues across all systems.
 
 ## Background

--- a/docs/SOUP-LIST.md
+++ b/docs/SOUP-LIST.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # SOUP Inventory — kcenon Ecosystem
 
+> **SSOT**: This document is the single source of truth for **SOUP Inventory — kcenon Ecosystem**.
+
 > **SOUP** = Software of Unknown Provenance (IEC 62304 §8.1.2)
 >
 > This document catalogs all third-party dependencies used across the kcenon

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # SOUP List &mdash; common_system
 
+> **SSOT**: This document is the single source of truth for **SOUP List &mdash; common_system**.
+
 > **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**
 >
 > This document is the authoritative reference for all external software dependencies.

--- a/docs/advanced/ADR-001-vcpkg-only.md
+++ b/docs/advanced/ADR-001-vcpkg-only.md
@@ -10,6 +10,8 @@ category: "ADR"
 
 # ADR-001: Standardize on vcpkg as the sole package manager
 
+> **SSOT**: This document is the single source of truth for **ADR-001: Standardize on vcpkg as the sole package manager**.
+
 | Field | Value |
 |-------|-------|
 | Status | Accepted |

--- a/docs/advanced/DEPENDENCY_MATRIX.kr.md
+++ b/docs/advanced/DEPENDENCY_MATRIX.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Dependency Matrix - 상세 분석
 
+> **SSOT**: This document is the single source of truth for **Dependency Matrix - 상세 분석**.
+
 > **Language:** [English](DEPENDENCY_MATRIX.md) | **한국어**
 
 

--- a/docs/advanced/DEPENDENCY_MATRIX.md
+++ b/docs/advanced/DEPENDENCY_MATRIX.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Dependency Matrix - Detailed Analysis
 
+> **SSOT**: This document is the single source of truth for **Dependency Matrix - Detailed Analysis**.
+
 > **Language:** **English** | [한국어](DEPENDENCY_MATRIX.kr.md)
 
 

--- a/docs/advanced/IEXECUTOR_MIGRATION_GUIDE.md
+++ b/docs/advanced/IEXECUTOR_MIGRATION_GUIDE.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # IExecutor API Migration Guide
 
+> **SSOT**: This document is the single source of truth for **IExecutor API Migration Guide**.
+
 **Date**: 2025-11-09
 **Status**: Deprecation Notice
 **Target Removal**: Next major version (2.0.0)

--- a/docs/advanced/MIGRATION.kr.md
+++ b/docs/advanced/MIGRATION.kr.md
@@ -12,6 +12,8 @@ category: "MIGR"
 
 # 마이그레이션 가이드
 
+> **SSOT**: This document is the single source of truth for **마이그레이션 가이드**.
+
 ## 목차
 
 - [개요](#개요)

--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -12,6 +12,8 @@ category: "MIGR"
 
 # Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Migration Guide**.
+
 ## Table of Contents
 
 - [Overview](#overview)

--- a/docs/advanced/NAMESPACE_MIGRATION.md
+++ b/docs/advanced/NAMESPACE_MIGRATION.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Namespace Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Namespace Migration Guide**.
+
 ## Issue
 
 The common_system include path is `kcenon/common/*`, but some headers declare `namespace common` instead of `namespace kcenon::common`. This creates inconsistency where:

--- a/docs/advanced/STRUCTURE.md
+++ b/docs/advanced/STRUCTURE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Common System - Project Structure
 
+> **SSOT**: This document is the single source of truth for **Common System - Project Structure**.
+
 **English | [한국어](STRUCTURE.kr.md)**
 
 ---

--- a/docs/architecture/RUNTIME_BINDING.md
+++ b/docs/architecture/RUNTIME_BINDING.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Runtime Binding Architecture
 
+> **SSOT**: This document is the single source of truth for **Runtime Binding Architecture**.
+
 ## Overview
 
 The Runtime Binding Pattern is a fundamental architectural approach in common_system that decouples interface definitions from their implementations at runtime. This pattern enables:

--- a/docs/contributing/CHANGELOG_TEMPLATE.md
+++ b/docs/contributing/CHANGELOG_TEMPLATE.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # CHANGELOG Template
 
+> **SSOT**: This document is the single source of truth for **CHANGELOG Template**.
+
 This template provides a standardized CHANGELOG format for all KCENON ecosystem systems.
 
 ## Format Specification

--- a/docs/contributing/CI_CD_GUIDE.md
+++ b/docs/contributing/CI_CD_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # CI/CD Guide - common_system
 
+> **SSOT**: This document is the single source of truth for **CI/CD Guide - common_system**.
+
 This document describes the Continuous Integration and Continuous Deployment (CI/CD) pipeline for the `common_system` project, a header-only C++ library. The pipelines are designed to validate code quality, test functionality, and ensure documentation is always up-to-date.
 
 ## Table of Contents

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -14,6 +14,8 @@ category: "PROJ"
 
 # Contributing to common_system
 
+> **SSOT**: This document is the single source of truth for **Contributing to common_system**.
+
 Thank you for your interest in contributing to the common_system library! This document provides guidelines and instructions for contributing code, documentation, and improvements.
 
 ## Table of Contents

--- a/docs/contributing/DOCUMENTATION_GUIDELINES.md
+++ b/docs/contributing/DOCUMENTATION_GUIDELINES.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Documentation Structure Guidelines
 
+> **SSOT**: This document is the single source of truth for **Documentation Structure Guidelines**.
+
 > **Language:** **English** | [한국어](DOCUMENTATION_GUIDELINES.kr.md)
 
 **Version:** 1.0.0

--- a/docs/contributing/templates/ARCHITECTURE_TEMPLATE.md
+++ b/docs/contributing/templates/ARCHITECTURE_TEMPLATE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # [SYSTEM_NAME] Architecture
 
+> **SSOT**: This document is the single source of truth for **[SYSTEM_NAME] Architecture**.
+
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)
 
 **Version:** X.Y.Z

--- a/docs/contributing/templates/FEATURE_TEMPLATE.md
+++ b/docs/contributing/templates/FEATURE_TEMPLATE.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # [SYSTEM_NAME] Features
 
+> **SSOT**: This document is the single source of truth for **[SYSTEM_NAME] Features**.
+
 > **Language:** **English** | [한국어](FEATURES.kr.md)
 
 **Version:** X.Y.Z

--- a/docs/contributing/templates/GUIDE_TEMPLATE.md
+++ b/docs/contributing/templates/GUIDE_TEMPLATE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # [Guide Title]
 
+> **SSOT**: This document is the single source of truth for **[Guide Title]**.
+
 > **Language:** **English** | [한국어](GUIDE_NAME.kr.md)
 
 **Version:** X.Y.Z

--- a/docs/guides/BEST_PRACTICES.md
+++ b/docs/guides/BEST_PRACTICES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Best Practices for common_system
 
+> **SSOT**: This document is the single source of truth for **Best Practices for common_system**.
+
 **Version**: 0.1.1.0
 **Last Updated**: 2026-01-03
 

--- a/docs/guides/CONCEPTS_GUIDE.kr.md
+++ b/docs/guides/CONCEPTS_GUIDE.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # C++20 Concepts 가이드
 
+> **SSOT**: This document is the single source of truth for **C++20 Concepts 가이드**.
+
 **Language:** [English](CONCEPTS_GUIDE.md) | **한국어**
 
 이 가이드는 Common System 라이브러리에서 컴파일 타임 타입 검증을 위해 C++20 concepts를 사용하는 방법을 설명합니다.

--- a/docs/guides/CONCEPTS_GUIDE.md
+++ b/docs/guides/CONCEPTS_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # C++20 Concepts Guide
 
+> **SSOT**: This document is the single source of truth for **C++20 Concepts Guide**.
+
 **Language:** **English** | [한국어](CONCEPTS_GUIDE.kr.md)
 
 This guide explains how to use C++20 concepts in the Common System library for compile-time type validation.

--- a/docs/guides/CVE-SCANNING.md
+++ b/docs/guides/CVE-SCANNING.md
@@ -10,6 +10,8 @@ category: "SECU"
 
 # CVE Scanning and SBOM Generation Guide
 
+> **SSOT**: This document is the single source of truth for **CVE Scanning and SBOM Generation Guide**.
+
 This document describes the automated SBOM generation and CVE scanning pipeline
 used across the kcenon ecosystem.
 

--- a/docs/guides/DI_MIGRATION_GUIDE.md
+++ b/docs/guides/DI_MIGRATION_GUIDE.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # DI Container Migration Guide
 
+> **SSOT**: This document is the single source of truth for **DI Container Migration Guide**.
+
 > **Language:** **English**
 
 ## Table of Contents

--- a/docs/guides/ERROR_CODE_GUIDELINES.md
+++ b/docs/guides/ERROR_CODE_GUIDELINES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Error Code Guidelines
 
+> **SSOT**: This document is the single source of truth for **Error Code Guidelines**.
+
 **Version**: 0.2.0.0
 **Last Updated**: 2025-11-08
 **Status**: Active

--- a/docs/guides/ERROR_HANDLING.kr.md
+++ b/docs/guides/ERROR_HANDLING.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Error Handling 가이드라인
 
+> **SSOT**: This document is the single source of truth for **Error Handling 가이드라인**.
+
 > **Language:** [English](ERROR_HANDLING.md) | **한국어**
 
 

--- a/docs/guides/ERROR_HANDLING.md
+++ b/docs/guides/ERROR_HANDLING.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Error Handling Guidelines
 
+> **SSOT**: This document is the single source of truth for **Error Handling Guidelines**.
+
 > **Language:** **English** | [한국어](ERROR_HANDLING.kr.md)
 
 

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Common System - Frequently Asked Questions
 
+> **SSOT**: This document is the single source of truth for **Common System - Frequently Asked Questions**.
+
 **Version:** 0.2.0 | **Last Updated:** November 2025
 
 This FAQ covers the most common questions about the common_system library - a header-only C++20 foundation library providing universal interfaces and design patterns for modular system architectures.

--- a/docs/guides/FMT_MIGRATION_GUIDE.md
+++ b/docs/guides/FMT_MIGRATION_GUIDE.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # fmt → std::format Migration Guide
 
+> **SSOT**: This document is the single source of truth for **fmt → std::format Migration Guide**.
+
 > **Tracking**: [common_system#406](https://github.com/kcenon/common_system/issues/406)
 >
 > **Status**: Migration complete — all ecosystem projects now use C++20 `std::format`

--- a/docs/guides/INTEGRATION.kr.md
+++ b/docs/guides/INTEGRATION.kr.md
@@ -12,6 +12,8 @@ category: "INTR"
 
 # 시스템 통합 가이드
 
+> **SSOT**: This document is the single source of truth for **시스템 통합 가이드**.
+
 ## 목차
 
 - [개요](#개요)

--- a/docs/guides/INTEGRATION.md
+++ b/docs/guides/INTEGRATION.md
@@ -12,6 +12,8 @@ category: "INTR"
 
 # System Integration Guide
 
+> **SSOT**: This document is the single source of truth for **System Integration Guide**.
+
 ## Table of Contents
 
 - [Overview](#overview)

--- a/docs/guides/INTEGRATION_POLICY.kr.md
+++ b/docs/guides/INTEGRATION_POLICY.kr.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # common_system 통합 정책
 
+> **SSOT**: This document is the single source of truth for **common_system 통합 정책**.
+
 > **Language:** [English](INTEGRATION_POLICY.md) | **한국어**
 
 ## 개요

--- a/docs/guides/INTEGRATION_POLICY.md
+++ b/docs/guides/INTEGRATION_POLICY.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # common_system Integration Policy
 
+> **SSOT**: This document is the single source of truth for **common_system Integration Policy**.
+
 > **Language:** **English** | [한국어](INTEGRATION_POLICY.kr.md)
 
 ## Overview

--- a/docs/guides/LOGGING_BEST_PRACTICES.md
+++ b/docs/guides/LOGGING_BEST_PRACTICES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Logging Best Practices
 
+> **SSOT**: This document is the single source of truth for **Logging Best Practices**.
+
 This guide covers best practices for logging in applications using the common_system runtime binding pattern.
 
 ## Overview

--- a/docs/guides/MIGRATION_RUNTIME_BINDING.md
+++ b/docs/guides/MIGRATION_RUNTIME_BINDING.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Migration Guide: Runtime Binding Pattern
 
+> **SSOT**: This document is the single source of truth for **Migration Guide: Runtime Binding Pattern**.
+
 This guide provides step-by-step instructions for migrating existing code to use the runtime binding pattern introduced in common_system v2.0.
 
 ## Prerequisites

--- a/docs/guides/MODULE_MIGRATION.kr.md
+++ b/docs/guides/MODULE_MIGRATION.kr.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # C++20 모듈 마이그레이션 가이드
 
+> **SSOT**: This document is the single source of truth for **C++20 모듈 마이그레이션 가이드**.
+
 **common_system에서 기존 헤더 대신 C++20 모듈을 사용하기 위한 가이드**입니다.
 
 > **Language:** [English](MODULE_MIGRATION.md) | **한국어**

--- a/docs/guides/MODULE_MIGRATION.md
+++ b/docs/guides/MODULE_MIGRATION.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # C++20 Module Migration Guide
 
+> **SSOT**: This document is the single source of truth for **C++20 Module Migration Guide**.
+
 **Guide for using C++20 modules** with common_system instead of traditional header includes.
 
 > **Language:** **English** | [한국어](MODULE_MIGRATION.kr.md)

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Quick Start Guide - common_system
 
+> **SSOT**: This document is the single source of truth for **Quick Start Guide - common_system**.
+
 **5-minute guide** to get started with the header-only common_system library for C++20.
 
 ## Prerequisites

--- a/docs/guides/RAII_GUIDELINES.kr.md
+++ b/docs/guides/RAII_GUIDELINES.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Common System을 위한 RAII 패턴 가이드라인
 
+> **SSOT**: This document is the single source of truth for **Common System을 위한 RAII 패턴 가이드라인**.
+
 > **Language:** [English](RAII_GUIDELINES.md) | **한국어**
 
 

--- a/docs/guides/RAII_GUIDELINES.md
+++ b/docs/guides/RAII_GUIDELINES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # RAII Pattern Guidelines for Common System
 
+> **SSOT**: This document is the single source of truth for **RAII Pattern Guidelines for Common System**.
+
 > **Language:** **English** | [한국어](RAII_GUIDELINES.kr.md)
 
 

--- a/docs/guides/RESULT_MIGRATION_GUIDE.kr.md
+++ b/docs/guides/RESULT_MIGRATION_GUIDE.kr.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Result\<T\> 마이그레이션 가이드
 
+> **SSOT**: This document is the single source of truth for **Result\<T\> 마이그레이션 가이드**.
+
 > **Language:** [English](RESULT_MIGRATION_GUIDE.md) | **한국어**
 
 ## 목차

--- a/docs/guides/RESULT_MIGRATION_GUIDE.md
+++ b/docs/guides/RESULT_MIGRATION_GUIDE.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Result\<T\> Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Result\<T\> Migration Guide**.
+
 > **Language:** **English** | [한국어](RESULT_MIGRATION_GUIDE.kr.md)
 
 ## Table of Contents

--- a/docs/guides/SECURITY_BEST_PRACTICES.md
+++ b/docs/guides/SECURITY_BEST_PRACTICES.md
@@ -10,6 +10,8 @@ category: "SECU"
 
 # Security Best Practices
 
+> **SSOT**: This document is the single source of truth for **Security Best Practices**.
+
 This guide documents security features and best practices for the Common System, focusing on registry protection and audit logging.
 
 ## Overview

--- a/docs/guides/SMART_POINTER_GUIDELINES.kr.md
+++ b/docs/guides/SMART_POINTER_GUIDELINES.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 스마트 포인터 사용 가이드라인
 
+> **SSOT**: This document is the single source of truth for **스마트 포인터 사용 가이드라인**.
+
 > **Language:** [English](SMART_POINTER_GUIDELINES.md) | **한국어**
 
 

--- a/docs/guides/SMART_POINTER_GUIDELINES.md
+++ b/docs/guides/SMART_POINTER_GUIDELINES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Smart Pointer Usage Guidelines
 
+> **SSOT**: This document is the single source of truth for **Smart Pointer Usage Guidelines**.
+
 > **Language:** **English** | [한국어](SMART_POINTER_GUIDELINES.kr.md)
 
 

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Troubleshooting Guide - common_system
 
+> **SSOT**: This document is the single source of truth for **Troubleshooting Guide - common_system**.
+
 > **Language:** **English** | [한국어](TROUBLESHOOTING.kr.md)
 
 A comprehensive troubleshooting guide for the common_system header-only library. This document covers the most common issues encountered when using, integrating, and debugging header-only C++ libraries.

--- a/docs/guides/TROUBLESHOOTING_LOGGING.md
+++ b/docs/guides/TROUBLESHOOTING_LOGGING.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Troubleshooting Guide
 
+> **SSOT**: This document is the single source of truth for **Troubleshooting Guide**.
+
 This guide helps diagnose and resolve common issues with the logging system in common_system.
 
 ## Quick Diagnostic Checklist

--- a/docs/performance/E2E_BENCHMARKS.md
+++ b/docs/performance/E2E_BENCHMARKS.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # End-to-End Benchmark Documentation
 
+> **SSOT**: This document is the single source of truth for **End-to-End Benchmark Documentation**.
+
 > **Status**: ✅ **Complete**
 
 This document provides comprehensive end-to-end performance benchmarks measuring system integration overhead when multiple kcenon ecosystem systems work together in real-world scenarios.


### PR DESCRIPTION
## Summary

- Create `docs/README.md` as the single source of truth documentation index for common_system
- Add SSOT declarations (`> **SSOT**: ...`) to each authoritative document header
- Registry table lists all 83 documents with doc_id, topic, authority document link, and status
- Documents grouped by category (Architecture, API, Features, Guides, etc.)
- Verified no duplicate doc_id values and all file links are valid

## Test Plan

- [x] All 83 document entries have valid file links
- [x] No duplicate doc_id values within the project
- [x] SSOT declarations added to authoritative documents
- [x] Registry follows the format specified in issue #563

Closes kcenon/common_system#563