### PR TITLE
docs: add @file Doxygen blocks to public API headers

### DIFF
--- a/include/kcenon/common/adapters/adapter.h
+++ b/include/kcenon/common/adapters/adapter.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file adapter.h
+ * @brief Adapter traits and base class for type-erased cross-system wrappers.
+ *
+ * @see smart_adapter.h For the ownership-managing adapter variant
+ */
+
 #pragma once
 
 #include <atomic>

--- a/include/kcenon/common/interfaces/database_interface.h
+++ b/include/kcenon/common/interfaces/database_interface.h
@@ -2,6 +2,16 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file database_interface.h
+ * @brief Abstract database interface with value types and query operations.
+ *
+ * Defines IDatabase, database_value variant, and database_row for
+ * backend-agnostic database access across the ecosystem.
+ *
+ * @see database_system For the concrete implementations
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/include/kcenon/common/utils/circular_buffer.h
+++ b/include/kcenon/common/utils/circular_buffer.h
@@ -2,6 +2,14 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file circular_buffer.h
+ * @brief Thread-safe fixed-capacity circular buffer (SPSC-friendly).
+ *
+ * Provides a mutex-protected ring buffer with optional overwrite-on-full
+ * semantics. Useful for bounded logging, event queues, and sliding windows.
+ */
+
 #pragma once
 
 #include <array>

--- a/include/kcenon/common/utils/object_pool.h
+++ b/include/kcenon/common/utils/object_pool.h
@@ -2,6 +2,15 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file object_pool.h
+ * @brief Thread-safe object pool reusing raw storage for expensive objects.
+ *
+ * Allocates raw memory once, performs placement-new on acquisition,
+ * and destructs (but does not deallocate) on release. Reduces allocation
+ * overhead for frequently created/destroyed objects.
+ */
+
 #pragma once
 
 #include <cstddef>


### PR DESCRIPTION
## Summary

Add `@file` Doxygen documentation blocks to 4 public API headers that were missing them, achieving 100% `@file` coverage across all headers in common_system.

### Headers Updated
- `include/kcenon/common/adapters/adapter.h`
- `include/kcenon/common/interfaces/database_interface.h`
- `include/kcenon/common/utils/circular_buffer.h`
- `include/kcenon/common/utils/object_pool.h`

Closes #568

## Test Plan
- [ ] Verify Doxygen generation produces no warnings on updated headers
- [ ] Confirm existing CI checks pass