### PR TITLE
docs(adr): add initial architecture decision records

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ category: "GUID"
 > **SSOT**: This file is the single source of truth for the documentation index
 > of **common_system**.
 
-Total documents: **83**
+Total documents: **86**
 
 ## Document Index
 
@@ -80,28 +80,31 @@ Total documents: **83**
 | 59 | COM-INTR-006 | common_system Integration Policy | [INTEGRATION_POLICY.md](./guides/INTEGRATION_POLICY.md) | Released |
 | 60 | COM-QUAL-001 | Common System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | 61 | COM-QUAL-002 | Common System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| 62 | COM-SECU-001 | CVE Scanning and SBOM Generation Guide | [CVE-SCANNING.md](./guides/CVE-SCANNING.md) | Released |
-| 63 | COM-SECU-002 | Security Best Practices | [SECURITY_BEST_PRACTICES.md](./guides/SECURITY_BEST_PRACTICES.md) | Released |
-| 64 | COM-ADR-001 | ADR-001: Standardize on vcpkg as the sole package manager | [ADR-001-vcpkg-only.md](./advanced/ADR-001-vcpkg-only.md) | Released |
-| 65 | COM-PROJ-001 | 변경 이력 | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
-| 66 | COM-PROJ-002 | Changelog | [CHANGELOG.md](./CHANGELOG.md) | Released |
-| 67 | COM-PROJ-003 | KCENON 에코시스템 호환성 매트릭스 | [COMPATIBILITY.kr.md](./COMPATIBILITY.kr.md) | Released |
-| 68 | COM-PROJ-004 | KCENON Ecosystem Compatibility Matrix | [COMPATIBILITY.md](./COMPATIBILITY.md) | Released |
-| 69 | COM-PROJ-005 | Deprecated APIs | [DEPRECATION.kr.md](./DEPRECATION.kr.md) | Released |
-| 70 | COM-PROJ-006 | Deprecated APIs | [DEPRECATION.md](./DEPRECATION.md) | Released |
-| 71 | COM-PROJ-007 | Unified System SDK Improvement Proposal | [IMPROVEMENT_PROPOSAL.md](./IMPROVEMENT_PROPOSAL.md) | Released |
-| 72 | COM-PROJ-008 | Common System - 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
-| 73 | COM-PROJ-009 | Common System - Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
-| 74 | COM-PROJ-010 | Releasing common_system | [RELEASING.md](./RELEASING.md) | Released |
-| 75 | COM-PROJ-011 | Rust/C++ Feature Parity Matrix | [RUST_PARITY.md](./RUST_PARITY.md) | Released |
-| 76 | COM-PROJ-012 | SOUP Inventory — kcenon Ecosystem | [SOUP-LIST.md](./SOUP-LIST.md) | Released |
-| 77 | COM-PROJ-013 | SOUP List &mdash; common_system | [SOUP.md](./SOUP.md) | Released |
-| 78 | COM-PROJ-014 | Dependency Matrix - 상세 분석 | [DEPENDENCY_MATRIX.kr.md](./advanced/DEPENDENCY_MATRIX.kr.md) | Released |
-| 79 | COM-PROJ-015 | Dependency Matrix - Detailed Analysis | [DEPENDENCY_MATRIX.md](./advanced/DEPENDENCY_MATRIX.md) | Released |
-| 80 | COM-PROJ-016 | CHANGELOG Template | [CHANGELOG_TEMPLATE.md](./contributing/CHANGELOG_TEMPLATE.md) | Released |
-| 81 | COM-PROJ-017 | Contributing to common_system | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
-| 82 | COM-PROJ-018 | Documentation Structure Guidelines | [DOCUMENTATION_GUIDELINES.md](./contributing/DOCUMENTATION_GUIDELINES.md) | Released |
-| 83 | COM-PROJ-019 | [SYSTEM_NAME] Features | [FEATURE_TEMPLATE.md](./contributing/templates/FEATURE_TEMPLATE.md) | Released |
+| 62 | COM-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| 63 | COM-SECU-001 | CVE Scanning and SBOM Generation Guide | [CVE-SCANNING.md](./guides/CVE-SCANNING.md) | Released |
+| 64 | COM-SECU-002 | Security Best Practices | [SECURITY_BEST_PRACTICES.md](./guides/SECURITY_BEST_PRACTICES.md) | Released |
+| 65 | COM-ADR-001 | ADR-001: Standardize on vcpkg as the sole package manager | [ADR-001-vcpkg-only.md](./advanced/ADR-001-vcpkg-only.md) | Released |
+| 66 | COM-ADR-002 | ADR-002: Header-Only Library Design | [ADR-002-header-only-library-design.md](./adr/ADR-002-header-only-library-design.md) | Accepted |
+| 67 | COM-ADR-003 | ADR-003: Result<T> Error Handling Pattern | [ADR-003-result-error-handling-pattern.md](./adr/ADR-003-result-error-handling-pattern.md) | Accepted |
+| 68 | COM-PROJ-001 | 변경 이력 | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| 69 | COM-PROJ-002 | Changelog | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| 70 | COM-PROJ-003 | KCENON 에코시스템 호환성 매트릭스 | [COMPATIBILITY.kr.md](./COMPATIBILITY.kr.md) | Released |
+| 71 | COM-PROJ-004 | KCENON Ecosystem Compatibility Matrix | [COMPATIBILITY.md](./COMPATIBILITY.md) | Released |
+| 72 | COM-PROJ-005 | Deprecated APIs | [DEPRECATION.kr.md](./DEPRECATION.kr.md) | Released |
+| 73 | COM-PROJ-006 | Deprecated APIs | [DEPRECATION.md](./DEPRECATION.md) | Released |
+| 74 | COM-PROJ-007 | Unified System SDK Improvement Proposal | [IMPROVEMENT_PROPOSAL.md](./IMPROVEMENT_PROPOSAL.md) | Released |
+| 75 | COM-PROJ-008 | Common System - 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| 76 | COM-PROJ-009 | Common System - Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| 77 | COM-PROJ-010 | Releasing common_system | [RELEASING.md](./RELEASING.md) | Released |
+| 78 | COM-PROJ-011 | Rust/C++ Feature Parity Matrix | [RUST_PARITY.md](./RUST_PARITY.md) | Released |
+| 79 | COM-PROJ-012 | SOUP Inventory — kcenon Ecosystem | [SOUP-LIST.md](./SOUP-LIST.md) | Released |
+| 80 | COM-PROJ-013 | SOUP List &mdash; common_system | [SOUP.md](./SOUP.md) | Released |
+| 81 | COM-PROJ-014 | Dependency Matrix - 상세 분석 | [DEPENDENCY_MATRIX.kr.md](./advanced/DEPENDENCY_MATRIX.kr.md) | Released |
+| 82 | COM-PROJ-015 | Dependency Matrix - Detailed Analysis | [DEPENDENCY_MATRIX.md](./advanced/DEPENDENCY_MATRIX.md) | Released |
+| 83 | COM-PROJ-016 | CHANGELOG Template | [CHANGELOG_TEMPLATE.md](./contributing/CHANGELOG_TEMPLATE.md) | Released |
+| 84 | COM-PROJ-017 | Contributing to common_system | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+| 85 | COM-PROJ-018 | Documentation Structure Guidelines | [DOCUMENTATION_GUIDELINES.md](./contributing/DOCUMENTATION_GUIDELINES.md) | Released |
+| 86 | COM-PROJ-019 | [SYSTEM_NAME] Features | [FEATURE_TEMPLATE.md](./contributing/templates/FEATURE_TEMPLATE.md) | Released |
 
 ## Documents by Category
 
@@ -199,12 +202,13 @@ Total documents: **83**
 | COM-INTR-005 | common_system 통합 정책 | [INTEGRATION_POLICY.kr.md](./guides/INTEGRATION_POLICY.kr.md) | Released |
 | COM-INTR-006 | common_system Integration Policy | [INTEGRATION_POLICY.md](./guides/INTEGRATION_POLICY.md) | Released |
 
-### Quality (2)
+### Quality (3)
 
 | doc_id | Topic | Document | Status |
 |--------|-------|----------|--------|
 | COM-QUAL-001 | Common System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | COM-QUAL-002 | Common System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
+| COM-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 
 ### Security (2)
 
@@ -213,11 +217,13 @@ Total documents: **83**
 | COM-SECU-001 | CVE Scanning and SBOM Generation Guide | [CVE-SCANNING.md](./guides/CVE-SCANNING.md) | Released |
 | COM-SECU-002 | Security Best Practices | [SECURITY_BEST_PRACTICES.md](./guides/SECURITY_BEST_PRACTICES.md) | Released |
 
-### Architecture Decision Records (1)
+### Architecture Decision Records (3)
 
 | doc_id | Topic | Document | Status |
 |--------|-------|----------|--------|
 | COM-ADR-001 | ADR-001: Standardize on vcpkg as the sole package manager | [ADR-001-vcpkg-only.md](./advanced/ADR-001-vcpkg-only.md) | Released |
+| COM-ADR-002 | ADR-002: Header-Only Library Design | [ADR-002-header-only-library-design.md](./adr/ADR-002-header-only-library-design.md) | Accepted |
+| COM-ADR-003 | ADR-003: Result<T> Error Handling Pattern | [ADR-003-result-error-handling-pattern.md](./adr/ADR-003-result-error-handling-pattern.md) | Accepted |
 
 ### Project (19)
 

--- a/docs/TRACEABILITY.md
+++ b/docs/TRACEABILITY.md
@@ -1,0 +1,97 @@
+---
+doc_id: "COM-QUAL-002"
+doc_title: "Feature-Test-Module Traceability Matrix"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "common_system"
+category: "QUAL"
+---
+
+# Traceability Matrix
+
+> **SSOT**: This document is the single source of truth for **Common System Feature-Test-Module Traceability**.
+
+## Feature -> Test -> Module Mapping
+
+### Core Components
+
+| Feature ID | Feature | Test File(s) | Module/Directory | Status |
+|-----------|---------|-------------|-----------------|--------|
+| COM-FEAT-001 | Result\<T\> Pattern | tests/improved_result_test.cpp, tests/result_helpers_test.cpp, integration_tests/scenarios/result_pattern_integration_test.cpp, integration_tests/performance/result_performance_test.cpp | include/kcenon/common/patterns/result/ | Covered |
+| COM-FEAT-002 | IExecutor Interface | tests/executor_test.cpp | include/kcenon/common/interfaces/ | Covered |
+| COM-FEAT-003 | Event Bus | tests/improved_event_bus_test.cpp, tests/event_bus_failure_test.cpp, integration_tests/scenarios/event_bus_integration_test.cpp | include/kcenon/common/patterns/ | Covered |
+| COM-FEAT-004 | Circuit Breaker | tests/circuit_breaker_test.cpp | include/kcenon/common/resilience/ | Covered |
+| COM-FEAT-005 | Circular Buffer | tests/circular_buffer_test.cpp | include/kcenon/common/utils/ | Covered |
+| COM-FEAT-006 | Object Pool | tests/object_pool_test.cpp | include/kcenon/common/utils/ | Covered |
+| COM-FEAT-007 | Adapter Pattern | tests/adapter_test.cpp | include/kcenon/common/adapters/ | Covered |
+| COM-FEAT-008 | Error Codes & Categories | tests/error_codes_test.cpp, tests/error_category_test.cpp | include/kcenon/common/error/ | Covered |
+| COM-FEAT-009 | C++20 Concepts | tests/concepts_test.cpp | include/kcenon/common/concepts/ | Covered |
+| COM-FEAT-010 | ABI Version Checking | tests/abi_version_test.cpp | include/kcenon/common/config/ | Covered |
+
+### Configuration & Bootstrap
+
+| Feature ID | Feature | Test File(s) | Module/Directory | Status |
+|-----------|---------|-------------|-----------------|--------|
+| COM-FEAT-011 | Config Loader | tests/config_loader_test.cpp | include/kcenon/common/config/, src/config/ | Covered |
+| COM-FEAT-012 | Config Watcher | tests/config_watcher_test.cpp | include/kcenon/common/config/, src/config/ | Covered |
+| COM-FEAT-013 | CLI Config Parser | tests/cli_config_parser_test.cpp | include/kcenon/common/config/ | Covered |
+| COM-FEAT-014 | Unified Config | tests/unified_config_test.cpp | include/kcenon/common/config/ | Covered |
+| COM-FEAT-015 | System Bootstrapper | tests/system_bootstrapper_test.cpp | include/kcenon/common/bootstrap/ | Covered |
+| COM-FEAT-016 | Unified Bootstrapper | tests/unified_bootstrapper_test.cpp | include/kcenon/common/bootstrap/ | Covered |
+
+### Dependency Injection
+
+| Feature ID | Feature | Test File(s) | Module/Directory | Status |
+|-----------|---------|-------------|-----------------|--------|
+| COM-FEAT-017 | Service Container (DI) | tests/service_container_test.cpp | include/kcenon/common/di/ | Covered |
+
+### Interfaces
+
+| Feature ID | Feature | Test File(s) | Module/Directory | Status |
+|-----------|---------|-------------|-----------------|--------|
+| COM-FEAT-018 | ILogger Interface | tests/log_functions_test.cpp, tests/global_logger_registry_test.cpp | include/kcenon/common/interfaces/, include/kcenon/common/logging/ | Covered |
+| COM-FEAT-019 | IDatabase Interface | tests/database_interface_test.cpp | include/kcenon/common/interfaces/ | Covered |
+| COM-FEAT-020 | IMetricCollector Interface | tests/metric_collector_interface_test.cpp | include/kcenon/common/interfaces/monitoring/ | Covered |
+| COM-FEAT-021 | Transport Interface | tests/transport_interface_test.cpp | include/kcenon/common/interfaces/transport/ | Covered |
+
+### Production Quality
+
+| Feature ID | Feature | Test File(s) | Module/Directory | Status |
+|-----------|---------|-------------|-----------------|--------|
+| COM-FEAT-022 | Thread Safety | tests/thread_safety_tests.cpp | (cross-cutting) | Covered |
+| COM-FEAT-023 | Source Location Support | tests/source_location_test.cpp | include/kcenon/common/ | Covered |
+| COM-FEAT-024 | Enum Serialization | tests/enum_serialization_test.cpp | include/kcenon/common/utils/ | Covered |
+| COM-FEAT-025 | Stats Snapshot | tests/stats_snapshot_test.cpp | include/kcenon/common/interfaces/ | Covered |
+| COM-FEAT-026 | Health Monitoring Interface | tests/health_monitoring_test.cpp | include/kcenon/common/interfaces/ | Covered |
+| COM-FEAT-027 | Security Controls | tests/security_controls_test.cpp | include/kcenon/common/ | Covered |
+| COM-FEAT-028 | Failure Window | tests/failure_window_test.cpp | include/kcenon/common/resilience/ | Covered |
+| COM-FEAT-029 | Exception Mapper | tests/unit/exception_mapper_test.cpp | include/kcenon/common/ | Covered |
+| COM-FEAT-030 | C++20 Module Support | tests/module_verification_test.cpp | src/modules/ | Covered |
+
+### Integration
+
+| Feature ID | Feature | Test File(s) | Module/Directory | Status |
+|-----------|---------|-------------|-----------------|--------|
+| COM-FEAT-031 | Full System Integration | integration_tests/scenarios/full_system_integration_test.cpp | (cross-cutting) | Covered |
+| COM-FEAT-032 | Runtime Binding Integration | integration_tests/scenarios/runtime_binding_integration_test.cpp | include/kcenon/common/di/ | Covered |
+| COM-FEAT-033 | Error Handling Integration | integration_tests/failures/error_handling_test.cpp | (cross-cutting) | Covered |
+| COM-FEAT-034 | Memory Pressure Testing | integration_tests/performance/memory_pressure_test.cpp | (cross-cutting) | Covered |
+| COM-FEAT-035 | Stress Testing | integration_tests/stress/stress_test.cpp | (cross-cutting) | Covered |
+
+## Coverage Summary
+
+| Category | Total Features | Covered | Partial | Uncovered |
+|----------|---------------|---------|---------|-----------|
+| Core Components | 10 | 10 | 0 | 0 |
+| Configuration & Bootstrap | 6 | 6 | 0 | 0 |
+| Dependency Injection | 1 | 1 | 0 | 0 |
+| Interfaces | 4 | 4 | 0 | 0 |
+| Production Quality | 9 | 9 | 0 | 0 |
+| Integration | 5 | 5 | 0 | 0 |
+| **Total** | **35** | **35** | **0** | **0** |
+
+## See Also
+
+- [FEATURES.md](FEATURES.md) -- Detailed feature documentation
+- [README.md](README.md) -- SSOT Documentation Registry

--- a/docs/adr/ADR-002-header-only-library-design.md
+++ b/docs/adr/ADR-002-header-only-library-design.md
@@ -1,0 +1,96 @@
+---
+doc_id: "COM-ADR-002"
+doc_title: "ADR-002: Header-Only Library Design"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Accepted"
+project: "common_system"
+category: "ADR"
+---
+
+# ADR-002: Header-Only Library Design
+
+> **SSOT**: This document is the single source of truth for **ADR-002: Header-Only Library Design**.
+
+| Field | Value |
+|-------|-------|
+| Status | Accepted |
+| Date | 2025-01-15 |
+| Decision Makers | kcenon ecosystem maintainers |
+
+## Context
+
+common_system is the Tier 0 foundation of the kcenon ecosystem — every other project
+depends on it. The library provides interfaces (`IExecutor`, `IJob`, `ILogger`),
+patterns (`Result<T>`, `event_bus`), C++20 concepts, and utility abstractions.
+
+Two distribution models were considered:
+
+1. **Compiled library** — Traditional `.a`/`.lib` static library requiring consumers
+   to link against a pre-built artifact.
+2. **Header-only library** — All code in headers, consumed via `#include` with no
+   separate compilation step for the library itself.
+
+Key constraints:
+- All 7 downstream projects must integrate common_system.
+- The library is predominantly interfaces (pure virtual) and templates.
+- Cross-platform support (Linux, macOS, Windows) with multiple compilers.
+- Pre-1.0 API: frequent interface changes expected.
+
+## Decision
+
+**Adopt a header-only distribution model** with `INTERFACE` CMake target.
+
+The CMake target `common_system` is declared as `INTERFACE`, meaning it only
+exports include paths and compile definitions — no object files are compiled
+when consumers add `target_link_libraries(... common_system)`.
+
+```cmake
+add_library(common_system INTERFACE)
+target_include_directories(common_system INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+```
+
+The `COMMON_HEADER_ONLY` CMake option (ON by default) controls this behavior.
+When disabled, the library compiles a static library from `.cpp` source files
+for non-template implementations.
+
+## Alternatives Considered
+
+### Compiled Static Library
+
+- **Pros**: Faster downstream builds (no re-parsing headers), ABI stability,
+  ability to hide implementation details.
+- **Cons**: Requires pre-built artifacts per platform/compiler/config combination,
+  complicates cross-platform CI, version mismatch risk when updating common_system
+  independently of consumers.
+
+### Shared Library (`.so`/`.dll`)
+
+- **Pros**: Reduced binary size, runtime updates without recompilation.
+- **Cons**: ABI compatibility burden, symbol visibility management, complicates
+  deployment for a pre-1.0 library with evolving interfaces.
+
+## Consequences
+
+### Positive
+
+- **Zero build friction**: Downstream projects only need the include path — no
+  pre-compilation, no artifact management, no linker errors from version mismatches.
+- **Template-friendly**: The library is primarily interfaces and templates, which
+  must be in headers regardless. Header-only aligns with the natural code structure.
+- **Single-source-of-truth builds**: Consumers always compile against the exact
+  version of common_system they reference — no stale `.a` artifacts.
+- **Simplified CI**: No need to build and cache common_system artifacts separately
+  for each platform/compiler/config matrix.
+
+### Negative
+
+- **Increased downstream compile times**: Every translation unit that includes
+  common_system headers re-parses them. Mitigated by precompiled headers (PCH)
+  and C++20 modules (experimental).
+- **No ABI stability**: Any header change forces recompilation of all consumers.
+  Acceptable for a pre-1.0 ecosystem.
+- **Header pollution**: All implementation details are visible to consumers.
+  Mitigated by `detail/` namespace convention.

--- a/docs/adr/ADR-003-result-error-handling-pattern.md
+++ b/docs/adr/ADR-003-result-error-handling-pattern.md
@@ -1,0 +1,112 @@
+---
+doc_id: "COM-ADR-003"
+doc_title: "ADR-003: Result<T> Error Handling Pattern"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Accepted"
+project: "common_system"
+category: "ADR"
+---
+
+# ADR-003: Result\<T\> Error Handling Pattern
+
+> **SSOT**: This document is the single source of truth for **ADR-003: Result<T> Error Handling Pattern**.
+
+| Field | Value |
+|-------|-------|
+| Status | Accepted |
+| Date | 2024-06-01 |
+| Decision Makers | kcenon ecosystem maintainers |
+
+## Context
+
+The kcenon ecosystem needed a consistent error handling strategy across all projects.
+C++ offers several error propagation mechanisms, each with tradeoffs:
+
+- **Exceptions** — Zero-cost happy path, but unpredictable control flow, disabled in
+  some embedded/real-time contexts, and poor composability in async pipelines.
+- **Error codes** — Explicit, but easily ignored, no type safety, and force out-parameters
+  for return values.
+- **`std::optional<T>`** — Signals absence but carries no error information.
+- **`std::expected<T, E>`** (C++23) — Not available when the project started (C++20 target).
+
+The ecosystem requires error handling that is:
+1. Explicit — callers cannot accidentally ignore errors.
+2. Composable — supports monadic chaining for pipeline-style code.
+3. Informative — carries structured error information (code, message, source location).
+4. Thread-safe for concurrent reads.
+
+## Decision
+
+**Adopt a Rust-inspired `Result<T>` type** as the standard error handling pattern
+across the entire ecosystem.
+
+```cpp
+// Result<T> holds either a value or an error
+auto result = some_operation();
+if (result.has_value()) {
+    use(result.value());
+} else {
+    handle(result.error());
+}
+
+// Monadic chaining
+auto final = get_config()
+    .and_then([](auto cfg) { return validate(cfg); })
+    .map([](auto valid) { return transform(valid); })
+    .or_else([](auto err) { return fallback(err); });
+```
+
+Key design choices:
+- `Result<T>` wraps `std::optional<T>` (value) + `std::optional<error_info>` (error).
+- `VoidResult` alias for operations with no return value.
+- Default constructor is **deleted** — forces explicit success/failure construction.
+- Monadic operations: `and_then()`, `map()`, `or_else()`, `map_error()`.
+- `error_info` carries error code, message, and source location.
+- Error code ranges are centralized: common (-1 to -99), thread (-100 to -199), etc.
+
+## Alternatives Considered
+
+### C++ Exceptions
+
+- **Pros**: Zero overhead on success, idiomatic C++, stack unwinding.
+- **Cons**: Unpredictable performance on error path, disabled by `-fno-exceptions`
+  in some build configurations, poor composability in async/coroutine contexts,
+  no compile-time enforcement of error handling.
+
+### `std::error_code` with Out Parameters
+
+- **Pros**: No heap allocation, well-understood pattern.
+- **Cons**: Easily ignored (no `[[nodiscard]]`), forces awkward API signatures
+  (`bool foo(int& out, std::error_code& ec)`), no monadic composition.
+
+### `std::expected<T, E>` (C++23)
+
+- **Pros**: Standard library support, monadic operations in C++23.
+- **Cons**: Not available in C++20 (project baseline). The ecosystem's `Result<T>`
+  predates `std::expected` availability. Migration may be considered post-C++23
+  adoption.
+
+## Consequences
+
+### Positive
+
+- **Ecosystem-wide consistency**: All 8 projects use `Result<T>` for fallible
+  operations, creating a uniform error handling contract.
+- **Composable pipelines**: `and_then`/`map`/`or_else` enable functional-style
+  error propagation without nested if-else chains.
+- **Explicit error handling**: Deleted default constructor + `[[nodiscard]]`
+  prevent accidental error suppression.
+- **Structured errors**: `error_info` with codes, messages, and source locations
+  provides rich debugging context.
+
+### Negative
+
+- **Learning curve**: Contributors unfamiliar with monadic error handling need
+  onboarding on the `Result<T>` API.
+- **Not thread-safe for writes**: Concurrent modification requires external
+  synchronization. Concurrent reads are safe.
+- **Migration effort**: Existing code using exceptions or raw error codes must
+  be migrated incrementally (ongoing in network_system at ~75-80%).
+- **Binary size**: Template instantiations for each `T` increase binary size
+  compared to exceptions or error codes.


### PR DESCRIPTION
## Summary

- Add initial Architecture Decision Records (ADRs) documenting key design decisions: ADR-002 (Header-Only Library Design), ADR-003 (Result<T> Error Handling Pattern)
- Each ADR follows the standard template with Context, Decision, Alternatives Considered, and Consequences sections
- ADRs include YAML frontmatter with doc_id for SSOT registry integration
- Updated docs/README.md SSOT registry to include new ADR entries

## Test Plan

- [x] ADR files follow the standard template format
- [x] YAML frontmatter with doc_id present in all ADRs
- [x] SSOT registry updated with new ADR entries
- [x] No duplicate doc_id values
- [x] All file links in registry are valid

Closes kcenon/common_system#565