### PR TITLE
feat(tools): add documentation audit CLI tool

### DIFF
--- a/tools/doc-audit/__init__.py
+++ b/tools/doc-audit/__init__.py
@@ -1,0 +1,3 @@
+"""Documentation audit tool for the kcenon ecosystem."""
+
+__version__ = "1.0.0"

--- a/tools/doc-audit/__main__.py
+++ b/tools/doc-audit/__main__.py
@@ -1,0 +1,125 @@
+"""CLI entry point for the documentation audit tool.
+
+Usage:
+    python -m doc-audit /path/to/project
+    python -m doc-audit --ecosystem /path/to/sources
+    python -m doc-audit --quick /path/to/project
+    python -m doc-audit --format json /path/to/project
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from .config import ECOSYSTEM_PROJECTS
+from .models import AuditReport
+from .utils import find_docs_dir, detect_project_name
+from .checker_metadata import check_metadata
+from .checker_links import check_links
+from .checker_ssot import check_ssot
+from .checker_structure import check_structure
+from .report import generate_markdown, generate_json
+
+
+def run_audit(project_path: str, quick: bool = False) -> AuditReport:
+    """Run all audit checks on a single project."""
+    project_name = detect_project_name(project_path)
+    report = AuditReport(project_name=project_name, project_path=project_path)
+
+    docs_dir = find_docs_dir(project_path)
+    if docs_dir is None:
+        print(f"  [SKIP] {project_name}: no docs/ directory found", file=sys.stderr)
+        return report
+
+    # Always run metadata and structure checks
+    report.results.append(check_metadata(docs_dir))
+    report.results.append(check_structure(docs_dir))
+
+    if not quick:
+        report.results.append(check_links(docs_dir))
+        report.results.append(check_ssot(docs_dir))
+
+    return report
+
+
+def print_report(report: AuditReport, fmt: str) -> None:
+    """Print a single project report in the requested format."""
+    if fmt == "json":
+        print(generate_json(report))
+    elif fmt == "markdown":
+        print(generate_markdown(report))
+    else:  # both
+        print(generate_markdown(report))
+        print("\n--- JSON ---\n")
+        print(generate_json(report))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="doc-audit",
+        description="Documentation audit tool for the kcenon ecosystem.",
+    )
+    parser.add_argument(
+        "path",
+        help="Project path (single project) or sources root (with --ecosystem)",
+    )
+    parser.add_argument(
+        "--quick",
+        action="store_true",
+        help="Run only metadata and structure checks (skip links and SSOT)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json", "both"],
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--ecosystem",
+        action="store_true",
+        help="Audit all ecosystem projects under the given root path",
+    )
+
+    args = parser.parse_args()
+    root = Path(args.path).resolve()
+
+    if not root.is_dir():
+        print(f"Error: '{root}' is not a directory", file=sys.stderr)
+        return 2
+
+    reports: list[AuditReport] = []
+
+    if args.ecosystem:
+        for project_name in ECOSYSTEM_PROJECTS:
+            project_dir = root / project_name
+            if project_dir.is_dir():
+                print(f"Auditing {project_name}...", file=sys.stderr)
+                reports.append(run_audit(str(project_dir), quick=args.quick))
+            else:
+                print(f"  [SKIP] {project_name}: directory not found", file=sys.stderr)
+    else:
+        reports.append(run_audit(str(root), quick=args.quick))
+
+    # Print reports
+    for report in reports:
+        print_report(report, args.format)
+
+    # Summary for ecosystem mode
+    if args.ecosystem and len(reports) > 1:
+        total_c = sum(r.total_critical for r in reports)
+        total_w = sum(r.total_warnings for r in reports)
+        total_i = sum(r.total_info for r in reports)
+        total = sum(r.total_findings for r in reports)
+        print(
+            f"\n=== Ecosystem Summary: {total} findings "
+            f"({total_c} critical, {total_w} warnings, {total_i} info) ===",
+            file=sys.stderr,
+        )
+
+    # Exit code: 1 if any critical findings
+    has_critical = any(r.has_critical for r in reports)
+    return 1 if has_critical else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/doc-audit/checker_links.py
+++ b/tools/doc-audit/checker_links.py
@@ -1,0 +1,89 @@
+"""Checker: Internal link validation."""
+
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+from .config import CRITICAL, WARNING, LINK_PATTERN
+from .models import Finding, CheckResult
+from .utils import discover_md_files, read_file_lines, extract_headings
+
+
+def check_links(docs_dir: Path) -> CheckResult:
+    """Validate all internal markdown links in docs/ files."""
+    result = CheckResult(checker_name="Links")
+    md_files = discover_md_files(docs_dir)
+
+    for md_file in md_files:
+        rel = md_file.relative_to(docs_dir)
+        lines = read_file_lines(md_file)
+
+        in_code_block = False
+        for line_num, line in enumerate(lines, start=1):
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                in_code_block = not in_code_block
+                continue
+            if in_code_block:
+                continue
+
+            for match in LINK_PATTERN.finditer(line):
+                link_text = match.group(1)
+                link_url = match.group(2)
+
+                # Skip external URLs
+                parsed = urlparse(link_url)
+                if parsed.scheme in ("http", "https", "mailto", "ftp"):
+                    continue
+
+                # Split URL into path and anchor
+                if "#" in link_url:
+                    path_part, anchor = link_url.rsplit("#", 1)
+                else:
+                    path_part = link_url
+                    anchor = None
+
+                # Skip empty path (pure anchor reference within same file)
+                if not path_part and anchor:
+                    headings = extract_headings(md_file)
+                    if anchor not in headings:
+                        result.findings.append(Finding(
+                            checker="Links",
+                            severity=WARNING,
+                            message=f"Broken anchor '#{anchor}' in same-file link",
+                            file=str(rel),
+                            line=line_num,
+                        ))
+                    continue
+
+                if not path_part:
+                    continue
+
+                # Resolve relative path
+                target = (md_file.parent / path_part).resolve()
+
+                if not target.exists():
+                    result.findings.append(Finding(
+                        checker="Links",
+                        severity=CRITICAL,
+                        message=f"Broken link: [{link_text}]({link_url}) "
+                                f"— target not found",
+                        file=str(rel),
+                        line=line_num,
+                    ))
+                    continue
+
+                # Validate anchor in target file
+                if anchor and target.suffix == ".md":
+                    headings = extract_headings(target)
+                    if anchor not in headings:
+                        result.findings.append(Finding(
+                            checker="Links",
+                            severity=WARNING,
+                            message=f"Broken anchor '#{anchor}' in "
+                                    f"[{link_text}]({link_url})",
+                            file=str(rel),
+                            line=line_num,
+                        ))
+
+    return result

--- a/tools/doc-audit/checker_metadata.py
+++ b/tools/doc-audit/checker_metadata.py
@@ -1,0 +1,109 @@
+"""Checker: YAML frontmatter validation."""
+
+from pathlib import Path
+
+from .config import (
+    CRITICAL, WARNING, INFO,
+    REQUIRED_FIELDS, VALID_STATUSES, VALID_CATEGORIES,
+    DOC_ID_PATTERN, SEMVER_PATTERN, DATE_PATTERN,
+)
+from .models import Finding, CheckResult
+from .utils import discover_md_files, extract_frontmatter
+
+
+def check_metadata(docs_dir: Path) -> CheckResult:
+    """Validate YAML frontmatter for all markdown files in docs/."""
+    result = CheckResult(checker_name="Metadata")
+    md_files = discover_md_files(docs_dir)
+    seen_ids: dict[str, Path] = {}
+
+    for md_file in md_files:
+        rel = md_file.relative_to(docs_dir)
+        fm = extract_frontmatter(md_file)
+
+        if fm is None:
+            result.findings.append(Finding(
+                checker="Metadata",
+                severity=WARNING,
+                message="Missing YAML frontmatter",
+                file=str(rel),
+            ))
+            continue
+
+        # Check required fields
+        for field_name in REQUIRED_FIELDS:
+            if field_name not in fm or not fm[field_name]:
+                result.findings.append(Finding(
+                    checker="Metadata",
+                    severity=CRITICAL if field_name == "doc_id" else WARNING,
+                    message=f"Missing required field: {field_name}",
+                    file=str(rel),
+                ))
+
+        # Validate doc_id format
+        doc_id = fm.get("doc_id", "")
+        if doc_id:
+            if not DOC_ID_PATTERN.match(doc_id):
+                result.findings.append(Finding(
+                    checker="Metadata",
+                    severity=WARNING,
+                    message=f"Invalid doc_id format: '{doc_id}' "
+                            f"(expected PREFIX-CATEGORY-NNN)",
+                    file=str(rel),
+                ))
+
+            # Check for duplicate doc_id
+            if doc_id in seen_ids:
+                result.findings.append(Finding(
+                    checker="Metadata",
+                    severity=CRITICAL,
+                    message=f"Duplicate doc_id '{doc_id}' "
+                            f"(also in {seen_ids[doc_id]})",
+                    file=str(rel),
+                ))
+            else:
+                seen_ids[doc_id] = rel
+
+        # Validate doc_version (semver)
+        version = fm.get("doc_version", "")
+        if version and not SEMVER_PATTERN.match(version):
+            result.findings.append(Finding(
+                checker="Metadata",
+                severity=INFO,
+                message=f"Invalid version format: '{version}' (expected X.Y.Z)",
+                file=str(rel),
+            ))
+
+        # Validate doc_date (ISO 8601)
+        date = fm.get("doc_date", "")
+        if date and not DATE_PATTERN.match(date):
+            result.findings.append(Finding(
+                checker="Metadata",
+                severity=INFO,
+                message=f"Invalid date format: '{date}' (expected YYYY-MM-DD)",
+                file=str(rel),
+            ))
+
+        # Validate doc_status
+        status = fm.get("doc_status", "")
+        if status and status not in VALID_STATUSES:
+            result.findings.append(Finding(
+                checker="Metadata",
+                severity=WARNING,
+                message=f"Invalid status: '{status}' "
+                        f"(expected one of: {', '.join(sorted(VALID_STATUSES))})",
+                file=str(rel),
+            ))
+
+        # Validate category
+        category = fm.get("category", "")
+        if category and category not in VALID_CATEGORIES:
+            result.findings.append(Finding(
+                checker="Metadata",
+                severity=INFO,
+                message=f"Non-standard category: '{category}' "
+                        f"(known: {', '.join(sorted(VALID_CATEGORIES))})",
+                file=str(rel),
+            ))
+
+    return result

--- a/tools/doc-audit/checker_ssot.py
+++ b/tools/doc-audit/checker_ssot.py
@@ -1,0 +1,147 @@
+"""Checker: SSOT registry consistency."""
+
+import re
+from pathlib import Path
+
+from .config import CRITICAL, WARNING, INFO
+from .models import Finding, CheckResult
+from .utils import discover_md_files, extract_frontmatter, read_file_lines
+
+
+def _parse_registry_table(readme_path: Path) -> list[dict[str, str]]:
+    """Parse the SSOT registry table from docs/README.md.
+
+    Returns a list of dicts with keys: doc_id, topic, file_path, status.
+    """
+    entries = []
+    lines = read_file_lines(readme_path)
+    in_table = False
+    header_seen = False
+
+    for line in lines:
+        line = line.strip()
+
+        # Detect table header row
+        if "doc_id" in line and "Authority Document" in line and "|" in line:
+            in_table = True
+            header_seen = False
+            continue
+
+        if in_table and line.startswith("|---"):
+            header_seen = True
+            continue
+
+        if in_table and header_seen and line.startswith("|"):
+            cols = [c.strip() for c in line.split("|")]
+            # Filter empty strings from split
+            cols = [c for c in cols if c]
+
+            if len(cols) >= 4:
+                doc_id = cols[1].strip()
+                topic = cols[2].strip()
+
+                # Extract file path from markdown link [name](./path)
+                link_match = re.search(r"\]\(\./([^)]+)\)", cols[3])
+                file_path = link_match.group(1) if link_match else ""
+
+                status_val = cols[4].strip() if len(cols) >= 5 else ""
+
+                entries.append({
+                    "doc_id": doc_id,
+                    "topic": topic,
+                    "file_path": file_path,
+                    "status": status_val,
+                })
+        elif in_table and header_seen and not line.startswith("|"):
+            # End of table
+            in_table = False
+            header_seen = False
+
+    return entries
+
+
+def check_ssot(docs_dir: Path) -> CheckResult:
+    """Validate SSOT registry consistency."""
+    result = CheckResult(checker_name="SSOT")
+
+    readme_path = docs_dir / "README.md"
+    if not readme_path.exists():
+        result.findings.append(Finding(
+            checker="SSOT",
+            severity=CRITICAL,
+            message="Missing docs/README.md (SSOT registry)",
+            file="README.md",
+        ))
+        return result
+
+    # Parse registry table
+    entries = _parse_registry_table(readme_path)
+
+    if not entries:
+        result.findings.append(Finding(
+            checker="SSOT",
+            severity=CRITICAL,
+            message="No registry entries found in docs/README.md",
+            file="README.md",
+        ))
+        return result
+
+    # Collect all doc_ids from actual files
+    actual_files: dict[str, str] = {}  # rel_path -> doc_id
+    all_md_files = discover_md_files(docs_dir)
+
+    for md_file in all_md_files:
+        rel = str(md_file.relative_to(docs_dir))
+        if rel == "README.md":
+            continue
+        fm = extract_frontmatter(md_file)
+        if fm and "doc_id" in fm:
+            actual_files[rel] = fm["doc_id"]
+
+    # Check each registry entry
+    registry_files: set[str] = set()
+    registry_ids: set[str] = set()
+
+    for entry in entries:
+        file_path = entry["file_path"]
+        doc_id = entry["doc_id"]
+        registry_files.add(file_path)
+        registry_ids.add(doc_id)
+
+        # Check file exists
+        target = docs_dir / file_path
+        if not target.exists():
+            result.findings.append(Finding(
+                checker="SSOT",
+                severity=CRITICAL,
+                message=f"Registry entry '{doc_id}' points to "
+                        f"non-existent file: {file_path}",
+                file="README.md",
+            ))
+            continue
+
+        # Check doc_id matches
+        fm = extract_frontmatter(target)
+        if fm:
+            actual_id = fm.get("doc_id", "")
+            if actual_id and actual_id != doc_id:
+                result.findings.append(Finding(
+                    checker="SSOT",
+                    severity=WARNING,
+                    message=f"doc_id mismatch: registry has '{doc_id}', "
+                            f"file has '{actual_id}'",
+                    file=file_path,
+                ))
+
+    # Check for files not listed in registry
+    for rel_path, doc_id in actual_files.items():
+        if rel_path not in registry_files:
+            result.findings.append(Finding(
+                checker="SSOT",
+                severity=INFO,
+                message=f"File '{rel_path}' (doc_id: {doc_id}) "
+                        f"not listed in SSOT registry",
+                file=rel_path,
+            ))
+
+    return result

--- a/tools/doc-audit/checker_structure.py
+++ b/tools/doc-audit/checker_structure.py
@@ -1,0 +1,72 @@
+"""Checker: README standard section compliance."""
+
+import re
+from pathlib import Path
+
+from .config import CRITICAL, WARNING, INFO, STANDARD_SECTIONS
+from .models import Finding, CheckResult
+from .utils import read_file_lines
+
+
+def _extract_h2_sections(filepath: Path) -> list[str]:
+    """Extract all H2 section titles from a markdown file."""
+    sections = []
+    lines = read_file_lines(filepath)
+    for line in lines:
+        match = re.match(r"^##\s+(.+)$", line.strip())
+        if match:
+            sections.append(match.group(1).strip())
+    return sections
+
+
+def _normalize_section(name: str) -> str:
+    """Normalize section name for comparison."""
+    # Remove emojis and special characters, lowercase
+    name = re.sub(r"[^\w\s]", "", name).strip().lower()
+    return name
+
+
+def check_structure(docs_dir: Path) -> CheckResult:
+    """Validate README.md compliance with the 13-section standard."""
+    result = CheckResult(checker_name="Structure")
+
+    # Check the project root README.md (one level up from docs/)
+    project_dir = docs_dir.parent
+    readme_path = project_dir / "README.md"
+
+    if not readme_path.exists():
+        result.findings.append(Finding(
+            checker="Structure",
+            severity=CRITICAL,
+            message="Missing project README.md",
+            file="README.md",
+        ))
+        return result
+
+    actual_sections = _extract_h2_sections(readme_path)
+    actual_normalized = [_normalize_section(s) for s in actual_sections]
+
+    # Check for each standard section
+    for standard_section in STANDARD_SECTIONS:
+        norm = _normalize_section(standard_section)
+        found = False
+        for actual_norm in actual_normalized:
+            if norm in actual_norm or actual_norm in norm:
+                found = True
+                break
+
+        if not found:
+            # Determine severity based on section importance
+            if standard_section in ("Overview", "Getting Started", "License"):
+                severity = WARNING
+            else:
+                severity = INFO
+
+            result.findings.append(Finding(
+                checker="Structure",
+                severity=severity,
+                message=f"Missing standard section: '## {standard_section}'",
+                file="README.md",
+            ))
+
+    return result

--- a/tools/doc-audit/config.py
+++ b/tools/doc-audit/config.py
@@ -1,0 +1,72 @@
+"""Constants and configuration for the documentation audit tool."""
+
+import re
+
+# Required YAML frontmatter fields
+REQUIRED_FIELDS = [
+    "doc_id",
+    "doc_title",
+    "doc_version",
+    "doc_date",
+    "doc_status",
+    "project",
+    "category",
+]
+
+# Valid doc_status values
+VALID_STATUSES = {"Draft", "Review", "Released", "Deprecated", "Accepted"}
+
+# Valid category values
+VALID_CATEGORIES = {
+    "ARCH", "API", "GUID", "PERF", "PROJ", "MIGR",
+    "FEAT", "QUAL", "SECU", "INTR", "ADR",
+}
+
+# doc_id format: PREFIX-CATEGORY-NNN
+DOC_ID_PATTERN = re.compile(r"^[A-Z]{2,4}-[A-Z]{2,4}-\d{3}$")
+
+# Semver pattern (loose)
+SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+
+# ISO 8601 date pattern (YYYY-MM-DD)
+DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+# Markdown link pattern: [text](url)
+LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+
+# Standard README sections (from issue #561)
+STANDARD_SECTIONS = [
+    "Overview",
+    "Architecture",
+    "Getting Started",
+    "API Reference",
+    "Features",
+    "Configuration",
+    "Integration",
+    "Performance",
+    "Testing",
+    "Troubleshooting",
+    "Contributing",
+    "Changelog",
+    "License",
+]
+
+# Project prefixes
+PROJECT_PREFIXES = {
+    "common_system": "COM",
+    "thread_system": "THR",
+    "logger_system": "LOG",
+    "container_system": "CNT",
+    "monitoring_system": "MON",
+    "database_system": "DBS",
+    "network_system": "NET",
+    "pacs_system": "PAC",
+}
+
+# Ecosystem projects
+ECOSYSTEM_PROJECTS = list(PROJECT_PREFIXES.keys())
+
+# Severity levels
+CRITICAL = "critical"
+WARNING = "warning"
+INFO = "info"

--- a/tools/doc-audit/models.py
+++ b/tools/doc-audit/models.py
@@ -1,0 +1,71 @@
+"""Data models for audit findings and results."""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class Finding:
+    """A single audit finding."""
+    checker: str
+    severity: str  # "critical", "warning", "info"
+    message: str
+    file: str
+    line: Optional[int] = None
+
+    def __str__(self) -> str:
+        loc = self.file
+        if self.line is not None:
+            loc = f"{self.file}:{self.line}"
+        return f"[{self.severity.upper()}] {self.checker}: {loc} — {self.message}"
+
+
+@dataclass
+class CheckResult:
+    """Result from a single checker run."""
+    checker_name: str
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def critical_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == "critical")
+
+    @property
+    def warning_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == "warning")
+
+    @property
+    def info_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == "info")
+
+    @property
+    def total(self) -> int:
+        return len(self.findings)
+
+
+@dataclass
+class AuditReport:
+    """Complete audit report for a project."""
+    project_name: str
+    project_path: str
+    results: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def total_findings(self) -> int:
+        return sum(r.total for r in self.results)
+
+    @property
+    def total_critical(self) -> int:
+        return sum(r.critical_count for r in self.results)
+
+    @property
+    def total_warnings(self) -> int:
+        return sum(r.warning_count for r in self.results)
+
+    @property
+    def total_info(self) -> int:
+        return sum(r.info_count for r in self.results)
+
+    @property
+    def has_critical(self) -> bool:
+        return self.total_critical > 0

--- a/tools/doc-audit/report.py
+++ b/tools/doc-audit/report.py
@@ -1,0 +1,106 @@
+"""Report generation for documentation audit results."""
+
+import json
+from datetime import date
+from pathlib import Path
+
+from .config import CRITICAL, WARNING, INFO
+from .models import AuditReport, Finding
+
+
+def _severity_icon(severity: str) -> str:
+    """Return a text marker for severity level."""
+    return {"critical": "[CRITICAL]", "warning": "[WARNING]", "info": "[INFO]"}.get(
+        severity, "[?]"
+    )
+
+
+def generate_markdown(report: AuditReport) -> str:
+    """Generate a Markdown-formatted audit report."""
+    lines: list[str] = []
+    lines.append(f"# Documentation Audit Report: {report.project_name}")
+    lines.append("")
+    lines.append(f"**Project**: `{report.project_path}`")
+    lines.append(f"**Date**: {date.today().isoformat()}")
+    lines.append("")
+
+    # Summary
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(f"| Metric | Count |")
+    lines.append(f"|--------|-------|")
+    lines.append(f"| Total findings | {report.total_findings} |")
+    lines.append(f"| Critical | {report.total_critical} |")
+    lines.append(f"| Warnings | {report.total_warnings} |")
+    lines.append(f"| Info | {report.total_info} |")
+    lines.append("")
+
+    if report.has_critical:
+        lines.append(
+            "**Result**: FAIL — critical issues found that must be resolved."
+        )
+    elif report.total_warnings > 0:
+        lines.append("**Result**: PASS with warnings.")
+    else:
+        lines.append("**Result**: PASS — no issues found.")
+    lines.append("")
+
+    # Per-checker details
+    for result in report.results:
+        lines.append(f"## {result.checker_name} ({result.total} findings)")
+        lines.append("")
+
+        if not result.findings:
+            lines.append("No issues found.")
+            lines.append("")
+            continue
+
+        for finding in result.findings:
+            loc = finding.file
+            if finding.line is not None:
+                loc = f"{finding.file}:{finding.line}"
+            icon = _severity_icon(finding.severity)
+            lines.append(f"- {icon} `{loc}` — {finding.message}")
+
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def generate_json(report: AuditReport) -> str:
+    """Generate a JSON-formatted audit report."""
+    data = {
+        "project_name": report.project_name,
+        "project_path": report.project_path,
+        "date": date.today().isoformat(),
+        "summary": {
+            "total": report.total_findings,
+            "critical": report.total_critical,
+            "warnings": report.total_warnings,
+            "info": report.total_info,
+            "pass": not report.has_critical,
+        },
+        "results": [],
+    }
+
+    for result in report.results:
+        checker_data = {
+            "checker": result.checker_name,
+            "total": result.total,
+            "critical": result.critical_count,
+            "warnings": result.warning_count,
+            "info": result.info_count,
+            "findings": [],
+        }
+        for finding in result.findings:
+            checker_data["findings"].append(
+                {
+                    "severity": finding.severity,
+                    "message": finding.message,
+                    "file": finding.file,
+                    "line": finding.line,
+                }
+            )
+        data["results"].append(checker_data)
+
+    return json.dumps(data, indent=2)

--- a/tools/doc-audit/utils.py
+++ b/tools/doc-audit/utils.py
@@ -1,0 +1,83 @@
+"""Utility functions for file discovery and path resolution."""
+
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+
+def find_docs_dir(project_path: str) -> Optional[Path]:
+    """Find the docs/ directory in a project."""
+    docs_dir = Path(project_path) / "docs"
+    if docs_dir.is_dir():
+        return docs_dir
+    return None
+
+
+def discover_md_files(docs_dir: Path) -> list[Path]:
+    """Discover all .md files in the docs directory recursively."""
+    return sorted(docs_dir.rglob("*.md"))
+
+
+def extract_frontmatter(filepath: Path) -> Optional[dict[str, str]]:
+    """Extract YAML frontmatter from a markdown file.
+
+    Returns a dict of key-value pairs, or None if no frontmatter found.
+    """
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            content = f.read()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    if not content.startswith("---"):
+        return None
+
+    end_idx = content.find("---", 3)
+    if end_idx == -1:
+        return None
+
+    fm_text = content[3:end_idx].strip()
+    result = {}
+    for line in fm_text.split("\n"):
+        if ":" in line:
+            key, val = line.split(":", 1)
+            key = key.strip()
+            val = val.strip().strip('"')
+            result[key] = val
+
+    return result
+
+
+def read_file_lines(filepath: Path) -> list[str]:
+    """Read a file and return its lines."""
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            return f.readlines()
+    except (OSError, UnicodeDecodeError):
+        return []
+
+
+def detect_project_name(project_path: str) -> str:
+    """Detect the project name from the directory name."""
+    return Path(project_path).name
+
+
+def slugify(text: str) -> str:
+    """Convert heading text to a markdown anchor slug."""
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s]+", "-", text)
+    text = re.sub(r"-+", "-", text)
+    return text.strip("-")
+
+
+def extract_headings(filepath: Path) -> list[str]:
+    """Extract all markdown heading anchors from a file."""
+    headings = []
+    lines = read_file_lines(filepath)
+    for line in lines:
+        match = re.match(r"^#{1,6}\s+(.+)$", line.strip())
+        if match:
+            headings.append(slugify(match.group(1)))
+    return headings


### PR DESCRIPTION
## Summary

- Add Python CLI documentation audit tool (`tools/doc-audit/`) with 4 modular checkers: metadata validation, internal link checking, SSOT registry consistency, and README structure compliance
- Supports `--quick` mode for CI (metadata + structure only), `--ecosystem` mode for all 8 projects, and `--format` flag for markdown/json/both output
- Validates YAML frontmatter fields, doc_id format (`PREFIX-CAT-NNN`), broken internal links (with code block skip), SSOT registry table parsing, and 13 standard README sections

## Tool Structure

```
tools/doc-audit/
├── __init__.py          # Package init (v1.0.0)
├── __main__.py          # CLI entry point (argparse)
├── config.py            # Constants, regex patterns, field definitions
├── models.py            # Finding, CheckResult, AuditReport dataclasses
├── checker_metadata.py  # YAML frontmatter validation
├── checker_links.py     # Internal link and anchor validation
├── checker_ssot.py      # SSOT registry consistency
├── checker_structure.py # README standard section compliance
├── report.py            # Markdown and JSON report generation
└── utils.py             # File discovery, path resolution, heading extraction
```

## Usage

```bash
python -m tools.doc-audit /path/to/project              # Full audit
python -m tools.doc-audit /path/to/project --quick       # Fast CI check
python -m tools.doc-audit /path/to/sources --ecosystem   # All 8 repos
python -m tools.doc-audit /path/to/project --format json # JSON output
```

## Test plan

- [x] Tested `--quick` mode on common_system (7 findings detected correctly)
- [x] Tested `--ecosystem` mode across all 8 repos (54 findings in quick mode)
- [x] Tested `--format json` output (valid JSON, correct finding counts)
- [x] Tested full mode with link + SSOT checkers (code block skip working)
- [x] Verified exit code 1 on critical findings, 0 otherwise

Closes #567