### PR TITLE
ci: add documentation audit workflows

### DIFF
--- a/.github/workflows/doc-audit-ecosystem.yml
+++ b/.github/workflows/doc-audit-ecosystem.yml
@@ -1,0 +1,96 @@
+name: Ecosystem Documentation Audit
+
+on:
+  schedule:
+    - cron: '23 3 * * 1'  # Monday 3:23 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Audit ${{ matrix.repo }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - common_system
+          - thread_system
+          - logger_system
+          - container_system
+          - monitoring_system
+          - database_system
+          - network_system
+          - pacs_system
+
+    steps:
+      - name: Checkout audit tool
+        uses: actions/checkout@v4
+        with:
+          path: common_system
+          sparse-checkout: tools/doc-audit
+
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          repository: kcenon/${{ matrix.repo }}
+          path: ${{ matrix.repo }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Prepare audit tool
+        run: |
+          cp -r common_system/tools/doc-audit "$RUNNER_TEMP/doc_audit"
+
+      - name: Run full audit
+        run: |
+          python -m doc_audit "$GITHUB_WORKSPACE/${{ matrix.repo }}" --format json \
+            | tee audit-report.json
+        env:
+          PYTHONPATH: ${{ runner.temp }}
+
+      - name: Upload audit report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: audit-${{ matrix.repo }}
+          path: audit-report.json
+          retention-days: 30
+
+  summary:
+    name: Audit Summary
+    runs-on: ubuntu-latest
+    needs: audit
+    if: always()
+
+    steps:
+      - name: Download all reports
+        uses: actions/download-artifact@v4
+        with:
+          path: reports
+          pattern: audit-*
+
+      - name: Generate summary
+        run: |
+          echo "## Ecosystem Documentation Audit Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Repository | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          for dir in reports/audit-*/; do
+            repo=$(basename "$dir" | sed 's/^audit-//')
+            if [ -f "$dir/audit-report.json" ]; then
+              echo "| $repo | Completed |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| $repo | No report |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done

--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -1,0 +1,69 @@
+name: Documentation Audit
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - 'README.kr.md'
+      - 'CLAUDE.md'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  audit:
+    name: Documentation Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Prepare audit tool
+        run: |
+          cp -r tools/doc-audit "$RUNNER_TEMP/doc_audit"
+
+      - name: Run audit (quick mode)
+        id: audit
+        run: |
+          python -m doc_audit . --quick --format markdown | tee audit-report.md
+          EXIT_CODE=${PIPESTATUS[0]}
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          exit $EXIT_CODE
+        env:
+          PYTHONPATH: ${{ runner.temp }}
+        continue-on-error: true
+
+      - name: Comment on PR
+        if: steps.audit.outputs.exit_code == '1'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const reportPath = 'audit-report.md';
+            if (!fs.existsSync(reportPath)) return;
+            const report = fs.readFileSync(reportPath, 'utf8');
+            if (!report.trim()) return;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## Documentation Audit Report\n\n${report}`
+            });
+
+      - name: Fail on critical findings
+        if: steps.audit.outputs.exit_code == '1'
+        run: |
+          echo "::error::Documentation audit found critical issues. See PR comment for details."
+          exit 1


### PR DESCRIPTION
Closes #569

## Summary
- Add `doc-audit.yml` — runs documentation audit in quick mode on PRs modifying `docs/`, `README.md`, `README.kr.md`, or `CLAUDE.md`
- Add `doc-audit-ecosystem.yml` — weekly (Monday 3:23 AM UTC) ecosystem-wide audit of all 8 repos with matrix strategy and artifact uploads
- Audit failures post findings as PR comments and block merge
- Uses `PYTHONPATH` + `RUNNER_TEMP` for clean tool isolation

## Test Plan
- [ ] Verify doc-audit.yml triggers on docs/ file changes in PRs
- [ ] Verify ecosystem workflow runs via workflow_dispatch
- [ ] Verify audit report artifacts are uploaded correctly