### PR TITLE
docs: add ecosystem cross-navigation links

### DIFF
--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -1,0 +1,40 @@
+# Ecosystem Integration
+
+## Position in kcenon Ecosystem
+
+**common_system** is the foundation layer of the kcenon ecosystem. It provides core interfaces, design patterns, and shared utilities that all other systems depend on. No other system is required to use common_system.
+
+## Dependencies
+
+| System | Relationship |
+|--------|-------------|
+| (none) | common_system has no ecosystem dependencies — it is the root |
+
+## Dependent Systems
+
+| System | How It Uses common_system |
+|--------|--------------------------|
+| thread_system | Core interfaces for thread management and scheduling |
+| logger_system | Base patterns for logging infrastructure |
+| container_system | Shared utilities for type-safe containers |
+| monitoring_system | Foundation interfaces for metrics and tracing |
+| database_system | Core patterns for database abstraction |
+| network_system | Base interfaces for networking protocols |
+| pacs_system | All foundation types and utilities |
+
+## All Ecosystem Systems
+
+| System | Description | Docs |
+|--------|------------|------|
+| common_system | Foundation — interfaces, patterns, utilities | [Docs](https://kcenon.github.io/common_system/) |
+| thread_system | High-performance thread pool, DAG scheduling | [Docs](https://kcenon.github.io/thread_system/) |
+| logger_system | Async logging, decorators, OpenTelemetry | [Docs](https://kcenon.github.io/logger_system/) |
+| container_system | Type-safe containers, SIMD serialization | [Docs](https://kcenon.github.io/container_system/) |
+| monitoring_system | Metrics, tracing, alerts, plugins | [Docs](https://kcenon.github.io/monitoring_system/) |
+| database_system | Multi-backend DB (PostgreSQL, SQLite, MongoDB, Redis) | [Docs](https://kcenon.github.io/database_system/) |
+| network_system | TCP/UDP/WebSocket/HTTP2/QUIC/gRPC networking | [Docs](https://kcenon.github.io/network_system/) |
+| pacs_system | DICOM medical imaging (12 libraries) | [Docs](https://kcenon.github.io/pacs_system/) |
+
+## Ecosystem Overview
+
+See the [Ecosystem Overview](https://kcenon.github.io/common_system/) in common_system for the complete dependency map and system selection guide.

--- a/docs/ECOSYSTEM_OVERVIEW.md
+++ b/docs/ECOSYSTEM_OVERVIEW.md
@@ -1,0 +1,39 @@
+# kcenon Ecosystem Overview
+
+## System Map
+
+```
+common_system (Foundation — interfaces, patterns, utilities)
+├── thread_system (High-performance thread pool, DAG scheduling)
+├── logger_system (Async logging, decorators, OpenTelemetry)
+├── container_system (Type-safe containers, SIMD serialization)
+├── monitoring_system (Metrics, tracing, alerts, plugins)
+├── database_system (Multi-backend DB: PostgreSQL, SQLite, MongoDB, Redis)
+├── network_system (TCP/UDP/WebSocket/HTTP2/QUIC/gRPC)
+└── pacs_system (DICOM medical imaging, 12 libraries)
+```
+
+## Which System Do I Need?
+
+| Use Case | Start Here | Then Add |
+|----------|-----------|----------|
+| Building a server | network_system | container_system, logger_system |
+| Need logging | logger_system | monitoring_system |
+| Thread pool / async work | thread_system | common_system |
+| Database access | database_system | common_system |
+| System monitoring | monitoring_system | logger_system |
+| Data serialization | container_system | common_system |
+| Medical imaging (DICOM) | pacs_system | (includes everything) |
+
+## Documentation Links
+
+| System | GitHub Pages | Repository |
+|--------|------------|------------|
+| common_system | https://kcenon.github.io/common_system/ | https://github.com/kcenon/common_system |
+| thread_system | https://kcenon.github.io/thread_system/ | https://github.com/kcenon/thread_system |
+| logger_system | https://kcenon.github.io/logger_system/ | https://github.com/kcenon/logger_system |
+| container_system | https://kcenon.github.io/container_system/ | https://github.com/kcenon/container_system |
+| monitoring_system | https://kcenon.github.io/monitoring_system/ | https://github.com/kcenon/monitoring_system |
+| database_system | https://kcenon.github.io/database_system/ | https://github.com/kcenon/database_system |
+| network_system | https://kcenon.github.io/network_system/ | https://github.com/kcenon/network_system |
+| pacs_system | https://kcenon.github.io/pacs_system/ | https://github.com/kcenon/pacs_system |


### PR DESCRIPTION
## Summary
- Add `docs/ECOSYSTEM_OVERVIEW.md` with full system map, use-case guide, and documentation links for all 8 kcenon ecosystem repositories
- Add `docs/ECOSYSTEM.md` with common_system's position as the foundation layer, its dependents, and cross-navigation links

Closes #583