### PR TITLE
docs(tutorials): add tutorials, FAQ and troubleshooting guide

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -73,6 +73,11 @@ INPUT                  = ./include/kcenon/common \
                          ./src \
                          ./README.md \
                          ./docs/mainpage.dox \
+                         ./docs/tutorial_result.dox \
+                         ./docs/tutorial_di.dox \
+                         ./docs/tutorial_eventbus.dox \
+                         ./docs/faq.dox \
+                         ./docs/troubleshooting.dox \
                          ./examples
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \

--- a/docs/faq.dox
+++ b/docs/faq.dox
@@ -1,0 +1,117 @@
+/**
+@page faq Frequently Asked Questions
+
+@tableofcontents
+
+@section faq_result Result<T> Questions
+
+@subsection faq_result_vs_exceptions When should I use Result<T> instead of exceptions?
+
+Use `Result<T>` when the failure is an expected part of the API contract:
+configuration parsing, network timeouts, missing files, invalid user input.
+Use exceptions for genuinely exceptional situations: out-of-memory, programmer
+errors like precondition violations, and corruption.
+
+The boundary matters more than the choice: never leak exceptions across a
+module that promises `Result<T>`, and never return `Result<T>` from a function
+whose caller expects exceptions.
+
+@subsection faq_result_chain How do I chain Result<T> operations without nesting?
+
+Use `.and_then()` / `.or_else()` — each step composes onto the previous one and
+short-circuits on the first error. See @ref tutorial_result "Result Tutorial"
+for a worked example.
+
+@subsection faq_result_unwrap Why doesn't .value() just return a default on error?
+
+Because silently swallowing errors is how bugs hide for months. If you genuinely
+want a default, say so explicitly with `.value_or(default)`. `.value()` on an
+error is a contract violation and should fail loudly.
+
+@section faq_di Dependency Injection Questions
+
+@subsection faq_di_container_lifecycle How does the service container lifecycle work?
+
+Singletons live for the lifetime of the container. Transients are created on
+each resolve and owned by the caller. The container itself is process-global
+by default (`service_container::instance()`), but you can create local
+instances for isolated test scopes.
+
+@subsection faq_di_standalone Can I use common_system without the rest of the ecosystem?
+
+Yes. common_system is deliberately the foundation layer and has no dependencies
+on the other kcenon systems. You can pull it in for `Result<T>`, the service
+container, and the event bus without committing to the full stack.
+
+@section faq_build Build and Integration Questions
+
+@subsection faq_cpp_version What C++ version is required?
+
+C++20. Specifically, the code uses `std::format`, concepts, and three-way
+comparison, so the minimum compiler baseline is GCC 13, Clang 17, or MSVC 2022.
+
+@subsection faq_integration How do I integrate with existing exception-based code?
+
+Wrap the exception boundary with a try/catch that converts to `Result`:
+
+@code{.cpp}
+Result<int> safe_parse(const std::string& s) {
+    try {
+        return make_ok(std::stoi(s));
+    } catch (const std::exception& e) {
+        return make_error<int>(error_code::parse_failed, e.what());
+    }
+}
+@endcode
+
+Do this once at the boundary — not in every function.
+
+@section faq_threading Threading Questions
+
+@subsection faq_threading_safety Is the service container thread-safe?
+
+Yes for lookup and resolve. Registration is also thread-safe but intended to
+happen during application startup before any resolves — registering from
+multiple threads while others are resolving is supported but stylistically suspect.
+
+@subsection faq_eventbus_thread Does the event bus dispatch on a worker thread?
+
+No — handlers run synchronously on the publisher's thread. If you need async
+dispatch, wrap the handler in a lambda that posts work to thread_system's pool.
+
+@section faq_testing Testing Questions
+
+@subsection faq_test_mock How do I mock a service for testing?
+
+Create a test double that implements the interface and register it instead of
+the production implementation. See @ref tutorial_di for the pattern.
+
+@subsection faq_test_result How do I test Result-returning functions?
+
+Check both branches explicitly:
+
+@code{.cpp}
+TEST(Parser, rejects_empty_input) {
+    auto r = parse("");
+    ASSERT_TRUE(r.is_error());
+    EXPECT_EQ(r.error().code, error_code::invalid_argument);
+}
+@endcode
+
+@section faq_performance Performance Questions
+
+@subsection faq_result_cost Is Result<T> expensive compared to exceptions?
+
+In the happy path, `Result<T>` is usually cheaper: no stack unwinding, no RTTI
+lookup, and the compiler can often inline the check away. In the error path,
+Result is consistently cheap while exceptions are consistently expensive.
+
+@section faq_deploy Deployment Questions
+
+@subsection faq_header_only Is common_system header-only?
+
+Most of it is. Some patterns (event bus, circuit breaker) have small .cpp
+files. The CMake target handles both cases transparently — just link
+`kcenon::common_system`.
+
+*/

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -199,6 +199,16 @@ git clone https://github.com/kcenon/common_system.git
 | Unwrap Demo | @ref unwrap_demo.cpp | Result unwrapping, value_or, and chaining patterns |
 | Multi-System App | @ref multi_system_app/main.cpp | Multi-system integration with config and DI |
 
+@section learning_resources Learning Resources
+
+New to common_system? Start here:
+
+- @ref tutorial_result "Tutorial: Result<T> Error Handling" — explicit error handling without exceptions
+- @ref tutorial_di "Tutorial: Dependency Injection" — service container registration and resolution
+- @ref tutorial_eventbus "Tutorial: Event Bus" — decoupled publish/subscribe messaging
+- @ref faq "Frequently Asked Questions" — common design and integration questions
+- @ref troubleshooting "Troubleshooting Guide" — build, link, and runtime issue solutions
+
 @section related Related Systems
 
 Common System is the foundation (Tier 0) of the kcenon ecosystem.

--- a/docs/troubleshooting.dox
+++ b/docs/troubleshooting.dox
@@ -1,0 +1,111 @@
+/**
+@page troubleshooting Troubleshooting Guide
+
+@tableofcontents
+
+@section ts_build Build Issues
+
+@subsection ts_build_cpp20 "error: 'format' is not a member of 'std'"
+
+**Cause**: Your compiler is below the C++20 baseline required by common_system.
+`std::format` arrived in GCC 13, Clang 17, and MSVC 2022 — earlier versions
+will reject the headers.
+
+**Fix**: Upgrade the compiler, or on Linux install `libstdc++-13-dev` alongside
+GCC 13.
+
+@subsection ts_build_concept "concept 'invocable' was not declared"
+
+**Cause**: The `<concepts>` header isn't being found, or `-std=c++20` isn't
+being passed to the compiler.
+
+**Fix**: In CMake, ensure `CMAKE_CXX_STANDARD` is set before the project
+declaration:
+
+@code{.cmake}
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(my_app)
+@endcode
+
+@section ts_cmake CMake Configuration Issues
+
+@subsection ts_cmake_notfound "Could not find package kcenon-common-system"
+
+**Cause**: CMake can't locate the installed package. Either it isn't installed,
+or `CMAKE_PREFIX_PATH` doesn't include the install location.
+
+**Fix**: Either install common_system to a system location
+(`cmake --install build`), or point your build at the install tree:
+
+@code{.bash}
+cmake -B build -DCMAKE_PREFIX_PATH=/opt/kcenon
+@endcode
+
+For development, prefer `FetchContent` or `add_subdirectory` to pull
+common_system directly into your build.
+
+@section ts_vcpkg vcpkg Integration Issues
+
+@subsection ts_vcpkg_port "port name not recognized"
+
+**Cause**: vcpkg's registry doesn't know about common_system — you need to
+register the overlay.
+
+**Fix**: Add the overlay to `vcpkg-configuration.json`:
+
+@code{.json}
+{
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/kcenon/vcpkg-registry",
+      "reference": "main",
+      "baseline": "...",
+      "packages": ["kcenon-common-system"]
+    }
+  ]
+}
+@endcode
+
+@section ts_linker Linker Issues
+
+@subsection ts_linker_undef "undefined reference to kcenon::common::event_bus::publish"
+
+**Cause**: The application is including the headers but not linking the library
+target. Some patterns (event bus, circuit breaker) have out-of-line definitions.
+
+**Fix**: In your `CMakeLists.txt`:
+
+@code{.cmake}
+target_link_libraries(my_app PRIVATE kcenon::common_system)
+@endcode
+
+Do NOT just add the include path — the linker needs the target.
+
+@section ts_runtime Runtime Issues
+
+@subsection ts_runtime_resolve "service_container::resolve: type not registered"
+
+**Cause**: You're trying to resolve a service that nothing ever registered.
+Common causes: initialization order, register-after-resolve, or the wrong
+interface type.
+
+**Fix**: Ensure registration happens during startup, before the first resolve.
+Log or break at the registration point to confirm it actually runs:
+
+@code{.cpp}
+auto& container = service_container::instance();
+container.register_singleton<IClock, system_clock>();
+assert(container.contains<IClock>());  // verify
+@endcode
+
+@subsection ts_runtime_value "bad_result_access thrown from Result::value()"
+
+**Cause**: You called `.value()` on a `Result` that carries an error. The error
+details are in `.error()`, not `.value()`.
+
+**Fix**: Check `.is_ok()` first, or use `.value_or(default)`. See
+@ref tutorial_result for the idiomatic pattern.
+
+*/

--- a/docs/tutorial_di.dox
+++ b/docs/tutorial_di.dox
@@ -1,0 +1,95 @@
+/**
+@page tutorial_di Tutorial: Dependency Injection
+
+@tableofcontents
+
+@section di_goal Goal
+
+Use common_system's lightweight service container to register, resolve, and compose dependencies. You'll learn how to structure an application so that services can be swapped for tests without changing call sites.
+
+@section di_prereq Prerequisites
+
+- Read @ref tutorial_result first — DI services frequently return `Result<T>`
+- Understand C++20 concepts and `std::shared_ptr`
+
+@section di_step1 Step 1: Define a service interface
+
+Services are ordinary abstract classes. The container binds concrete implementations to the interface type.
+
+@code{.cpp}
+#include <kcenon/common/patterns/service_container.h>
+
+struct IClock {
+    virtual ~IClock() = default;
+    virtual std::chrono::system_clock::time_point now() const = 0;
+};
+
+struct system_clock : IClock {
+    std::chrono::system_clock::time_point now() const override {
+        return std::chrono::system_clock::now();
+    }
+};
+@endcode
+
+@section di_step2 Step 2: Register and resolve
+
+Register the concrete implementation against the interface, then resolve it by type:
+
+@code{.cpp}
+using namespace kcenon::common;
+
+int main() {
+    auto& container = service_container::instance();
+    container.register_singleton<IClock, system_clock>();
+
+    auto clock = container.resolve<IClock>();
+    auto t = clock->now();
+    // ... use clock ...
+}
+@endcode
+
+`register_singleton` creates the instance once and returns the same shared pointer
+on every resolve. Use `register_transient` if you want a fresh instance per resolve.
+
+@section di_step3 Step 3: Swap implementations in tests
+
+The whole point of DI: production uses `system_clock`, tests use a fake that
+lets you advance time manually.
+
+@code{.cpp}
+struct fake_clock : IClock {
+    std::chrono::system_clock::time_point fixed_time;
+    std::chrono::system_clock::time_point now() const override {
+        return fixed_time;
+    }
+};
+
+TEST(MyService, handles_time_correctly) {
+    auto fake = std::make_shared<fake_clock>();
+    fake->fixed_time = std::chrono::system_clock::now();
+
+    auto& container = service_container::instance();
+    container.register_instance<IClock>(fake);
+
+    // service_under_test now sees the frozen time
+    MyService svc;
+    EXPECT_TRUE(svc.do_something().is_ok());
+}
+@endcode
+
+@section di_mistakes Common Mistakes
+
+- **Static singletons bypassing DI.** If `MyService` calls
+  `std::chrono::system_clock::now()` directly, DI can't help you test it.
+  Inject `IClock` through the constructor instead.
+- **Resolving inside hot loops.** Resolve once, store the pointer, reuse.
+  Container lookup is not free.
+- **Registering concrete types.** Always register against the interface —
+  otherwise swapping implementations later becomes a find-and-replace exercise.
+
+@section di_next Next Steps
+
+- @ref tutorial_eventbus "Tutorial: Event Bus" — decouple services further
+- See `examples/multi_system_app/` for a realistic multi-service application
+
+*/

--- a/docs/tutorial_eventbus.dox
+++ b/docs/tutorial_eventbus.dox
@@ -1,0 +1,91 @@
+/**
+@page tutorial_eventbus Tutorial: Event Bus
+
+@tableofcontents
+
+@section eb_goal Goal
+
+Use the event bus to decouple publishers from subscribers. You'll learn how to define events, subscribe handlers, and publish without the publisher knowing who — if anyone — is listening.
+
+@section eb_prereq Prerequisites
+
+- Read @ref tutorial_di first — event bus is typically registered as a DI service
+- Basic understanding of the observer pattern
+
+@section eb_step1 Step 1: Define an event type
+
+Events are plain structs. Keep them immutable — subscribers should not modify
+the event they receive.
+
+@code{.cpp}
+#include <kcenon/common/patterns/event_bus.h>
+
+struct user_logged_in {
+    std::string user_id;
+    std::chrono::system_clock::time_point timestamp;
+};
+@endcode
+
+@section eb_step2 Step 2: Subscribe a handler
+
+Subscribers register a callback for a specific event type. The handle returned
+by `subscribe` must stay alive for as long as you want the subscription active —
+destroying it cancels the subscription.
+
+@code{.cpp}
+using namespace kcenon::common;
+
+class audit_logger {
+    event_bus::subscription sub_;
+public:
+    explicit audit_logger(event_bus& bus) {
+        sub_ = bus.subscribe<user_logged_in>(
+            [](const user_logged_in& event) {
+                std::cout << "AUDIT: " << event.user_id
+                          << " logged in" << std::endl;
+            });
+    }
+};
+@endcode
+
+@section eb_step3 Step 3: Publish from another component
+
+The publisher holds no reference to subscribers — it just fires the event.
+All subscribers registered for that type receive it.
+
+@code{.cpp}
+class authentication_service {
+    event_bus& bus_;
+public:
+    explicit authentication_service(event_bus& bus) : bus_(bus) {}
+
+    Result<session> login(const credentials& creds) {
+        auto session = verify_credentials(creds);
+        if (session.is_error()) return session;
+
+        bus_.publish(user_logged_in{
+            .user_id = creds.username,
+            .timestamp = std::chrono::system_clock::now()
+        });
+
+        return session;
+    }
+};
+@endcode
+
+@section eb_mistakes Common Mistakes
+
+- **Long-running handlers.** Handlers run on the publisher's thread by default.
+  If you need to do heavy work, hand off to a worker thread — otherwise the
+  publisher is blocked.
+- **Subscribing inside handlers.** Adding/removing subscriptions while dispatching
+  an event can cause invalidation. Defer such changes to after the handler returns.
+- **Forgetting to store the subscription.** A discarded subscription handle is
+  immediately cancelled. Keep it in a member variable or container.
+
+@section eb_next Next Steps
+
+- @ref faq "FAQ" — when to use event bus vs direct method calls
+- @ref troubleshooting "Troubleshooting" — debugging missing events
+
+*/

--- a/docs/tutorial_result.dox
+++ b/docs/tutorial_result.dox
@@ -1,0 +1,97 @@
+/**
+@page tutorial_result Tutorial: Result<T> Error Handling
+
+@tableofcontents
+
+@section result_goal Goal
+
+Learn how to use `kcenon::common::Result<T>` for safe, explicit error handling without exceptions. By the end of this tutorial you will be able to create, chain, and consume `Result` values idiomatically.
+
+@section result_prereq Prerequisites
+
+- C++20 compiler (GCC 13+, Clang 17+, MSVC 2022+)
+- common_system installed (see @ref mainpage "Main Page" for installation)
+- Familiarity with basic template syntax
+
+@section result_step1 Step 1: Creating Result values
+
+A `Result<T>` carries either a successful value of type `T` or an `error_info`. Construct one of each:
+
+@code{.cpp}
+#include <kcenon/common/patterns/result.h>
+#include <string>
+
+using namespace kcenon::common;
+
+Result<int> parse_port(const std::string& s) {
+    try {
+        int port = std::stoi(s);
+        if (port < 1 || port > 65535) {
+            return make_error<int>(error_code::invalid_argument,
+                                   "Port out of range: " + s);
+        }
+        return make_ok(port);
+    } catch (const std::exception& e) {
+        return make_error<int>(error_code::parse_failed, e.what());
+    }
+}
+@endcode
+
+@note Prefer `make_ok` / `make_error` factory helpers over direct construction —
+they document intent and avoid accidental slicing.
+
+@section result_step2 Step 2: Consuming Result values
+
+Use `is_ok()` / `is_error()` to branch, or pattern-match with `std::visit`:
+
+@code{.cpp}
+void start_server(const std::string& port_str) {
+    auto result = parse_port(port_str);
+
+    if (result.is_ok()) {
+        int port = result.value();
+        std::cout << "Starting server on port " << port << std::endl;
+        // ... bind socket, begin listening ...
+    } else {
+        const auto& err = result.error();
+        std::cerr << "Failed: [" << static_cast<int>(err.code)
+                  << "] " << err.message << std::endl;
+    }
+}
+@endcode
+
+@section result_step3 Step 3: Chaining operations
+
+Multiple fallible operations can be chained with `.and_then()` so that the first
+error short-circuits the rest — no nested `if` pyramids required.
+
+@code{.cpp}
+Result<config> load_config(const std::string& path) {
+    return read_file(path)
+        .and_then([](const std::string& text) { return parse_json(text); })
+        .and_then([](const json_value& json) { return validate_schema(json); })
+        .and_then([](const json_value& json) { return build_config(json); });
+}
+@endcode
+
+Each step receives the previous step's success value; if any returns an error,
+the whole chain becomes that error.
+
+@section result_mistakes Common Mistakes
+
+- **Ignoring the return value.** `Result` has `[[nodiscard]]` — respect it. Silently
+  dropping a result discards its error, defeating the whole point of using it.
+- **Calling `.value()` without checking.** `.value()` on an error `Result` throws
+  (or aborts, depending on configuration). Use `.is_ok()` first, or prefer
+  `.value_or(default)`.
+- **Mixing exceptions and Result.** Choose one style per module. Wrapping
+  exception-throwing code at API boundaries is fine; sprinkling throws inside
+  Result chains defeats the explicitness.
+
+@section result_next Next Steps
+
+- @ref tutorial_di "Tutorial: Dependency Injection" — pass Result-returning services through DI
+- @ref faq "FAQ" — common Result<T> questions
+- See `examples/result_example.cpp` for a full working example
+
+*/


### PR DESCRIPTION
Closes #591

## Summary
- Add 3 tutorials: Result<T>, Dependency Injection, Event Bus
- Add FAQ page with 13+ entries covering Result, DI, build, threading, testing, performance, deployment
- Add troubleshooting guide with build, CMake, vcpkg, linker, and runtime issues
- Update mainpage.dox with Learning Resources section linking to all new pages
- Update Doxyfile INPUT paths to include new .dox files

## Test Plan
- Verify Doxygen CI build passes
- Verify new pages render correctly and @ref cross-links resolve