### PR TITLE
fix(vcpkg): disable default postgresql feature in database_system consumer test

### DIFF
--- a/tests/ecosystem-consumer/database-system/vcpkg.json
+++ b/tests/ecosystem-consumer/database-system/vcpkg.json
@@ -1,5 +1,10 @@
 {
   "name": "test-database-system",
   "version-string": "0.0.0",
-  "dependencies": ["kcenon-database-system"]
+  "dependencies": [
+    {
+      "name": "kcenon-database-system",
+      "default-features": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Disable default features (postgresql) in the database_system ecosystem consumer test to avoid libpq build failure on CI

## Why
The database_system vcpkg port's default feature \`postgresql\` pulls in \`libpq\`, which fails to build on CI runners because the required build tools (\`CMAKE_MAKE_PROGRAM\`, C++ compiler) are not available during the vcpkg install phase. Both ubuntu-24.04 and macos-14 are affected.

The consumer test only validates that the core DAL headers (\`database_manager.h\`) can be found and linked — it does not use any database backend. Disabling default features allows the core \`DatabaseSystem::database\` target to build without the heavy PostgreSQL dependency.

### Related Issues
- Closes #611

## Where
- \`tests/ecosystem-consumer/database-system/vcpkg.json\`

## Test Plan
- [ ] Layer 5 (database_system) passes on ubuntu-24.04
- [ ] Layer 5 (database_system) passes on macos-14
- [ ] No regression on Layers 0-4