### PR TITLE
fix(vcpkg): update registry baseline for monitoring_system thread_system alias

### DIFF
--- a/tests/ecosystem-consumer/common-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/common-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "7ffe9e2e943568bd78634d63c4f62103a22bed96",
+      "baseline": "85aeb57c255ac434979e420ae52b56a25c556fc2",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/container-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/container-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "7ffe9e2e943568bd78634d63c4f62103a22bed96",
+      "baseline": "85aeb57c255ac434979e420ae52b56a25c556fc2",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/database-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/database-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "7ffe9e2e943568bd78634d63c4f62103a22bed96",
+      "baseline": "85aeb57c255ac434979e420ae52b56a25c556fc2",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/logger-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/logger-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "7ffe9e2e943568bd78634d63c4f62103a22bed96",
+      "baseline": "85aeb57c255ac434979e420ae52b56a25c556fc2",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/monitoring-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/monitoring-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "7ffe9e2e943568bd78634d63c4f62103a22bed96",
+      "baseline": "85aeb57c255ac434979e420ae52b56a25c556fc2",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/network-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/network-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "7ffe9e2e943568bd78634d63c4f62103a22bed96",
+      "baseline": "85aeb57c255ac434979e420ae52b56a25c556fc2",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/pacs-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/pacs-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "7ffe9e2e943568bd78634d63c4f62103a22bed96",
+      "baseline": "85aeb57c255ac434979e420ae52b56a25c556fc2",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/thread-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/thread-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "7ffe9e2e943568bd78634d63c4f62103a22bed96",
+      "baseline": "85aeb57c255ac434979e420ae52b56a25c556fc2",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "7ffe9e2e943568bd78634d63c4f62103a22bed96",
+      "baseline": "85aeb57c255ac434979e420ae52b56a25c556fc2",
       "packages": ["kcenon-*"]
     }
   ]


### PR DESCRIPTION
## Summary
- Update ecosystem test vcpkg-configuration.json registry baseline to `a2a7f4d4`
- The new baseline adds a `thread_system::thread_system` umbrella alias in legacy/component build mode (0.3.2#2)

## Why
`monitoring_system-targets.cmake` references `thread_system::thread_system` but thread_system in legacy mode only exports component targets (`thread_base`, `utilities`, etc.). The new registry baseline injects an alias from `thread_system::thread_system` to `thread_system::thread_base`.

### Related Issues
- Related: kcenon/vcpkg-registry#53 (registry fix)

## Test Plan
- [ ] Layer 6 (monitoring_system) passes on ubuntu-24.04 and macos-14
- [ ] All previous layers remain passing (0-5)
- [ ] Layer 7 (pacs_system) unblocked