### PR TITLE
feat(ci): add semantic validation to port-sync-check

### DIFF
--- a/.github/workflows/port-sync-check.yml
+++ b/.github/workflows/port-sync-check.yml
@@ -108,3 +108,191 @@ jobs:
 
         # Informational only - do not fail the workflow on drift
         echo "Port sync check complete: ${SYNC_COUNT} synced, ${DRIFT_COUNT} drifted, ${ERROR_COUNT} errors"
+
+    - name: Semantic content validation
+      run: |
+        declare -A PROJECTS=(
+          ["common_system"]="kcenon-common-system"
+          ["thread_system"]="kcenon-thread-system"
+          ["logger_system"]="kcenon-logger-system"
+          ["container_system"]="kcenon-container-system"
+          ["monitoring_system"]="kcenon-monitoring-system"
+          ["database_system"]="kcenon-database-system"
+          ["network_system"]="kcenon-network-system"
+          ["pacs_system"]="kcenon-pacs-system"
+        )
+
+        WARN_COUNT=0
+
+        echo "## Semantic Content Validation" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+
+        # --- Validation 1: PACKAGE_NAME consistency ---
+        echo "### PACKAGE_NAME / CONFIG_PATH Validation" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Port | Source | PACKAGE_NAME | CONFIG_PATH | Status |" >> "$GITHUB_STEP_SUMMARY"
+        echo "|------|--------|--------------|-------------|--------|" >> "$GITHUB_STEP_SUMMARY"
+
+        for PROJECT in "${!PROJECTS[@]}"; do
+          PORT="${PROJECTS[$PROJECT]}"
+
+          for SOURCE in "project" "registry"; do
+            if [ "$SOURCE" = "project" ]; then
+              PORTFILE_CONTENT=$(gh api "repos/kcenon/${PROJECT}/contents/vcpkg-ports/${PORT}/portfile.cmake" \
+                --jq '.content' 2>/dev/null | base64 -d 2>/dev/null) || PORTFILE_CONTENT=""
+              SOURCE_LABEL="source"
+            else
+              PORTFILE_CONTENT=$(gh api "repos/kcenon/vcpkg-registry/contents/ports/${PORT}/portfile.cmake" \
+                --jq '.content' 2>/dev/null | base64 -d 2>/dev/null) || PORTFILE_CONTENT=""
+              SOURCE_LABEL="registry"
+            fi
+
+            if [ -z "$PORTFILE_CONTENT" ]; then
+              echo "| ${PORT} | ${SOURCE_LABEL} | -- | -- | skipped (not found) |" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            # Extract PACKAGE_NAME from vcpkg_cmake_config_fixup(PACKAGE_NAME ...)
+            PKG_NAME=$(echo "$PORTFILE_CONTENT" | grep -oP 'PACKAGE_NAME\s+\K[^\s)]+' | head -1)
+            # Extract CONFIG_PATH from vcpkg_cmake_config_fixup(... CONFIG_PATH ...)
+            CFG_PATH=$(echo "$PORTFILE_CONTENT" | grep -oP 'CONFIG_PATH\s+\K[^\s)]+' | head -1)
+
+            if [ -z "$PKG_NAME" ]; then
+              echo "| ${PORT} | ${SOURCE_LABEL} | -- | ${CFG_PATH:---} | skipped (no PACKAGE_NAME) |" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            STATUS="ok"
+            ISSUES=""
+
+            # Check snake_case: must not contain uppercase letters
+            if echo "$PKG_NAME" | grep -qP '[A-Z]'; then
+              ISSUES="PACKAGE_NAME has uppercase"
+              STATUS="**WARNING**"
+              WARN_COUNT=$((WARN_COUNT + 1))
+            fi
+
+            # Check CONFIG_PATH matches lib/cmake/<PACKAGE_NAME>
+            EXPECTED_CFG="lib/cmake/${PKG_NAME}"
+            if [ -n "$CFG_PATH" ] && [ "$CFG_PATH" != "$EXPECTED_CFG" ]; then
+              if [ -n "$ISSUES" ]; then ISSUES="${ISSUES}; "; fi
+              ISSUES="${ISSUES}CONFIG_PATH mismatch (expected ${EXPECTED_CFG})"
+              STATUS="**WARNING**"
+              WARN_COUNT=$((WARN_COUNT + 1))
+            fi
+
+            if [ "$STATUS" = "ok" ]; then
+              echo "| ${PORT} | ${SOURCE_LABEL} | ${PKG_NAME} | ${CFG_PATH} | ok |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| ${PORT} | ${SOURCE_LABEL} | ${PKG_NAME} | ${CFG_PATH} | ${STATUS}: ${ISSUES} |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+        done
+
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+
+        # --- Validation 2: Usage file target names ---
+        echo "### Usage File Target Validation" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Port | Source | Target | Status |" >> "$GITHUB_STEP_SUMMARY"
+        echo "|------|--------|--------|--------|" >> "$GITHUB_STEP_SUMMARY"
+
+        for PROJECT in "${!PROJECTS[@]}"; do
+          PORT="${PROJECTS[$PROJECT]}"
+
+          for SOURCE in "project" "registry"; do
+            if [ "$SOURCE" = "project" ]; then
+              USAGE_CONTENT=$(gh api "repos/kcenon/${PROJECT}/contents/vcpkg-ports/${PORT}/usage" \
+                --jq '.content' 2>/dev/null | base64 -d 2>/dev/null) || USAGE_CONTENT=""
+              SOURCE_LABEL="source"
+            else
+              USAGE_CONTENT=$(gh api "repos/kcenon/vcpkg-registry/contents/ports/${PORT}/usage" \
+                --jq '.content' 2>/dev/null | base64 -d 2>/dev/null) || USAGE_CONTENT=""
+              SOURCE_LABEL="registry"
+            fi
+
+            if [ -z "$USAGE_CONTENT" ]; then
+              echo "| ${PORT} | ${SOURCE_LABEL} | -- | skipped (not found) |" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            # Extract target from target_link_libraries(main PRIVATE <target>)
+            TARGET=$(echo "$USAGE_CONTENT" | grep -oP 'target_link_libraries\([^)]*PRIVATE\s+\K[^\s)]+' | head -1)
+
+            if [ -z "$TARGET" ]; then
+              echo "| ${PORT} | ${SOURCE_LABEL} | -- | skipped (no target found) |" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            STATUS="ok"
+            ISSUES=""
+
+            # Check namespace::target pattern
+            if ! echo "$TARGET" | grep -qP '^[a-z_]+::[a-z_]+$'; then
+              # Check specifically for PascalCase
+              if echo "$TARGET" | grep -qP '[A-Z]'; then
+                ISSUES="PascalCase in target name"
+              else
+                ISSUES="unexpected target format"
+              fi
+              STATUS="**WARNING**"
+              WARN_COUNT=$((WARN_COUNT + 1))
+            fi
+
+            if [ "$STATUS" = "ok" ]; then
+              echo "| ${PORT} | ${SOURCE_LABEL} | ${TARGET} | ok |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| ${PORT} | ${SOURCE_LABEL} | ${TARGET} | ${STATUS}: ${ISSUES} |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+        done
+
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+
+        # --- Validation 3: Version consistency ---
+        echo "### Version Consistency" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Port | Source Version | Registry Version | Status |" >> "$GITHUB_STEP_SUMMARY"
+        echo "|------|----------------|------------------|--------|" >> "$GITHUB_STEP_SUMMARY"
+
+        for PROJECT in "${!PROJECTS[@]}"; do
+          PORT="${PROJECTS[$PROJECT]}"
+
+          # Get version from source repo vcpkg.json
+          SRC_VERSION=$(gh api "repos/kcenon/${PROJECT}/contents/vcpkg-ports/${PORT}/vcpkg.json" \
+            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null \
+            | grep -oP '"version-semver"\s*:\s*"\K[^"]+' | head -1) || SRC_VERSION=""
+
+          # Get version from registry vcpkg.json
+          REG_VERSION=$(gh api "repos/kcenon/vcpkg-registry/contents/ports/${PORT}/vcpkg.json" \
+            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null \
+            | grep -oP '"version-semver"\s*:\s*"\K[^"]+' | head -1) || REG_VERSION=""
+
+          if [ -z "$SRC_VERSION" ] || [ -z "$REG_VERSION" ]; then
+            echo "| ${PORT} | ${SRC_VERSION:---} | ${REG_VERSION:---} | skipped (version not found) |" >> "$GITHUB_STEP_SUMMARY"
+            continue
+          fi
+
+          if [ "$SRC_VERSION" = "$REG_VERSION" ]; then
+            echo "| ${PORT} | ${SRC_VERSION} | ${REG_VERSION} | ok |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| ${PORT} | ${SRC_VERSION} | ${REG_VERSION} | **WARNING**: version drift |" >> "$GITHUB_STEP_SUMMARY"
+            WARN_COUNT=$((WARN_COUNT + 1))
+          fi
+        done
+
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+
+        # --- Summary ---
+        echo "### Semantic Validation Summary" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Warnings**: ${WARN_COUNT}" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+
+        if [ "$WARN_COUNT" -gt 0 ]; then
+          echo "> **Note**: Semantic issues detected. Review PACKAGE_NAME casing, usage targets, and version consistency." >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "> All semantic checks passed." >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+        # Informational only - do not fail the workflow
+        echo "Semantic validation complete: ${WARN_COUNT} warnings"


### PR DESCRIPTION
## Summary
- Add PACKAGE_NAME/CONFIG_PATH casing and consistency validation to port-sync-check workflow
- Add usage file target name verification (detects PascalCase drift)
- Add version consistency check between source and registry vcpkg.json
- All new checks report as warnings in GitHub step summary (non-blocking)

## Why
The existing port-sync-check workflow only compares file SHA hashes between source repos and the vcpkg-registry. This missed critical bugs like wrong PACKAGE_NAME casing (e.g., `LoggerSystem` vs `logger_system`) and incorrect target names in usage files, which caused `find_package` failures downstream.

The new semantic validation step fetches actual file content via the GitHub API, parses `PACKAGE_NAME` from `vcpkg_cmake_config_fixup()` calls, target names from `usage` files, and `version-semver` from `vcpkg.json`, then reports mismatches as warnings.

## What Changed
- `.github/workflows/port-sync-check.yml`: Added new "Semantic content validation" step after existing SHA comparison

### Validations Added
| Check | What It Detects |
|-------|-----------------|
| PACKAGE_NAME casing | Uppercase letters in PACKAGE_NAME (must be snake_case) |
| CONFIG_PATH consistency | CONFIG_PATH not matching `lib/cmake/<PACKAGE_NAME>` |
| Usage target names | PascalCase or malformed `namespace::target` patterns |
| Version drift | version-semver mismatch between source and registry |

All 8 ecosystem ports are covered: common, thread, logger, container, monitoring, database, network, pacs.

Relates to kcenon/vcpkg-registry#59
Closes #626

## Test plan
- [ ] Workflow runs successfully on manual trigger (workflow_dispatch)
- [ ] Detects simulated PascalCase PACKAGE_NAME mismatch
- [ ] Detects simulated target name error in usage file
- [ ] Detects version drift between source and registry
- [ ] Existing SHA drift detection still works unchanged
- [ ] New checks produce clear markdown summary tables