### PR TITLE
chore(vcpkg): sync source-local portfile with registry

### DIFF
--- a/tests/ecosystem-consumer/common-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/common-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
+      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/common-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/common-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2f19cd8392aa234f03887eea5abb50eebcf95d91",
+      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/common-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/common-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
+      "baseline": "78691fe0e4222d79337b979fc070794775580e7d",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/container-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/container-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
+      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/container-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/container-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2f19cd8392aa234f03887eea5abb50eebcf95d91",
+      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/container-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/container-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
+      "baseline": "78691fe0e4222d79337b979fc070794775580e7d",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/database-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/database-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
+      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/database-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/database-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2f19cd8392aa234f03887eea5abb50eebcf95d91",
+      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/database-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/database-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
+      "baseline": "78691fe0e4222d79337b979fc070794775580e7d",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/logger-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/logger-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
+      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/logger-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/logger-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2f19cd8392aa234f03887eea5abb50eebcf95d91",
+      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/logger-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/logger-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
+      "baseline": "78691fe0e4222d79337b979fc070794775580e7d",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/monitoring-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/monitoring-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
+      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/monitoring-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/monitoring-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2f19cd8392aa234f03887eea5abb50eebcf95d91",
+      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/monitoring-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/monitoring-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
+      "baseline": "78691fe0e4222d79337b979fc070794775580e7d",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/network-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/network-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
+      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/network-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/network-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2f19cd8392aa234f03887eea5abb50eebcf95d91",
+      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/network-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/network-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
+      "baseline": "78691fe0e4222d79337b979fc070794775580e7d",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/pacs-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/pacs-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
+      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/pacs-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/pacs-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2f19cd8392aa234f03887eea5abb50eebcf95d91",
+      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/pacs-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/pacs-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
+      "baseline": "78691fe0e4222d79337b979fc070794775580e7d",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/thread-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/thread-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
+      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/thread-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/thread-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2f19cd8392aa234f03887eea5abb50eebcf95d91",
+      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/thread-system/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/thread-system/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
+      "baseline": "78691fe0e4222d79337b979fc070794775580e7d",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "6e11de28379ec682976af616ea3d2ccab0546199",
+      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
+      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
       "packages": ["kcenon-*"]
     }
   ]

--- a/tests/ecosystem-consumer/vcpkg-configuration.json
+++ b/tests/ecosystem-consumer/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
+      "baseline": "78691fe0e4222d79337b979fc070794775580e7d",
       "packages": ["kcenon-*"]
     }
   ]

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2f19cd8392aa234f03887eea5abb50eebcf95d91",
+      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
       "packages": [
         "kcenon-*"
       ]

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
+      "baseline": "78691fe0e4222d79337b979fc070794775580e7d",
       "packages": [
         "kcenon-*"
       ]

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "2939f51d9d1511e3fca3fa8f51f9ef7d1a044430",
+      "baseline": "d08f5022113c820c9146df6768e240a43e788a4e",
       "packages": [
         "kcenon-*"
       ]

--- a/vcpkg-ports/kcenon-common-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-common-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-common-system",
   "version-semver": "0.2.0",
-  "port-version": 0,
+  "port-version": 1,
   "description": "High-performance C++20 foundation library providing Result<T> pattern, interfaces, and common utilities",
   "homepage": "https://github.com/kcenon/common_system",
   "license": "BSD-3-Clause",
@@ -15,5 +15,11 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "yaml": {
+      "description": "YAML configuration file support via yaml-cpp",
+      "dependencies": ["yaml-cpp"]
+    }
+  }
 }


### PR DESCRIPTION
## What

### Summary
Syncs the source-local vcpkg.json with the registry counterpart by bumping port-version and adding the yaml feature declaration.

### Change Type
- [x] Chore

### Affected Components
- `vcpkg-ports/kcenon-common-system/vcpkg.json`

## Why

### Problem Solved
Source-local overlay installs were treated as "older" by vcpkg's version resolver due to port-version 0 vs registry baseline 1. The yaml feature was also missing, meaning `kcenon-common-system[yaml]` via overlay wouldn't pull yaml-cpp.

### Related Issues
- Relates to kcenon/vcpkg-registry#75 (portfile logic sync — common_system portion)
- Relates to kcenon/vcpkg-registry#77 (port-version sync — common_system portion)

## How

### Implementation Details
- Bumped `port-version` from 0 to 1
- Added `yaml` feature with `yaml-cpp` dependency
- portfile.cmake was already identical (no logic changes needed)

### Breaking Changes
None