### PR TITLE
fix(di): reassign di_error_codes to avoid collision with thread_system range

### DIFF
--- a/include/kcenon/common/di/service_container_interface.h
+++ b/include/kcenon/common/di/service_container_interface.h
@@ -35,6 +35,7 @@
 
 #include "../patterns/result.h"
 #include "../concepts/service.h"
+#include "../error/error_codes.h"
 
 namespace kcenon::common {
 namespace di {
@@ -484,25 +485,29 @@ public:
 
 /**
  * @brief Error codes specific to dependency injection.
+ *
+ * These reference the centralized error code registry in error_codes.h
+ * (common_errors DI sub-range: -50 to -59) to prevent integer collisions
+ * with system-specific error code ranges.
  */
 namespace di_error_codes {
     /// Service not registered in container
-    constexpr int service_not_registered = -100;
+    constexpr int service_not_registered = error::codes::common_errors::di_service_not_registered;
 
     /// Circular dependency detected during resolution
-    constexpr int circular_dependency = -101;
+    constexpr int circular_dependency = error::codes::common_errors::di_circular_dependency;
 
     /// Service already registered (duplicate registration attempt)
-    constexpr int already_registered = -102;
+    constexpr int already_registered = error::codes::common_errors::di_already_registered;
 
     /// Factory threw an exception during instantiation
-    constexpr int factory_error = -103;
+    constexpr int factory_error = error::codes::common_errors::di_factory_error;
 
     /// Invalid service lifetime configuration
-    constexpr int invalid_lifetime = -104;
+    constexpr int invalid_lifetime = error::codes::common_errors::di_invalid_lifetime;
 
     /// Scoped service resolved from root container
-    constexpr int scoped_from_root = -105;
+    constexpr int scoped_from_root = error::codes::common_errors::di_scoped_from_root;
 }
 
 } // namespace di

--- a/include/kcenon/common/error/error_codes.h
+++ b/include/kcenon/common/error/error_codes.h
@@ -69,6 +69,14 @@ namespace common_errors {
     constexpr int network_error = -10;
     constexpr int registry_frozen = -11;
     constexpr int internal_error = -99;
+
+    // DI (dependency injection) errors (-50 to -59)
+    constexpr int di_service_not_registered = -50;
+    constexpr int di_circular_dependency = -51;
+    constexpr int di_already_registered = -52;
+    constexpr int di_factory_error = -53;
+    constexpr int di_invalid_lifetime = -54;
+    constexpr int di_scoped_from_root = -55;
 } // namespace common_errors
 
 // ============================================================================
@@ -348,6 +356,12 @@ static_assert(codes::common_errors::invalid_argument >= -99 && codes::common_err
 static_assert(codes::common_errors::internal_error >= -99 && codes::common_errors::internal_error <= -1,
               "common error codes must be in range [-99, -1]");
 
+// Validate DI error sub-range (-50 to -59, within common)
+static_assert(codes::common_errors::di_service_not_registered == -50,
+              "DI error codes must start at -50");
+static_assert(codes::common_errors::di_scoped_from_root >= -59 && codes::common_errors::di_scoped_from_root <= -50,
+              "DI error codes must be in range [-59, -50]");
+
 // Validate pacs_system range (-700 to -799)
 static_assert(codes::pacs_system::base == -700,
               "pacs_system base must be -700");
@@ -379,6 +393,14 @@ inline std::string_view get_error_message(int code) {
         case codes::common_errors::network_error: return "Network error";
         case codes::common_errors::registry_frozen: return "Registry is frozen";
         case codes::common_errors::internal_error: return "Internal error";
+
+        // DI errors
+        case codes::common_errors::di_service_not_registered: return "Service not registered in container";
+        case codes::common_errors::di_circular_dependency: return "Circular dependency detected";
+        case codes::common_errors::di_already_registered: return "Service already registered";
+        case codes::common_errors::di_factory_error: return "Factory error during instantiation";
+        case codes::common_errors::di_invalid_lifetime: return "Invalid service lifetime configuration";
+        case codes::common_errors::di_scoped_from_root: return "Scoped service resolved from root container";
 
         // thread_system errors
         case codes::thread_system::pool_full: return "Thread pool full";

--- a/tests/error_codes_test.cpp
+++ b/tests/error_codes_test.cpp
@@ -139,7 +139,7 @@ TEST(ErrorCodesTest, GetErrorMessageUnknownCode)
     EXPECT_EQ(get_error_message(-999), "Unknown error");
     EXPECT_EQ(get_error_message(-1000), "Unknown error");
     EXPECT_EQ(get_error_message(999), "Unknown error");
-    EXPECT_EQ(get_error_message(-50), "Unknown error");
+    EXPECT_EQ(get_error_message(-49), "Unknown error");
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Reassign DI error codes from -100~-105 to -50~-55 (common errors sub-range)
- Reference centralized registry via constexpr aliases (preserves `di_error_codes::` namespace)
- Add `static_assert` range validation and error messages for DI codes

## Related Issues
Closes #633

## Files Changed
| File | Change |
|------|--------|
| `include/kcenon/common/error/error_codes.h` | Add DI sub-range (-50 to -55), static_assert, error messages |
| `include/kcenon/common/di/service_container_interface.h` | Reference centralized codes via constexpr aliases |

## Test Plan
- [ ] `service_container_test` passes with new code values
- [ ] All 6 downstream systems compile (namespace name preserved)
- [ ] Grep confirms no raw -100 to -105 literals in DI context