### PR TITLE
docs(release): document automated portfile SHA512 sync flow

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -114,6 +114,64 @@ gh release create v0.2.0 \
   --generate-notes
 ```
 
+### 7. vcpkg Registry Sync (Automated)
+
+Publishing a GitHub Release triggers automatic propagation of the new version to
+`kcenon/vcpkg-registry`. No manual hash editing is required.
+
+| Step | Workflow | Source |
+|------|----------|--------|
+| Trigger on `release: published` | `on-release-sync-registry.yml` | `.github/workflows/on-release-sync-registry.yml` |
+| Compute SHA512, update port, open PR | `sync-vcpkg-registry.yml` (reusable) | `.github/workflows/sync-vcpkg-registry.yml` |
+
+What the reusable workflow does:
+
+1. Downloads the release tarball from `https://github.com/kcenon/common_system/archive/refs/tags/vX.Y.Z.tar.gz`
+2. Computes SHA512 via `sha512sum`
+3. Updates `vcpkg-ports/kcenon-common-system/portfile.cmake` with the new hash and
+   `vcpkg-ports/kcenon-common-system/vcpkg.json` with the new version
+4. Verifies the port installs via `vcpkg install` using overlay-ports (dry-run gate)
+5. Opens an auto-generated PR against `kcenon/vcpkg-registry` with the updated
+   port files and `versions/k-/kcenon-common-system.json` / `versions/baseline.json`
+   entries
+
+**Prerequisites (one-time setup):**
+
+- `VCPKG_REGISTRY_PAT` organization secret — PAT with write access to `kcenon/vcpkg-registry`
+- `vcpkg-ports/kcenon-common-system/portfile.cmake` must keep `REF "v${VERSION}"`
+  so the sync workflow does not need to patch the tag pattern
+
+**Verifying a release sync:**
+
+```bash
+# After `gh release create`, check that the sync workflow succeeded
+gh run list --repo kcenon/common_system \
+  --workflow on-release-sync-registry.yml --limit 3
+
+# Check that a PR was opened on the registry
+gh pr list --repo kcenon/vcpkg-registry --search "kcenon-common-system v0.2.0"
+```
+
+If the sync workflow fails, re-run it from the Actions tab — it is idempotent
+and will overwrite the in-flight `auto/kcenon-common-system-<version>` branch.
+
+### Reused by Downstream Ecosystem Repos
+
+The `sync-vcpkg-registry.yml` workflow is reusable. Ecosystem repositories
+(e.g. `thread_system`, `logger_system`) invoke it by adding their own
+`on-release-sync-registry.yml` that calls:
+
+```yaml
+uses: kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml@main
+with:
+  port-name: kcenon-<system-name>
+  version: ${{ github.event.release.tag_name }}
+secrets:
+  REGISTRY_PAT: ${{ secrets.VCPKG_REGISTRY_PAT }}
+```
+
+This keeps the SHA512 automation logic in one place for the whole ecosystem.
+
 ## Downstream Dependency Pinning
 
 Ecosystem projects should reference specific tags instead of `main`:


### PR DESCRIPTION
## What

Document the existing vcpkg-registry sync automation in `docs/RELEASING.md`.
The SHA512 automation requested by #643 is already implemented in
`.github/workflows/sync-vcpkg-registry.yml` and
`.github/workflows/on-release-sync-registry.yml`, but the release process
document did not describe this flow, leaving release engineers unaware that
hashes update automatically.

Adds a new \"vcpkg Registry Sync (Automated)\" section to \`docs/RELEASING.md\`
covering:

- Which workflow is triggered on \`release: published\`
- What the reusable sync workflow does (SHA512 compute, portfile update, dry-run verify, auto-PR)
- Prerequisites (\`VCPKG_REGISTRY_PAT\` secret)
- Verification commands (\`gh run list\`, \`gh pr list\`)
- How downstream ecosystem repos reuse this workflow

## Why

Closes #643.

The original issue asked to \"automate SHA512 hash update\" so releases don't
require manual editing. That automation already exists end-to-end:

- \`sync-vcpkg-registry.yml\` downloads the release tarball, computes SHA512,
  patches \`portfile.cmake\`, verifies via \`vcpkg install --overlay-ports\`,
  and opens a PR against \`kcenon/vcpkg-registry\`
- \`on-release-sync-registry.yml\` wires the above to \`release: published\`

The remaining Acceptance Criteria from the issue:

- [x] Release workflow computes SHA512 automatically — already implemented
- [x] Auto-generated PR in \`kcenon/vcpkg-registry\` updates REF and SHA512 — already implemented
- [x] Manual-hash instructions removed from release notes template — \`release-template.yml\` and \`release.yml\` contain no manual-hash steps
- [x] Documented release flow — **this PR**

## Where

- \`docs/RELEASING.md\` — added Section 7 (\"vcpkg Registry Sync (Automated)\") and a \"Reused by Downstream Ecosystem Repos\" subsection

## How

### Testing

No code paths changed; this is documentation only.

- [x] Markdown renders cleanly
- [x] Cross-references to \`.github/workflows/sync-vcpkg-registry.yml\` and \`.github/workflows/on-release-sync-registry.yml\` verified to exist
- [x] Reusable workflow invocation snippet matches the \`workflow_call\` inputs in \`sync-vcpkg-registry.yml\`

### Breaking Changes

None.