### PR TITLE
docs(readme): link C++20 Modules guide from content section

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ int main() {
 }
 ```
 
+> For the full dual-build strategy, compiler/CMake matrix, and fallback behavior,
+> see the [C++20 Modules Guide](docs/guides/CXX20_MODULES.md).
+
 ---
 
 ## Architecture


### PR DESCRIPTION
## What

Adds a direct reference from the README "C++20 Modules" usage section to the
existing [`docs/guides/CXX20_MODULES.md`](docs/guides/CXX20_MODULES.md) guide.

## Why

Closes #644.

The guide file itself already exists with full dual-build strategy, compiler matrix,
and fallback behavior. The README reference table at the bottom of the file also
links it. However, a reader looking at the inline C++20 Modules usage example in
the main content had no prompt to explore the full guide.

This PR adds a 2-line blockquote pointer at the end of that section so the guide
is discoverable from where readers are most likely to look first.

### Acceptance Criteria (from #644)

- [x] Guide page exists and is referenced from README — guide already exists; this PR adds the content-section link
- [x] Matrix covers GCC 14+, Clang 16+/17+, MSVC 2022+, Apple Clang (not supported) — already covered in the guide's Compiler and CMake Matrix section
- [x] Fallback behaviour explained — already covered in the guide's "Fallback Behavior" section

## Where

- \`README.md\` — C++20 Modules section (+3 lines)

## How

### Testing

No code paths changed; this is documentation only.

- [x] Link target (\`docs/guides/CXX20_MODULES.md\`) verified to exist
- [x] Markdown renders cleanly

### Breaking Changes

None.