### PR TITLE
docs(ecosystem): document version pins in ECOSYSTEM_OVERVIEW.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,10 @@ graph TD
 > [network_system](https://github.com/kcenon/network_system) — Tier 4: Uses IExecutor, Result&lt;T&gt;
 > [pacs_system](https://github.com/kcenon/pacs_system) — Tier 5: Full ecosystem consumer
 
+### Ecosystem Version Baseline
+
+Downstream consumers should pin against a known-good set of port versions. The current baseline is published in [`docs/ECOSYSTEM_OVERVIEW.md#versions`](docs/ECOSYSTEM_OVERVIEW.md#versions) with a reproducible `vcpkg-configuration.json` snippet.
+
 ### Ecosystem CI Verification
 
 The [Ecosystem vcpkg Integration](https://github.com/kcenon/common_system/actions/workflows/ecosystem-vcpkg-integration.yml) workflow validates that all 8 ecosystem ports install and build correctly as a consumer would experience them. It tests each port in bottom-up dependency order (Layer 0 through Layer 7) on Ubuntu and macOS, running on every PR that touches vcpkg ports and nightly at 03:00 UTC.

--- a/docs/ECOSYSTEM_OVERVIEW.md
+++ b/docs/ECOSYSTEM_OVERVIEW.md
@@ -37,3 +37,85 @@ common_system (Foundation — interfaces, patterns, utilities)
 | database_system | https://kcenon.github.io/database_system/ | https://github.com/kcenon/database_system |
 | network_system | https://kcenon.github.io/network_system/ | https://github.com/kcenon/network_system |
 | pacs_system | https://kcenon.github.io/pacs_system/ | https://github.com/kcenon/pacs_system |
+
+## Versions
+
+Known-good baseline for the kcenon ecosystem as published through the [`kcenon/vcpkg-registry`](https://github.com/kcenon/vcpkg-registry) overlay. Downstream consumers should lock to this baseline (see [Reproducing the ecosystem baseline](#reproducing-the-ecosystem-baseline) below) to avoid mixing versions that were not tested together.
+
+### Version matrix
+
+| Tier | vcpkg port | Current version | Depends on (kcenon) |
+|------|-----------|-----------------|---------------------|
+| 0 | `kcenon-common-system` | `0.2.0` | — |
+| 1 | `kcenon-thread-system` | `0.3.2` | `kcenon-common-system` |
+| 1 | `kcenon-container-system` | `0.1.0` | `kcenon-common-system` |
+| 2 | `kcenon-logger-system` | `0.1.3` | `kcenon-common-system` |
+| 3 | `kcenon-database-system` | `0.1.1` | `kcenon-common-system` |
+| 3 | `kcenon-monitoring-system` | `0.1.0` | `kcenon-common-system`, `kcenon-thread-system` |
+| 4 | `kcenon-network-system` | `0.1.1` | `kcenon-common-system`, `kcenon-thread-system` |
+| 5 | `kcenon-pacs-system` | `0.1.0` | `kcenon-common-system`, `kcenon-container-system`, `kcenon-logger-system`, `kcenon-network-system`, `kcenon-thread-system` |
+
+Tier classification follows `docs/ARCHITECTURE.md` (Tier 0 Foundation → Tier 5 Application). Tiers 0–2 are the stable core that downstream ecosystem components pin to; tiers 3–5 are higher-level systems that advance independently.
+
+### Baseline SHA
+
+Pin the overlay registry to commit [`b3fe244d03`](https://github.com/kcenon/vcpkg-registry/commit/b3fe244d03) (2026-04-10) for the version set above. Newer SHAs may bump port versions — audit the delta before advancing.
+
+The authoritative version table is [`versions/baseline.json`](https://github.com/kcenon/vcpkg-registry/blob/main/versions/baseline.json) in the registry; the table above is a human-readable snapshot that is refreshed when the registry advances.
+
+### Reproducing the ecosystem baseline
+
+Add the registry overlay and pin it in your `vcpkg-configuration.json`:
+
+```json
+{
+  "default-registry": {
+    "kind": "git",
+    "repository": "https://github.com/microsoft/vcpkg",
+    "baseline": "<your chosen vcpkg baseline>"
+  },
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/kcenon/vcpkg-registry",
+      "baseline": "b3fe244d03",
+      "packages": [
+        "kcenon-common-system",
+        "kcenon-thread-system",
+        "kcenon-container-system",
+        "kcenon-logger-system",
+        "kcenon-monitoring-system",
+        "kcenon-database-system",
+        "kcenon-network-system",
+        "kcenon-pacs-system"
+      ]
+    }
+  ]
+}
+```
+
+Then depend on the ports you need from `vcpkg.json`:
+
+```json
+{
+  "name": "my-app",
+  "version": "0.1.0",
+  "dependencies": [
+    "kcenon-common-system",
+    "kcenon-logger-system"
+  ]
+}
+```
+
+Vcpkg will resolve the full transitive dependency closure using the pinned baseline — you do not need to list `kcenon-thread-system` or other transitive deps by hand.
+
+### How versions advance
+
+New port versions land via the [`kcenon/vcpkg-registry`](https://github.com/kcenon/vcpkg-registry) repository. The source of truth for version bumps is:
+
+- Each upstream repository's `release.yml` workflow — builds and validates the release artifact.
+- The registry's `sync-vcpkg-registry.yml` workflow — publishes the new version, updates `versions/baseline.json`, and advances the overlay registry HEAD.
+
+Consumers who have pinned a baseline SHA will not pick up new versions until they explicitly advance the baseline in their `vcpkg-configuration.json`. Until then, the ecosystem composition above is reproducible.
+
+Part of [common_system#646](https://github.com/kcenon/common_system/issues/646) — Ecosystem-wide vcpkg distribution readiness EPIC.


### PR DESCRIPTION
## What

Adds a Versions section to `docs/ECOSYSTEM_OVERVIEW.md` documenting all 8 kcenon vcpkg port versions, the overlay registry baseline SHA, a reproducible `vcpkg-configuration.json` snippet, and a policy section on how versions advance. Links the new section from README.

### Change type

- [x] Documentation

## Why

Closes #652

- EPIC [#646](https://github.com/kcenon/common_system/issues/646) acceptance criterion "Version pins documented in ecosystem manifest" — currently unmet.
- Downstream consumers cannot reproduce a known-good ecosystem composition without manually crawling each `vcpkg.json`.
- Pairs with the Ecosystem vcpkg Integration workflow so consumers know what the workflow tested against.

## Where

| Path | Change |
|------|--------|
| `docs/ECOSYSTEM_OVERVIEW.md` | New Versions section: matrix, baseline SHA, reproducible snippet, advance policy |
| `README.md` | New Ecosystem Version Baseline subsection pointing to the Versions anchor |

## How

### Data sources

Version table was harvested live from `kcenon/vcpkg-registry` (ports/*/vcpkg.json and versions/baseline.json). Tier classification is taken from `docs/ARCHITECTURE.md`.

### Covered ports (Tier 0–5)

- Tier 0: `kcenon-common-system` 0.2.0
- Tier 1: `kcenon-thread-system` 0.3.2, `kcenon-container-system` 0.1.0
- Tier 2: `kcenon-logger-system` 0.1.3
- Tier 3: `kcenon-database-system` 0.1.1, `kcenon-monitoring-system` 0.1.0
- Tier 4: `kcenon-network-system` 0.1.1
- Tier 5: `kcenon-pacs-system` 0.1.0

Registry baseline: `b3fe244d03` (2026-04-10).

### Breaking changes

None.

### Test plan

Docs-only. Anchor integrity validated locally. The reproducible `vcpkg-configuration.json` snippet is a copy-paste config; integration consumers can validate by running `vcpkg install` against the listed ports.

## Checklist

- [x] Version table covers all Tier-0/1/2 systems (and 3–5 for completeness)
- [x] Baseline SHA from vcpkg-registry referenced
- [x] Reproducible `vcpkg-configuration.json` snippet included
- [x] README links to the version manifest
- [x] `How versions advance` subsection points to the source-of-truth workflows
- [x] Related issues linked (`Closes #652`, `Part of #646`)