### PR TITLE
docs(readme): link kcenon-system-layout standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ include/kcenon/common/
 
 [Complete Architecture Guide](docs/ARCHITECTURE.md)
 
+### Layout Standard
+
+The kcenon ecosystem follows a canonical directory, build-system, and test-infrastructure layout defined in [kcenon-system-layout.md](docs/kcenon-system-layout.md). This standard governs all eight ecosystem systems and is owned by `common_system` as the foundation tier.
+
 ---
 
 ## Core Concepts


### PR DESCRIPTION
Closes #662
Part of #656

## Summary

Add a short Layout Standard subsection under the Architecture section
that links to `docs/kcenon-system-layout.md`, making the ecosystem-wide
layout standard discoverable from the project entry point.

## Why

A standard nobody reads is not a standard. The README is the entry point;
one paragraph plus link is enough to make the document discoverable.

## Changes

- Added one new `### Layout Standard` subsection (4 lines) under `## Architecture`
- One short paragraph + link to `docs/kcenon-system-layout.md`
- No other README structural changes

## Acceptance Criteria

- [x] README links to the standard
- [x] Section is no more than one short paragraph
- [x] No other README structural changes in this PR

## Test Plan

- Documentation-only change; no build/runtime impact
- Verify the rendered link resolves to `docs/kcenon-system-layout.md` on GitHub
- TOC unchanged because the new heading is `###` and the TOC only lists `##` sections