### PR TITLE
docs(layout): document cmake/template/ exception (v1.0 -> v1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- Standard amendment v1.0 → v1.1: document `cmake/template/` exception for the layout-standard owner ([#671](https://github.com/kcenon/common_system/issues/671))
+
 ## [1.0.0] - 2026-04-13
 
 ### Added

--- a/docs/kcenon-system-layout.md
+++ b/docs/kcenon-system-layout.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Version** | 1.0 |
+| **Version** | 1.1 |
 | **Status** | Active |
 | **Scope** | All 8 systems in the kcenon ecosystem |
 | **Owner** | common_system (this repository) |
@@ -237,6 +237,19 @@ deferred per [kcenon/common_system#657](https://github.com/kcenon/common_system/
 Non-Goals. New tests added to `pacs_system` SHOULD still prefer GTest unless a strong
 reason exists; review-time decision.
 
+### common_system: cmake/template/ sub-path
+
+`common_system` owns and vends the reusable CMake template ([#659](https://github.com/kcenon/common_system/issues/659)).
+Its canonical modules reside under `cmake/template/` rather than directly under `cmake/`,
+allowing the template to carry its own `VERSION` file and be copied verbatim by
+downstream systems. The root `CMakeLists.txt` adds `cmake/template` to
+`CMAKE_MODULE_PATH` so all `include(options)`, `include(compiler)`, etc. calls
+resolve to `cmake/template/<name>.cmake`. This layout is functionally equivalent
+to the canonical `cmake/<name>.cmake` layout and is a documented owner exception.
+
+All other systems MUST place their (copied) modules under `cmake/` directly, not
+under `cmake/template/`.
+
 ### Per-system deviations during migration
 
 While a system is mid-migration, it MAY transiently violate parts of this standard. The
@@ -262,7 +275,7 @@ This standard follows SemVer:
   Adoption is non-blocking for existing systems until their next migration phase.
 - **PATCH** — clarifications, typo fixes, non-normative wording.
 
-The current version is **v1.0**.
+The current version is **v1.1**.
 
 ## Discovery
 


### PR DESCRIPTION
## What

### Summary

Amend `docs/kcenon-system-layout.md` to permit `cmake/template/` sub-path as a documented owner exception for `common_system`. Bumps standard version v1.0 → v1.1 (additive convention, SemVer MINOR).

### Change Type

- [x] Documentation

### Affected Files

| File | Change |
|------|--------|
| `docs/kcenon-system-layout.md` | New Exceptions entry, version header v1.0 → v1.1, Versioning section bump |
| `CHANGELOG.md` | New entry under Unreleased / Documentation |

## Why

### Problem Solved

The Phase 7 audit (#661) flagged DEV-01: `common_system`'s cmake modules live under `cmake/template/`, technically deviating from the standard's `cmake/*.cmake` rule. The structural reason is intentional — `common_system` is the template owner and namespaces canonical modules under `template/` so they can be version-tracked and copied verbatim by downstream systems. Without this Exceptions entry, `common_system` silently violates its own standard.

### Related Issues

- Closes #671 (SA-01 standard amendment)
- Relates to #661 (audit that surfaced DEV-01)
- Part of #656 (Sub-EPIC: Phase 0+7)
- Part of #657 (Master EPIC: ecosystem-wide standardization)

### Why MINOR (not PATCH)

This is an additive convention — it introduces a new permitted layout for one system without removing or weakening any existing rule. SemVer treats additive convention changes as MINOR.

## How

### Implementation Highlights

1. **Exceptions section** in `docs/kcenon-system-layout.md` now lists "common_system: `cmake/template/` sub-path" alongside the existing pacs_system Catch2 exception.
2. **Version header** in the document table updated from `1.0` to `1.1`.
3. **Versioning section** updated: "The current version is **v1.1**."
4. **Other systems' obligation preserved**: the Exceptions entry explicitly states "All other systems MUST place their (copied) modules under `cmake/` directly, not under `cmake/template/`."
5. **CHANGELOG** entry under Unreleased / Documentation, linking back to this issue.

### Test Plan

This is a documentation-only change.

- [x] Standard Exceptions section now lists `cmake/template/` for common_system
- [x] Version header updated v1.0 → v1.1
- [x] CHANGELOG entry under Unreleased / Documentation
- [x] Other systems' obligation explicitly preserved
- [x] No code, build system, or test changes

### Breaking Changes

None.

### Rollback Plan

Single-PR revert restores standard v1.0. The audit (#661) remains valid; the deviation simply returns to "undocumented".

## References

- Audit report: kcenon/common_system#661 (audit comment thread)
- Reference standard: [`docs/kcenon-system-layout.md`](https://github.com/kcenon/common_system/blob/develop/docs/kcenon-system-layout.md)

Closes #671.
