### PR TITLE
chore(release): verify SHA512 against actual archive (Part of #674)

### DIFF
--- a/.github/workflows/sync-vcpkg-registry.yml
+++ b/.github/workflows/sync-vcpkg-registry.yml
@@ -103,6 +103,44 @@ jobs:
         echo "SHA512: ${SHA512}"
         rm -f /tmp/source.tar.gz
 
+    - name: Verify SHA512 against actual GitHub archive
+      env:
+        VERSION: ${{ steps.meta.outputs.version }}
+        REPO: ${{ steps.meta.outputs.repo }}
+        NEW_SHA: ${{ steps.sha.outputs.sha512 }}
+      run: |
+        # Re-download the archive from GitHub and recompute SHA512 to guard
+        # against any drift between the value the workflow is about to write
+        # to portfile.cmake and the bytes a vcpkg consumer will actually fetch.
+        # See kcenon/common_system#675 (parent EPIC #674) and microsoft/vcpkg#51511.
+        set -euo pipefail
+        TAG="v${VERSION}"
+        ARCHIVE_URL="https://github.com/${REPO}/archive/refs/tags/${TAG}.tar.gz"
+        VERIFY_FILE="/tmp/verify-archive.tar.gz"
+
+        echo "Re-fetching ${ARCHIVE_URL} for independent verification..."
+        # Use --fail so curl returns non-zero on HTTP errors; download to a
+        # file (rather than piping into sha512sum) so a fetch failure cannot
+        # silently produce the empty-input hash cf83e1357eefb8bdf...
+        if ! curl -fsSL --retry 3 --retry-delay 2 -o "${VERIFY_FILE}" "${ARCHIVE_URL}"; then
+          echo "::error::Failed to download release archive for verification: ${ARCHIVE_URL}"
+          exit 1
+        fi
+
+        ACTUAL_SHA=$(sha512sum "${VERIFY_FILE}" | awk '{print $1}')
+        rm -f "${VERIFY_FILE}"
+
+        if [[ "${NEW_SHA}" != "${ACTUAL_SHA}" ]]; then
+          echo "::error::SHA512 mismatch detected for ${TAG}"
+          echo "::error::Workflow computed: ${NEW_SHA}"
+          echo "::error::GitHub archive:    ${ACTUAL_SHA}"
+          echo "::error::Refusing to commit a portfile that would not install."
+          exit 1
+        fi
+
+        echo "SHA512 verified against ${ARCHIVE_URL}"
+        echo "  ${ACTUAL_SHA}"
+
     - name: Update portfile.cmake with new SHA512 and REF
       env:
         PORT_NAME: ${{ inputs.port-name }}


### PR DESCRIPTION
Closes #675

Part of #674.

## What

Adds an independent SHA512 verification step to `.github/workflows/sync-vcpkg-registry.yml` that re-downloads the release archive from GitHub and compares the recomputed digest against the value the workflow is about to write to `portfile.cmake`. On mismatch, the step prints both SHAs and exits 1 before any registry commit happens.

## Why

Detected via [microsoft/vcpkg#51511](https://github.com/microsoft/vcpkg/issues/51511) and [kcenon/vcpkg-registry#87](https://github.com/kcenon/vcpkg-registry/issues/87) - every kcenon port shipped a mismatched SHA512 because the release workflow never compared its computed value against the actual archive. Cold-cache vcpkg consumers (new CI runners, fresh users) hit 100% install failure when the SHA in `vcpkg-registry/ports/kcenon-common-system/portfile.cmake` does not match the bytes at `https://github.com/kcenon/common_system/archive/refs/tags/v<version>.tar.gz`. This PR closes the detection gap for `common_system`.

## Where

| File | Change |
|------|--------|
| `.github/workflows/sync-vcpkg-registry.yml` | New step `Verify SHA512 against actual GitHub archive` inserted between the existing `sha` step (id: `sha`) and `Update portfile.cmake with new SHA512 and REF` |

### Audit summary (other workflows considered)

| Workflow | Touches portfile SHA? | Action |
|----------|----------------------|--------|
| `sync-vcpkg-registry.yml` | Yes (computes `steps.sha.outputs.sha512`, writes to portfile) | **Hardened (this PR)** |
| `release.yml` | No (build/test/GitHub Release only) | No change needed |
| `release-template.yml` | No (reusable build/test template) | No change needed |
| `on-release-sync-registry.yml` | No (thin caller of `sync-vcpkg-registry.yml`) | Inherits hardening automatically |
| `port-sync-check.yml` | Compares git-blob SHAs for drift detection, not archive SHA512 | Out of scope |

Only `sync-vcpkg-registry.yml` actually computes a SHA512, so an inline step in that single workflow is more appropriate than extracting a composite action.

## How

The new step runs immediately after the existing `Download release archive and compute SHA512` step and before `Update portfile.cmake with new SHA512 and REF`. It re-fetches the archive with `curl -fsSL --retry 3` to a file (not piped) so a 404 cannot silently produce the empty-input hash `cf83e1357eefb8bdf...`. The exit-1 error message includes both the workflow-computed SHA and the archive's actual SHA so debug logs are immediately useful.

Runtime: ~1-2s on a typical `common_system` archive (~200 KB).

## Test Plan

### How a reviewer can validate the new step fires

1. Cut a release tag (`v0.x.y`) - the existing `Sync Registry on Release` workflow triggers `sync-vcpkg-registry.yml`
2. Inspect the run log for the new step `Verify SHA512 against actual GitHub archive`. On a healthy release, the step prints:
   ```
   Re-fetching https://github.com/kcenon/common_system/archive/refs/tags/v0.x.y.tar.gz for independent verification...
   SHA512 verified against https://github.com/kcenon/common_system/archive/refs/tags/v0.x.y.tar.gz
     <128-char hex digest>
   ```

### How to simulate a mismatch

Locally executed and confirmed before push:
- **Match path** (real `v0.2.0` archive, real workflow-computed SHA): step exits 0, prints verification line.
- **Mismatch path** (real archive SHA, workflow SHA replaced with all-zero digest): step exits 1 with annotations `SHA512 mismatch detected for v0.2.0` / `Workflow computed: 000...` / `GitHub archive: ac4588...` / `Refusing to commit a portfile that would not install.`
- **Bad URL path** (nonexistent tag `v999.999.999`): `curl -fsSL` returns RC=22, the `if !` branch fires `exit 1` with `Failed to download release archive for verification: <URL>`. The download-to-file pattern (rather than a pipe) is required to make this work - piping into `sha512sum` would otherwise mask the curl failure with the empty-input hash.

YAML structure validated with `js-yaml`; step ordering confirmed (Verify is step 5 of 12, after `sha` and before portfile update).

## Breaking Changes

None. The new step is additive; on a successful release it adds ~1-2s and one log line. On a SHA mismatch (the failure mode this PR is designed to detect) it short-circuits the existing run before any vcpkg-registry commit, which is the desired behavior.