### PR TITLE
chore(release): sync Doxyfile/CLAUDE version metadata with VERSION

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,5 +87,5 @@ sanitizers, benchmarks, CVE scan, SBOM, Doxygen docs.
 - C++20 required (GCC 11+, Clang 14+, MSVC 2022+, Apple Clang 14+)
 - C++20 modules experimental (CMake 3.28+, Clang 16+/GCC 14+; Apple Clang unsupported)
 - `Result<T>` is NOT thread-safe for concurrent modification (concurrent reads safe)
-- Pre-1.0 (v0.2.0): API may change between minor versions
+- v1.0.0: stable API; changes follow semantic versioning
 - Platform: Linux, macOS, Windows; UWP/Xbox excluded

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,7 +1,7 @@
 # Doxyfile for common_system
 
 PROJECT_NAME           = "Common System"
-PROJECT_NUMBER         = "0.2.0"
+PROJECT_NUMBER         = "1.0.0"
 PROJECT_BRIEF          = "Common interfaces and patterns for system integration"
 OUTPUT_DIRECTORY       = documents
 CREATE_SUBDIRS         = NO


### PR DESCRIPTION
Closes #687

## Summary
- Doxyfile `PROJECT_NUMBER` "0.2.0" -> "1.0.0" (now matches root VERSION)
- CLAUDE.md "Known Constraints": replaced stale "Pre-1.0 (v0.2.0)" line with "v1.0.0: stable API; changes follow semantic versioning"
- 3-way version metadata now agrees: Doxyfile PROJECT_NUMBER == VERSION == vcpkg.json version == 1.0.0
- Released version is unchanged; only stale metadata was corrected to agree.

## Test Plan
- Metadata-only change (no build required).
- Verified Doxyfile / VERSION / vcpkg.json all read 1.0.0.
- Verified no remaining 0.2.0 / 0.1.0 references in Doxyfile or CLAUDE.md.

## Follow-ups
Ecosystem-wide 3-way version-metadata audit of the other 7 repos remains tracked under #687:
- [ ] thread_system - Doxyfile/VERSION/vcpkg 3-way match
- [ ] logger_system - Doxyfile/VERSION/vcpkg 3-way match
- [ ] monitoring_system - Doxyfile/VERSION/vcpkg 3-way match
- [ ] container_system - Doxyfile/VERSION/vcpkg 3-way match (Doxyfile reported at 0.1.0)
- [ ] database_system - Doxyfile/VERSION/vcpkg 3-way match
- [ ] network_system - Doxyfile/VERSION/vcpkg 3-way match
- [ ] messaging_system - Doxyfile/VERSION/vcpkg 3-way match
- [ ] Add the 3-way version check to the conformance linter
