### PR TITLE
chore(ci): consolidate Doxygen workflows; mark governance SSOT (DRAFT)

### DIFF
--- a/.github/workflows/build-Doxygen.yaml
+++ b/.github/workflows/build-Doxygen.yaml
@@ -1,3 +1,7 @@
+# Thin CALLER for the canonical Doxygen workflow.
+# This file only maps repository events to the reusable workflow `doxygen.yml`
+# (the single source of truth for documentation build/deploy). Keep this file
+# trigger-only; do not add build steps here — edit `doxygen.yml` instead.
 name: Generate-Documentation
 
 on:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,3 +1,8 @@
+# SSOT: Canonical Doxygen build/deploy logic for common_system.
+# This is a REUSABLE workflow (workflow_call only) — it has no event triggers
+# of its own. The thin caller `build-Doxygen.yaml` wires repository events
+# (push/pull_request/workflow_dispatch) to this workflow. Do not duplicate the
+# build/deploy steps in the caller; keep all generation logic here.
 name: Doxygen Documentation
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+<!-- SSOT: This root CHANGELOG.md is the single source of truth for the
+     English changelog. The Korean translation lives at docs/CHANGELOG.kr.md.
+     The docs/ tree also carries a registry-tracked English copy
+     (docs/CHANGELOG.md, doc_id COM-PROJ-002) for the documentation portal;
+     this root file is canonical and the docs copy mirrors it. -->
+
+> **SSOT:** This file is the single source of truth for the English changelog.
+> **Language:** **English** | [한국어](docs/CHANGELOG.kr.md)
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,14 @@
 # Contributing to Common System
 
+<!-- SSOT: The single source of truth for contribution guidelines is
+     docs/contributing/CONTRIBUTING.md (registry doc_id COM-PROJ-017).
+     This root file is a brief quick-start redirect; keep substantive
+     contribution policy in the canonical document to avoid drift. -->
+
+> **Canonical document:** The full contribution guide is maintained at
+> [`docs/contributing/CONTRIBUTING.md`](docs/contributing/CONTRIBUTING.md)
+> (the single source of truth). This page is a brief quick-start summary.
+
 Thank you for considering contributing to Common System\! This document provides guidelines and instructions for contributors.
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ if (result.is_err()) {
 | | [Migration](docs/advanced/MIGRATION.md) | Version upgrade guide |
 | | [IExecutor Migration](docs/advanced/IEXECUTOR_MIGRATION_GUIDE.md) | Executor API migration |
 | | [Runtime Binding](docs/architecture/RUNTIME_BINDING.md) | Core design pattern |
-| **Contributing** | [Contributing](CONTRIBUTING.md) | How to contribute |
+| **Contributing** | [Contributing](docs/contributing/CONTRIBUTING.md) | How to contribute |
 | | [Error Code Guidelines](docs/guides/ERROR_CODE_GUIDELINES.md) | Error code management |
 
 ---


### PR DESCRIPTION
Closes #689

## Status: DRAFT

## Done
- **Doxygen workflows — role separation made explicit (no behavior change).** The two files were already a reusable + caller pair, not true duplicate twins:
  - `.github/workflows/doxygen.yml` — marked as the canonical REUSABLE workflow (`workflow_call` only) that owns all build/deploy logic.
  - `.github/workflows/build-Doxygen.yaml` — marked as the thin CALLER that wires repository events (push / pull_request / workflow_dispatch) to `doxygen.yml`.
  - Added header comments to both so they are not mistaken for redundant duplicates and so build steps are not copied into the caller.
- **Governance SSOT markers (root vs docs).**
  - `CONTRIBUTING.md` (root) — added an SSOT/HTML-comment marker designating `docs/contributing/CONTRIBUTING.md` (registry doc_id COM-PROJ-017, which already carries its own SSOT marker) as canonical, and a short redirect note making the root file a brief quick-start.
  - `CHANGELOG.md` (root) — added an SSOT marker (canonical English changelog; Korean translation at `docs/CHANGELOG.kr.md`; registry mirror at `docs/CHANGELOG.md` COM-PROJ-002).
  - `README.md` — repointed the Contributing entry in the documentation table to the canonical `docs/contributing/CONTRIBUTING.md`. The Quick Links entry intentionally keeps linking to the root `CONTRIBUTING.md`, which is itself a brief quick-start that redirects to the canonical doc.

## Notes
- **doc-audit workflows were NOT consolidated — they are role-separated, not duplicates.** `doc-audit.yml` is a PR gate (single repo, quick mode, comments on PRs); `doc-audit-ecosystem.yml` is a scheduled weekly scan across 8 ecosystem repos (matrix, full mode, artifact upload). Merging them would conflate two distinct purposes, so they are left unchanged.
- **No file deletions.** There is no exact root-vs-docs duplicate of `CHANGELOG`/`CONTRIBUTING` to delete:
  - `docs/CONTRIBUTING.md` does not exist; the canonical contributing doc lives at `docs/contributing/CONTRIBUTING.md` (24.8 KB, full) vs the root quick-start (3.6 KB).
  - `docs/CHANGELOG.md` is a separate registry-tracked English copy (COM-PROJ-002), and `docs/CHANGELOG.kr.md` is the Korean translation — both already carry SSOT markers; only the root files lacked markers, which this PR adds.
  - `CODE_OF_CONDUCT.md` exists only at root (no docs/ duplicate) — left unchanged.
- Changes are documentation/comment-only; docs-only PRs do not trigger the build CI.
