### PR TITLE
fix(error): classify positive codes as Invalid not Success

### DIFF
--- a/include/kcenon/common/error/error_codes.h
+++ b/include/kcenon/common/error/error_codes.h
@@ -458,7 +458,10 @@ inline std::string_view get_error_message(int code) {
  * @return Category name
  */
 inline std::string_view get_category_name(int code) {
-    if (code >= 0) return "Success";
+    if (code == codes::common_errors::success) return "Success";
+    // Positive codes are out of range: this registry assigns categories only
+    // to negative error codes, so any code > 0 is not a valid error code.
+    if (code > 0) return "Invalid";
     if (code > static_cast<int>(category::thread_system)) return "Common";
     if (code > static_cast<int>(category::logger_system)) return "ThreadSystem";
     if (code > static_cast<int>(category::monitoring_system)) return "LoggerSystem";

--- a/tests/error_codes_test.cpp
+++ b/tests/error_codes_test.cpp
@@ -148,9 +148,29 @@ TEST(ErrorCodesTest, GetErrorMessageUnknownCode)
 
 TEST(ErrorCodesTest, GetCategoryNameSuccess)
 {
+    // Only the success sentinel (0) is classified as "Success".
+    EXPECT_EQ(get_category_name(codes::common_errors::success), "Success");
     EXPECT_EQ(get_category_name(0), "Success");
-    EXPECT_EQ(get_category_name(1), "Success");
-    EXPECT_EQ(get_category_name(100), "Success");
+}
+
+// Regression test for issue #698: positive codes were misclassified as
+// "Success", masking real errors. The category registry only spans negative
+// codes, so any positive value must be reported as "Invalid", never "Success".
+TEST(ErrorCodesTest, GetCategoryNamePositiveCodesAreInvalid)
+{
+    // monitoring-style positive code (monitoring emits 1000-4999)
+    EXPECT_NE(get_category_name(1000), "Success");
+    EXPECT_EQ(get_category_name(1000), "Invalid");
+
+    // container-style positive code (container static_cast into shared code)
+    EXPECT_NE(get_category_name(100), "Success");
+    EXPECT_EQ(get_category_name(100), "Invalid");
+
+    EXPECT_EQ(get_category_name(1), "Invalid");
+
+    // The negative ladder must remain untouched by the positive-code fix.
+    EXPECT_EQ(get_category_name(codes::thread_system::pool_full), "ThreadSystem");
+    EXPECT_EQ(get_category_name(-100), "ThreadSystem");
 }
 
 TEST(ErrorCodesTest, GetCategoryNameCommon)


### PR DESCRIPTION
## What

Fix `get_category_name` so positive error codes are no longer reported as category "Success".

## Why

common's classifier returned "Success" for any `code >= 0`. Two downstream systems emit POSITIVE codes into the shared `error_info.code` (monitoring 1000-4999 via `to_common_error()`; container 100+), so genuine failures crossing the common boundary were silently classified as success. This is a live correctness defect and must be fixed before common's v1.0.0 tag freezes the error contract under SemVer.

## How

- `get_category_name`: only `codes::common_errors::success` (0) maps to "Success"; `code > 0` maps to "Invalid" (out-of-range of the negative registry); `code < 0` flows through the existing category ranges unchanged.
- Corrected the pre-existing `GetCategoryNameSuccess` test (it asserted the buggy `get_category_name(1) == "Success"` / `(100) == "Success"`).
- Added `GetCategoryNamePositiveCodesAreInvalid` regression test (monitoring 1000, container 100, and a negative thread code still maps to "ThreadSystem").
- Local: `common_error_codes_test` 21/21 pass (Google Test 1.17.0).

## Where

- `include/kcenon/common/error/error_codes.h` (`get_category_name`)
- `tests/error_codes_test.cpp`

`get_error_message` left untouched: its `default: return "Unknown error"` already handles positive/unregistered codes acceptably.

Closes #698
Part of kcenon/common_system#684
