### PR TITLE
feat(error): gate error-code registry SSOT (header <-> module)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Run conformance linter
         run: python3 scripts/conformance_lint.py
+
+      - name: Check error-code registry SSOT (header <-> module)
+        run: python3 scripts/check_error_registry_ssot.py

--- a/scripts/check_error_registry_ssot.py
+++ b/scripts/check_error_registry_ssot.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Single-source-of-truth (SSOT) drift guard for the error-code registry.
+
+The centralized error-code registry exists in two physical forms:
+
+  1. include/kcenon/common/error/error_codes.h  -- the classic header (SSOT)
+  2. src/modules/error.cppm                      -- the C++20 module partition
+
+The module partition re-declares the entire registry inline instead of
+``#include``-ing the header (Apple Clang cannot build modules, so the header
+cannot simply be imported there yet). That duplication is a silent drift risk:
+a code added to or changed in the header but not mirrored in the ``.cppm``
+(or vice versa) diverges between module-built and header-built consumers with
+no compiler error.
+
+This script parses both registries and fails (exit 1) when they disagree:
+
+  * a ``constexpr int <name> = <expr>;`` present in one file but not the other
+    (within the same namespace path), or
+  * the same name resolving to a different integer value, or
+  * a ``category`` enum entry present in one file but not the other, or with a
+    different value.
+
+It exits 0 when the two registries are identical, 1 on any divergence, and 2 on
+a usage / IO error. Only the Python 3 standard library is used so the script
+runs anywhere ``python3`` is available, with no build toolchain required.
+
+The header is the authoritative SSOT: when reconciling, edit the ``.cppm`` to
+match ``error_codes.h``, never the reverse.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Locations (resolved relative to the repository root, which is the parent of
+# the scripts/ directory this file lives in).
+# --------------------------------------------------------------------------- #
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HEADER_PATH = REPO_ROOT / "include" / "kcenon" / "common" / "error" / "error_codes.h"
+MODULE_PATH = REPO_ROOT / "src" / "modules" / "error.cppm"
+
+# --------------------------------------------------------------------------- #
+# Parsing
+# --------------------------------------------------------------------------- #
+# A namespace opener. Handles both the classic header form ("namespace error {")
+# and the module form that uses a qualified name on one line
+# ("export namespace kcenon::common::error {"). The captured group is the
+# "::"-joined namespace path opened by this single brace.
+_NS_OPEN = re.compile(r"^\s*(?:export\s+)?namespace\s+([A-Za-z_][\w:]*)\s*\{")
+# A constexpr int declaration: "constexpr int <name> = <expr>;".
+_CONSTEXPR_INT = re.compile(r"^\s*constexpr\s+int\s+([A-Za-z_]\w*)\s*=\s*([^;]+);")
+# A category enum entry: "name = value," inside the enum body.
+_ENUM_ENTRY = re.compile(r"^\s*([A-Za-z_]\w*)\s*=\s*(-?\d+)\s*,?\s*$")
+
+# Outer namespace segments that wrap the whole registry. Stripped from every
+# dotted key so the two files compare on equal footing regardless of whether
+# the wrapper is spelled as nested "namespace kcenon::common { namespace error"
+# blocks (header) or a single "namespace kcenon::common::error" (module).
+_OUTER_NS = ("kcenon", "common", "error")
+
+
+def _strip_comment(line: str) -> str:
+    """Remove a trailing // comment (registry files use no // inside exprs)."""
+    idx = line.find("//")
+    return line[:idx] if idx != -1 else line
+
+
+def _evaluate(expr: str, namespace_consts: dict, category_values: dict) -> int:
+    """Resolve an integer constexpr expression.
+
+    Handles the forms that appear in the registry:
+      * an integer literal,
+      * ``static_cast<int>(category::X)`` referencing a category enumerator,
+      * ``base - N`` / ``base + N`` where ``base`` is a constant already seen
+        in the current namespace and N is an integer literal.
+    Raises ValueError if it cannot resolve.
+    """
+    expr = expr.strip()
+
+    # static_cast<int>(category::thread_system) -> the category enum value.
+    m = re.match(r"static_cast<int>\(category::([A-Za-z_]\w*)\)", expr)
+    if m:
+        name = m.group(1)
+        if name not in category_values:
+            raise ValueError(f"unknown category enumerator: {name}")
+        return category_values[name]
+
+    # Plain integer literal.
+    if re.fullmatch(r"-?\d+", expr):
+        return int(expr)
+
+    # "<name> - <int>" or "<name> + <int>" referencing a same-namespace const.
+    m = re.fullmatch(r"([A-Za-z_]\w*)\s*([+-])\s*(\d+)", expr)
+    if m:
+        base_name, op, num = m.group(1), m.group(2), int(m.group(3))
+        if base_name not in namespace_consts:
+            raise ValueError(f"unresolved base reference: {base_name}")
+        base_val = namespace_consts[base_name]
+        return base_val + num if op == "+" else base_val - num
+
+    raise ValueError(f"unparseable expression: {expr!r}")
+
+
+def _normalize_key(segments: list, name: str) -> str:
+    """Build the comparison key, stripping the outer wrapper namespace.
+
+    ``segments`` is the active namespace path (e.g. ["kcenon", "common",
+    "error", "codes", "thread_system"]). The leading ``_OUTER_NS`` wrapper is
+    removed so the header and module spellings collapse to the same key
+    (e.g. "codes.thread_system.pool_full").
+    """
+    path = list(segments)
+    outer = list(_OUTER_NS)
+    if path[: len(outer)] == outer:
+        path = path[len(outer):]
+    return ".".join(path + [name]) if path else name
+
+
+def parse_registry(path: Path) -> dict:
+    """Parse a registry file into a flat {normalized.name: value} map.
+
+    Both ``constexpr int`` declarations and ``category`` enum entries are
+    collected, keyed by their namespace path with the outer wrapper stripped.
+    """
+    if not path.is_file():
+        raise FileNotFoundError(f"registry file not found: {path}")
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    results: dict = {}
+    # Namespace frames: each entry is (segments_list, brace_depth_at_open).
+    # A single opener line may declare several "::"-joined segments but still
+    # opens exactly one brace, so the frame records all its segments together.
+    ns_frames: list = []
+    # Per-frame constant table for resolving "base - N" expressions, parallel
+    # to ns_frames so it is popped together with its namespace.
+    consts_frames: list = []
+    # category enum values, shared across the file for static_cast resolution.
+    category_values: dict = {}
+
+    brace_depth = 0
+    in_enum = False
+    enum_open_depth = 0
+
+    def active_segments() -> list:
+        segs: list = []
+        for frame_segs, _ in ns_frames:
+            segs.extend(frame_segs)
+        return segs
+
+    def active_consts() -> dict:
+        return consts_frames[-1] if consts_frames else {}
+
+    for raw in lines:
+        line = _strip_comment(raw)
+        opens = line.count("{")
+        closes = line.count("}")
+
+        # --- category enum body -------------------------------------------- #
+        if not in_enum and re.search(r"\benum\s+class\s+category\b", line):
+            in_enum = True
+            enum_open_depth = brace_depth
+            brace_depth += opens - closes
+            continue
+
+        if in_enum:
+            entry = _ENUM_ENTRY.match(line)
+            if entry:
+                name, val = entry.group(1), int(entry.group(2))
+                category_values[name] = val
+                results[f"category.{name}"] = val
+            brace_depth += opens - closes
+            if brace_depth <= enum_open_depth:
+                in_enum = False
+            continue
+
+        # --- namespace open ------------------------------------------------ #
+        ns = _NS_OPEN.match(line)
+        if ns:
+            segments = ns.group(1).split("::")
+            ns_frames.append((segments, brace_depth))
+            consts_frames.append({})
+            brace_depth += 1
+            continue
+
+        # --- constexpr int declaration ------------------------------------- #
+        decl = _CONSTEXPR_INT.match(line)
+        if decl:
+            name, expr = decl.group(1), decl.group(2).strip()
+            value = _evaluate(expr, active_consts(), category_values)
+            if consts_frames:
+                consts_frames[-1][name] = value
+            results[_normalize_key(active_segments(), name)] = value
+            brace_depth += opens - closes
+            continue
+
+        # --- generic brace tracking / namespace close --------------------- #
+        brace_depth += opens - closes
+        # Pop any namespace frames whose opening depth is now above the
+        # current brace depth (their closing brace was just consumed).
+        while ns_frames and brace_depth <= ns_frames[-1][1]:
+            ns_frames.pop()
+            consts_frames.pop()
+
+    return results
+
+
+# --------------------------------------------------------------------------- #
+# Comparison
+# --------------------------------------------------------------------------- #
+def diff_registries(header: dict, module: dict) -> list:
+    """Return a list of human-readable divergence messages (empty if in sync)."""
+    problems: list = []
+
+    header_keys = set(header)
+    module_keys = set(module)
+
+    for name in sorted(header_keys - module_keys):
+        problems.append(
+            f"MISSING IN .cppm : {name} = {header[name]} "
+            f"(present in error_codes.h, absent from error.cppm)"
+        )
+    for name in sorted(module_keys - header_keys):
+        problems.append(
+            f"EXTRA IN .cppm   : {name} = {module[name]} "
+            f"(present in error.cppm, absent from error_codes.h)"
+        )
+    for name in sorted(header_keys & module_keys):
+        if header[name] != module[name]:
+            problems.append(
+                f"VALUE MISMATCH   : {name} -> error_codes.h={header[name]} "
+                f"vs error.cppm={module[name]}"
+            )
+
+    return problems
+
+
+def main(argv: list) -> int:
+    try:
+        header = parse_registry(HEADER_PATH)
+        module = parse_registry(MODULE_PATH)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    # Defensive sanity check: a parser that silently extracts nothing must not
+    # masquerade as "in sync". The registry always has dozens of entries.
+    if not header or not module:
+        print(
+            "error: parsed an empty registry "
+            f"(header={len(header)}, module={len(module)}); "
+            "the parser or a source file is broken.",
+            file=sys.stderr,
+        )
+        return 2
+
+    problems = diff_registries(header, module)
+
+    if problems:
+        print("Error-code registry SSOT drift detected between:")
+        print(f"  header : {HEADER_PATH.relative_to(REPO_ROOT)}  (SSOT)")
+        print(f"  module : {MODULE_PATH.relative_to(REPO_ROOT)}")
+        print()
+        for p in problems:
+            print(f"  {p}")
+        print()
+        print(
+            "Reconcile by editing src/modules/error.cppm to match "
+            "error_codes.h (the header is the SSOT)."
+        )
+        return 1
+
+    print(
+        f"Error-code registry SSOT OK: {len(header)} entries match between "
+        "error_codes.h and error.cppm."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/modules/error.cppm
+++ b/src/modules/error.cppm
@@ -72,6 +72,14 @@ namespace common_errors {
     constexpr int network_error = -10;
     constexpr int registry_frozen = -11;
     constexpr int internal_error = -99;
+
+    // DI (dependency injection) errors (-50 to -59)
+    constexpr int di_service_not_registered = -50;
+    constexpr int di_circular_dependency = -51;
+    constexpr int di_already_registered = -52;
+    constexpr int di_factory_error = -53;
+    constexpr int di_invalid_lifetime = -54;
+    constexpr int di_scoped_from_root = -55;
 } // namespace common_errors
 
 // ============================================================================
@@ -304,6 +312,14 @@ inline std::string_view get_error_message(int code) {
         case codes::common_errors::registry_frozen: return "Registry is frozen";
         case codes::common_errors::internal_error: return "Internal error";
 
+        // DI errors
+        case codes::common_errors::di_service_not_registered: return "Service not registered in container";
+        case codes::common_errors::di_circular_dependency: return "Circular dependency detected";
+        case codes::common_errors::di_already_registered: return "Service already registered";
+        case codes::common_errors::di_factory_error: return "Factory error during instantiation";
+        case codes::common_errors::di_invalid_lifetime: return "Invalid service lifetime configuration";
+        case codes::common_errors::di_scoped_from_root: return "Scoped service resolved from root container";
+
         // thread_system errors
         case codes::thread_system::pool_full: return "Thread pool full";
         case codes::thread_system::pool_shutdown: return "Thread pool shutdown";
@@ -360,7 +376,10 @@ inline std::string_view get_error_message(int code) {
  * @return Category name
  */
 inline std::string_view get_category_name(int code) {
-    if (code >= 0) return "Success";
+    if (code == codes::common_errors::success) return "Success";
+    // Positive codes are out of range: this registry assigns categories only
+    // to negative error codes, so any code > 0 is not a valid error code.
+    if (code > 0) return "Invalid";
     if (code > static_cast<int>(category::thread_system)) return "Common";
     if (code > static_cast<int>(category::logger_system)) return "ThreadSystem";
     if (code > static_cast<int>(category::monitoring_system)) return "LoggerSystem";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -721,6 +721,27 @@ set_tests_properties(common_error_codes_test PROPERTIES
     LABELS "unit;error"
 )
 
+# Error registry contract gate (Issue #699)
+add_executable(common_error_registry_contract_test
+    error_registry_contract_test.cpp
+)
+
+target_link_libraries(common_error_registry_contract_test PRIVATE
+    kcenon::common
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+target_compile_features(common_error_registry_contract_test PRIVATE cxx_std_17)
+
+add_test(NAME common_error_registry_contract_test COMMAND common_error_registry_contract_test)
+
+set_tests_properties(common_error_registry_contract_test PROPERTIES
+    TIMEOUT 60
+    LABELS "unit;error"
+)
+
 # Source location tests (Issue #359)
 add_executable(common_source_location_test
     source_location_test.cpp
@@ -792,6 +813,7 @@ set(COMMON_TEST_TARGETS
     common_database_interface_test
     common_failure_window_test
     common_error_codes_test
+    common_error_registry_contract_test
     common_source_location_test
 )
 

--- a/tests/error_registry_contract_test.cpp
+++ b/tests/error_registry_contract_test.cpp
@@ -1,0 +1,165 @@
+/**
+ * @file error_registry_contract_test.cpp
+ * @brief Runtime contract gate for the centralized error-code registry.
+ *
+ * This test LOCKS the behavioral contract of the error-code registry so that
+ * violations cannot silently accumulate (issue #699). It complements the
+ * compile-time static_asserts in error_codes.h (which fix the reserved range
+ * bases) and the cppm<->header SSOT drift guard
+ * (scripts/check_error_registry_ssot.py).
+ *
+ * Locked invariants:
+ *   1. get_category_name(0) == "Success"; any positive code == "Invalid"
+ *      (regression lock for issue #698).
+ *   2. Each reserved system base maps to the correct category name, probed via
+ *      representative real codes from codes::.
+ *   3. The reserved ranges are mutually DISJOINT at runtime: no code value maps
+ *      to two categories, and the category:: enum bases are strictly ordered.
+ *   4. get_error_message returns "Unknown error" (not "Success") for an
+ *      unregistered positive code.
+ *
+ * @date 2026-06-13
+ */
+
+#include <gtest/gtest.h>
+#include <kcenon/common/error/error_codes.h>
+
+#include <array>
+#include <set>
+#include <string_view>
+
+using namespace kcenon::common::error;
+
+// ============================================================================
+// (1) #698 lock: success sentinel vs positive codes
+// ============================================================================
+
+TEST(ErrorRegistryContractTest, SuccessIsOnlyZero)
+{
+    EXPECT_EQ(get_category_name(0), "Success");
+    EXPECT_EQ(get_category_name(codes::common_errors::success), "Success");
+}
+
+TEST(ErrorRegistryContractTest, PositiveCodesAreInvalidNotSuccess)
+{
+    // Regression lock for issue #698: positive codes must never be reported as
+    // "Success" (which masked real errors). The registry spans negative codes
+    // only, so every positive value is "Invalid".
+    for (int code : {1, 2, 42, 100, 1000, 4999, 2147483647})
+    {
+        EXPECT_EQ(get_category_name(code), "Invalid")
+            << "positive code " << code << " must be Invalid";
+        EXPECT_NE(get_category_name(code), "Success")
+            << "positive code " << code << " must not be Success";
+    }
+}
+
+// ============================================================================
+// (2) Each reserved system base maps to the correct category name, probed via
+//     representative real codes from codes::.
+// ============================================================================
+
+TEST(ErrorRegistryContractTest, ReservedBasesMapToCorrectCategory)
+{
+    // Probe the exact base values.
+    EXPECT_EQ(get_category_name(-100), "ThreadSystem");
+    EXPECT_EQ(get_category_name(-200), "LoggerSystem");
+    EXPECT_EQ(get_category_name(-300), "MonitoringSystem");
+    EXPECT_EQ(get_category_name(-400), "ContainerSystem");
+    EXPECT_EQ(get_category_name(-500), "DatabaseSystem");
+    EXPECT_EQ(get_category_name(-600), "NetworkSystem");
+    EXPECT_EQ(get_category_name(-700), "PACSSystem");
+
+    // Probe via representative real codes from each system namespace; each must
+    // resolve to its own category.
+    EXPECT_EQ(get_category_name(codes::common_errors::invalid_argument), "Common");
+    EXPECT_EQ(get_category_name(codes::thread_system::pool_full), "ThreadSystem");
+    EXPECT_EQ(get_category_name(codes::logger_system::file_open_failed), "LoggerSystem");
+    EXPECT_EQ(get_category_name(codes::monitoring_system::metric_not_found), "MonitoringSystem");
+    EXPECT_EQ(get_category_name(codes::container_system::value_type_mismatch), "ContainerSystem");
+    EXPECT_EQ(get_category_name(codes::database_system::connection_failed), "DatabaseSystem");
+    EXPECT_EQ(get_category_name(codes::network_system::connection_failed), "NetworkSystem");
+    EXPECT_EQ(get_category_name(codes::pacs_system::file_not_found), "PACSSystem");
+}
+
+// ============================================================================
+// (3) Reserved ranges are mutually DISJOINT at runtime.
+// ============================================================================
+
+TEST(ErrorRegistryContractTest, CategoryEnumBasesAreStrictlyOrdered)
+{
+    // The classifier ladder in get_category_name relies on the bases being
+    // strictly descending. Lock that ordering so a reordered/duplicated enum
+    // base is caught here rather than silently misrouting codes.
+    EXPECT_GT(static_cast<int>(category::success), static_cast<int>(category::common));
+    EXPECT_GT(static_cast<int>(category::common), static_cast<int>(category::thread_system));
+    EXPECT_GT(static_cast<int>(category::thread_system), static_cast<int>(category::logger_system));
+    EXPECT_GT(static_cast<int>(category::logger_system), static_cast<int>(category::monitoring_system));
+    EXPECT_GT(static_cast<int>(category::monitoring_system), static_cast<int>(category::container_system));
+    EXPECT_GT(static_cast<int>(category::container_system), static_cast<int>(category::database_system));
+    EXPECT_GT(static_cast<int>(category::database_system), static_cast<int>(category::network_system));
+    EXPECT_GT(static_cast<int>(category::network_system), static_cast<int>(category::pacs_system));
+}
+
+TEST(ErrorRegistryContractTest, ReservedRangesAreDisjoint)
+{
+    // Every negative code in [-799, -1] must map to exactly one category, and
+    // each contiguous 100-wide block must be homogeneous. Walking every value
+    // proves no code straddles two categories (no overlap, no gap).
+    struct Block { int lo; int hi; std::string_view name; };
+    constexpr std::array<Block, 8> blocks{{
+        {-99,  -1,  "Common"},
+        {-199, -100, "ThreadSystem"},
+        {-299, -200, "LoggerSystem"},
+        {-399, -300, "MonitoringSystem"},
+        {-499, -400, "ContainerSystem"},
+        {-599, -500, "DatabaseSystem"},
+        {-699, -600, "NetworkSystem"},
+        {-799, -700, "PACSSystem"},
+    }};
+
+    for (const auto& b : blocks)
+    {
+        for (int code = b.lo; code <= b.hi; ++code)
+        {
+            EXPECT_EQ(get_category_name(code), b.name)
+                << "code " << code << " must belong to " << b.name;
+        }
+    }
+
+    // Cross-check: the set of distinct category names seen across the whole
+    // negative span equals the eight reserved categories plus the open-ended
+    // PACS tail. No code value yields two different names because the function
+    // is deterministic, but we assert the full name set to catch a collapsed
+    // or duplicated branch.
+    std::set<std::string_view> seen;
+    for (int code = -1; code >= -799; --code)
+    {
+        seen.insert(get_category_name(code));
+    }
+    const std::set<std::string_view> expected{
+        "Common", "ThreadSystem", "LoggerSystem", "MonitoringSystem",
+        "ContainerSystem", "DatabaseSystem", "NetworkSystem", "PACSSystem"};
+    EXPECT_EQ(seen, expected);
+}
+
+// ============================================================================
+// (4) Unregistered positive codes resolve to "Unknown error", never "Success".
+// ============================================================================
+
+TEST(ErrorRegistryContractTest, UnregisteredPositiveCodeIsUnknownError)
+{
+    // A positive code is never a registered error; get_error_message must fall
+    // through to "Unknown error" and must NOT return "Success" (which is the
+    // message for code 0 only).
+    for (int code : {1, 7, 100, 1000, 4999})
+    {
+        EXPECT_EQ(get_error_message(code), "Unknown error")
+            << "positive code " << code << " must be Unknown error";
+        EXPECT_NE(get_error_message(code), "Success")
+            << "positive code " << code << " must not be Success";
+    }
+
+    // Sanity: code 0 alone is "Success".
+    EXPECT_EQ(get_error_message(0), "Success");
+}


### PR DESCRIPTION
## What

Gate the centralized error-code registry contract so header/module drift and classifier regressions cannot silently accumulate.

## Why

`src/modules/error.cppm` re-declares the entire registry INLINE instead of `#include`-ing `error_codes.h`, so the two could diverge with no compiler error (module-built vs header-built consumers). The guard immediately caught real drift: the module was **missing the 6 DI error codes** (`di_service_not_registered=-50` .. `di_scoped_from_root=-55`) and still used the pre-#698 classifier (`code >= 0 -> "Success"`). So module-built consumers had both the missing DI codes and the #698 mis-classification bug.

## How

- **Reconciled** `error.cppm` to the header SSOT: added the 6 DI constants + their `get_error_message` cases, and aligned `get_category_name` to #698 (`0 -> "Success"`, `>0 -> "Invalid"`). No value in `error_codes.h` was changed.
- **SSOT guard** `scripts/check_error_registry_ssot.py` (std-lib only): parses every `constexpr int` + `category` enum entry from both files, resolves `base ± N` / `static_cast<int>(category::X)`, and exits non-zero on any missing name or value mismatch. Result: `134 entries match`, exit 0 (negative-tested: a single injected divergence fails it).
- **CI wiring**: added the guard as a step in `.github/workflows/conformance.yml` (already triggers on PR to develop).
- **Runtime contract test** `tests/error_registry_contract_test.cpp` (6 cases): success-is-only-0 / positive->"Invalid" (#698), each reserved base maps to the correct category, the 8 reserved blocks are exhaustively disjoint over `[-799,-1]`, enum bases strictly descending, unregistered positive -> "Unknown error". Local: 6/6 pass.

## Where

- `src/modules/error.cppm`, `scripts/check_error_registry_ssot.py`, `tests/error_registry_contract_test.cpp`, `tests/CMakeLists.txt`, `.github/workflows/conformance.yml`

## Scope note / deferred

The long-term fix — making `error.cppm` `#include` `error_codes.h` to eliminate the dual SSOT entirely — is deferred: C++20 modules are OFF by default and Apple Clang cannot build them, so that refactor is unverifiable here. The Python guard + conformance step hold the two registries in lockstep in the interim. Cross-repo `static_assert` propagation and the monitoring `to_common_error` runtime test ride the remap PRs and the gate-propagation epic #701.

Closes #699
Part of kcenon/common_system#685
