### PR TITLE
fix(error): remove exported using-directive rejected by clang-16

### DIFF
--- a/src/modules/result/utilities.cppm
+++ b/src/modules/result/utilities.cppm
@@ -34,8 +34,6 @@ export namespace kcenon::common {
 // ============================================================================
 
 namespace error_codes {
-    using namespace error::codes::common_errors;
-
     // Uppercase aliases for backward compatibility
     constexpr int SUCCESS = error::codes::common_errors::success;
     constexpr int INVALID_ARGUMENT = error::codes::common_errors::invalid_argument;


### PR DESCRIPTION
## What

Remove the `using namespace error::codes::common_errors;` directive from the exported `kcenon::common::error_codes` namespace in `src/modules/result/utilities.cppm`.

## Why

C++20 forbids exporting a using-directive from a module interface. clang-16 emits `-Wexport-using-directive` and, under the project's `-Werror`, promotes it to a hard error:

```
src/modules/result/utilities.cppm:37:35: error: ISO C++20 does not permit using directive to be exported [-Werror,-Wexport-using-directive]
```

This breaks the **Module Build / ubuntu-22.04 / clang-16** job. GCC and MSVC do not diagnose it, so only the clang-16 module build is red. The failure is reproducible on the current develop HEAD, and it is the only `using namespace` in any exported `.cppm`.

## How

The directive only made the **lowercase** `common_errors` names visible under `error_codes::`. Every reference inside this file already uses the fully-qualified name (`error::codes::common_errors::success`), and an org-wide search shows all downstream consumers use the **uppercase** compatibility aliases (`error_codes::INVALID_ARGUMENT`, etc.), which are explicit `constexpr` members unaffected by this change. The directive is therefore dead code; removing it is behavior-preserving.

## Verification

`ci.yml` (which contains the clang-16 module build) runs only on `pull_request` targeting `main`, so it does not run on this develop-targeting PR. The clang-16 build is validated by the v1.0.0 release PR #696 (develop -> main) re-running after this lands on develop.

Relates to #696
