### PR TITLE
chore: reconcile develop with main (Dependabot CI-action bumps #678, #683)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Download baseline (if exists)
       if: github.event_name == 'pull_request'
-      uses: dawidd6/action-download-artifact@v20
+      uses: dawidd6/action-download-artifact@v21
       with:
         workflow: benchmark.yml
         branch: main

--- a/.github/workflows/ecosystem-benchmarks.yml
+++ b/.github/workflows/ecosystem-benchmarks.yml
@@ -66,7 +66,7 @@ jobs:
         retention-days: 90
 
     - name: Download baseline (if exists)
-      uses: dawidd6/action-download-artifact@v20
+      uses: dawidd6/action-download-artifact@v21
       with:
         workflow: ecosystem-benchmarks.yml
         branch: main

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run OSV-Scanner on vcpkg manifest
-        uses: google/osv-scanner-action/osv-scanner-action@v2.3.5
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
         with:
           scan-args: |-
             --lockfile=vcpkg.json
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run OSV-Scanner filesystem scan (fallback)
         if: hashFiles('osv-results.sarif') == ''
-        uses: google/osv-scanner-action/osv-scanner-action@v2.3.5
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
         with:
           scan-args: |-
             --recursive


### PR DESCRIPTION
Back-merge `main` into `develop` to reconcile the two Dependabot CI-action bumps that landed on main but not develop:

- #678 dawidd6/action-download-artifact 20 -> 21 (339dc0eb)
- #683 google/osv-scanner-action 2.3.5 -> 2.3.8 (36bf5ce4)

After this merge, `main` becomes an ancestor of `develop`, so the v1.0.0 release PR #696 (develop -> main) is a clean promotion that does not drop these CI-action bumps. Merge with a merge commit (not squash) to preserve ancestry. Does not touch release artifacts, versions, or tags.