### PR TITLE
fix(ci): wire fuzz subdirectory into the build graph

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -37,8 +37,8 @@ jobs:
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_BUILD_TYPE=Debug \
             -DBUILD_FUZZERS=ON \
-            -DCOMMON_SYSTEM_BUILD_TESTS=OFF \
-            -DCOMMON_SYSTEM_BUILD_EXAMPLES=OFF
+            -DCOMMON_BUILD_TESTS=OFF \
+            -DCOMMON_BUILD_EXAMPLES=OFF
 
       - name: Build
         run: cmake --build build-fuzz --target ${{ matrix.target }}

--- a/cmake/common-extras.cmake
+++ b/cmake/common-extras.cmake
@@ -43,6 +43,14 @@ if(COMMON_BUILD_BENCHMARKS)
 endif()
 
 # -----------------------------------------------------------------------------
+# Fuzz targets (libFuzzer + Clang, opt-in via BUILD_FUZZERS)
+# -----------------------------------------------------------------------------
+option(BUILD_FUZZERS "Build libFuzzer fuzz targets (requires Clang)" OFF)
+if(BUILD_FUZZERS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/fuzz/CMakeLists.txt")
+    add_subdirectory(fuzz)
+endif()
+
+# -----------------------------------------------------------------------------
 # Documentation (project-specific Doxygen target)
 # -----------------------------------------------------------------------------
 if(COMMON_BUILD_DOCS)


### PR DESCRIPTION
## What

Wire the `fuzz/` subdirectory into the build graph so the `Fuzzing`
workflow can build `result_error_fuzzer`, and fix two stale CMake option
spellings in the workflow.

Change type: **fix(ci)** — build wiring + workflow config.

## Why

The `Fuzzing` scheduled workflow failed on its first (and only) run
(2026-06-22) at the Build step with `ninja: error: unknown target
'result_error_fuzzer'`.

Root cause: the fuzz infrastructure (`fuzz/CMakeLists.txt`, `fuzzing.yml`)
landed in the v1.0.0 release (#696) without root build wiring. The root
CMake never declared `BUILD_FUZZERS` nor called `add_subdirectory(fuzz)`, so
`-DBUILD_FUZZERS=ON` was an unused variable, `fuzz/CMakeLists.txt`'s
`if(NOT BUILD_FUZZERS) return()` guard was never reached, and the target was
never created.

## Where

| File | Change |
|------|--------|
| `cmake/common-extras.cmake` | Declare `option(BUILD_FUZZERS ... OFF)` and `add_subdirectory(fuzz)` (EXISTS-guarded), matching the examples/benchmarks opt-in pattern |
| `.github/workflows/fuzzing.yml` | `COMMON_SYSTEM_BUILD_TESTS/EXAMPLES` -> `COMMON_BUILD_TESTS/EXAMPLES` (real option names) |

## How (verification)

- The default build path is unaffected: `BUILD_FUZZERS` defaults OFF and is
  EXISTS-guarded, so `add_subdirectory(fuzz)` runs only when explicitly
  enabled with a Clang toolchain.
- Verified by dispatching the `Fuzzing` workflow on this branch
  (`gh workflow run`, short `max_total_time`): Configure no longer warns
  about an unused `BUILD_FUZZERS`, Build produces `result_error_fuzzer`, and
  Run executes the fuzzer.

Relates to #639 (v1.0 readiness — restores CI green precondition).
