### PR TITLE
fix(build): prepend common's module path so its own template modules win

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,14 @@ project(common_system VERSION ${PROJECT_VERSION} LANGUAGES CXX)
 # checklist; the calls below mirror that checklist 1-to-1. Project-specific
 # layers (common-* modules) live directly under cmake/ and are included
 # explicitly.
-list(APPEND CMAKE_MODULE_PATH
+#
+# Prepend (INSERT 0) rather than APPEND: when common_system is built from
+# source via add_subdirectory by a consumer, the consumer's cmake/ is already
+# on CMAKE_MODULE_PATH. The bare include(<module>) calls below (options,
+# dependencies, targets, ...) must resolve to common_system's OWN template
+# modules, not the consumer's same-named modules; prepending gives common's
+# paths precedence.
+list(INSERT CMAKE_MODULE_PATH 0
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/template"
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
 )


### PR DESCRIPTION
## What

Prepend common_system's own cmake module paths (`list(INSERT ... 0 ...)`
instead of `list(APPEND ...)`) so its bare `include(<module>)` calls always
resolve to its own template modules.

Change type: **fix(build)** — CMake module resolution.

## Why

When common_system is built from source via `add_subdirectory` (a local
consumer in `UNIFIED_USE_LOCAL` mode, e.g. logger_system's sanitizer build),
the consumer's `cmake/` is already on `CMAKE_MODULE_PATH`. common's
`CMakeLists.txt` then APPENDs its own paths, so for same-named modules the
consumer's win. common's bare `include(options/compiler/dependencies/targets/
...)` resolve to the **consumer's** modules, cross-wiring the build:

- `include(dependencies)` re-entered the consumer's dependency resolver,
  causing a duplicate `add_subdirectory` on the same binary directory;
- `include(targets)` ran the consumer's `targets.cmake` against common's
  source tree (failing its include-tree existence check).

This surfaced as the logger_system `Sanitizer Tests` Configure failures.
logger_system was hardened on its side (isolating `CMAKE_MODULE_PATH` around
local-dependency `add_subdirectory`), but the root cause is here: common should
own its own module resolution.

## Where

`CMakeLists.txt` — `list(APPEND CMAKE_MODULE_PATH ...)` ->
`list(INSERT CMAKE_MODULE_PATH 0 ...)` for `cmake/template` and `cmake`.

## How (verification)

- Standalone builds are unaffected (no conflicting earlier entries; common's
  modules resolve to common's own either way). CMake builtin modules live in
  `CMAKE_ROOT` and are unaffected by `CMAKE_MODULE_PATH` order.
- common_system's own CI (this PR) confirms no regression to the standalone /
  vcpkg builds.
- Fixes the cross-resolution at the source for every local consumer that builds
  common from source.

Relates to #639 (v1.0 readiness — ecosystem build robustness).
